### PR TITLE
Propagate Arrow Storage Exceptions

### DIFF
--- a/python/pyhdk/_storage.pxd
+++ b/python/pyhdk/_storage.pxd
@@ -119,10 +119,10 @@ cdef class Storage(SchemaProvider):
 
 cdef extern from "omniscidb/ArrowStorage/ArrowStorage.h":
   cdef cppclass CArrowStorage "ArrowStorage"(CSchemaProvider, CAbstractDataProvider):
-    CArrowStorage(int, string, int);
+    CArrowStorage(int, string, int) except +;
 
-    CTableInfoPtr importArrowTable(shared_ptr[CArrowTable], string&, CTableOptions&);
-    void dropTable(const string&, bool)
+    CTableInfoPtr importArrowTable(shared_ptr[CArrowTable], string&, CTableOptions&) except +;
+    void dropTable(const string&, bool) except +;
 
 cdef extern from "omniscidb/BufferProvider/BufferProvider.h" namespace "Data_Namespace":
   cdef cppclass CBufferProvider "BufferProvider":
@@ -146,11 +146,11 @@ cdef extern from "omniscidb/DataMgr/PersistentStorageMgr/PersistentStorageMgr.h"
 
 cdef extern from "omniscidb/DataMgr/DataMgr.h" namespace "Data_Namespace":
   cdef cppclass CDataMgr "DataMgr":
-    CDataMgr(const CConfig&, const CSystemParameters&, map[CGpuMgrPlatform, unique_ptr[CGpuMgr]]&& gpuMgrs, size_t reservedGpuMem, size_t numReaderThreads)
+    CDataMgr(const CConfig&, const CSystemParameters&, map[CGpuMgrPlatform, unique_ptr[CGpuMgr]]&& gpuMgrs, size_t reservedGpuMem, size_t numReaderThreads) except +;
 
-    CPersistentStorageMgr* getPersistentStorageMgr()
-    CBufferProvider* getBufferProvider()
-    CDataProvider* getDataProvider()
+    CPersistentStorageMgr* getPersistentStorageMgr() except +;
+    CBufferProvider* getBufferProvider() except +;
+    CDataProvider* getDataProvider() except +;
 
 cdef class DataMgr:
   cdef shared_ptr[CDataMgr] c_data_mgr

--- a/python/tests/test_pyhdk_sql.py
+++ b/python/tests/test_pyhdk_sql.py
@@ -45,6 +45,10 @@ class TestSql:
         )
         return rel_alg_executor.execute(**kwargs)
 
+    @classmethod
+    def get_storage(cls):
+        return cls.storage
+
     def test_simple_count(self):
         res = self.execute_sql("SELECT COUNT(*) FROM test;")
         df = res.to_arrow().to_pandas()
@@ -62,3 +66,12 @@ class TestSql:
         res = self.execute_sql("SELECT * FROM test;", just_explain=True)
         explain_str = res.to_explain_str()
         assert explain_str[:15] == "IR for the CPU:"
+
+    def test_storage_exceptions(self):
+        at = pyarrow.Table.from_pandas(
+            pandas.DataFrame({"c": [1, 2, 3], "d": [10, 20, 30]})
+        )
+        opt = pyhdk.storage.TableOptions(2)
+
+        with pytest.raises(RuntimeError):
+            self.get_storage().importArrowTable(at, "test", opt)


### PR DESCRIPTION
Close #53 

Depends on #62 

We should add `except +` to the rest of the API, but it would be nice to have some tests at the same time. 