### PR TITLE
Whitelist date/time functions for cuda path

### DIFF
--- a/omniscidb/QueryEngine/CMakeLists.txt
+++ b/omniscidb/QueryEngine/CMakeLists.txt
@@ -223,7 +223,7 @@ function(precompile_llvm_module SOURCE_FILE SUFFIX)
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${result_module_name}
         COMMAND ${llvm_clangpp_cmd}
         ARGS -std=c++17 ${RT_OPT_FLAGS} ${ARGN} -c -emit-llvm
-        ${CLANG_SDK_INC} ${CLANG_CRT_INC} ${MAPD_DEFINITIONS}
+        ${CLANG_SDK_INC} ${CLANG_CRT_INC} ${MAPD_DEFINITIONS} -DEXECUTE_INCLUDE
         -o ${CMAKE_CURRENT_BINARY_DIR}/${result_module_name}
         -I ${CMAKE_CURRENT_SOURCE_DIR}/../
         ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE}

--- a/omniscidb/QueryEngine/CastIR.cpp
+++ b/omniscidb/QueryEngine/CastIR.cpp
@@ -137,16 +137,13 @@ llvm::Value* CodeGenerator::codegenCastTimestampToDate(llvm::Value* ts_lv,
   CHECK(ts_lv->getType()->isIntegerTy(64));
   if (unit > hdk::ir::TimeUnit::kSecond) {
     if (nullable) {
-      return cgen_state_->emitExternalCall(
-          "DateTruncateHighPrecisionToDateNullable",
-          get_int_type(64, cgen_state_->context_),
-          {{ts_lv,
-            cgen_state_->llInt(hdk::ir::unitsPerSecond(unit)),
-            cgen_state_->inlineIntNull(ctx.int64())}});
+      return cgen_state_->emitCall("DateTruncateHighPrecisionToDateNullable",
+                                   {{ts_lv,
+                                     cgen_state_->llInt(hdk::ir::unitsPerSecond(unit)),
+                                     cgen_state_->inlineIntNull(ctx.int64())}});
     }
-    return cgen_state_->emitExternalCall(
+    return cgen_state_->emitCall(
         "DateTruncateHighPrecisionToDate",
-        get_int_type(64, cgen_state_->context_),
         {{ts_lv, cgen_state_->llInt(hdk::ir::unitsPerSecond(unit))}});
   }
   std::unique_ptr<CodeGenerator::NullCheckCodegen> nullcheck_codegen;
@@ -155,8 +152,7 @@ llvm::Value* CodeGenerator::codegenCastTimestampToDate(llvm::Value* ts_lv,
     nullcheck_codegen = std::make_unique<NullCheckCodegen>(
         cgen_state_, executor(), ts_lv, type, "cast_timestamp_nullcheck");
   }
-  auto ret = cgen_state_->emitExternalCall(
-      "datetrunc_day", get_int_type(64, cgen_state_->context_), {ts_lv});
+  auto ret = cgen_state_->emitCall("datetrunc_day", {ts_lv});
   if (nullcheck_codegen) {
     ret = nullcheck_codegen->finalize(ll_int(NULL_BIGINT, cgen_state_->context_), ret);
   }

--- a/omniscidb/QueryEngine/DateAdd.cpp
+++ b/omniscidb/QueryEngine/DateAdd.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "ExtractFromTime.h"
 #include "IR/DateTimeEnums.h"
 #include "Shared/funcannotations.h"
 

--- a/omniscidb/QueryEngine/DateTimeIR.cpp
+++ b/omniscidb/QueryEngine/DateTimeIR.cpp
@@ -134,9 +134,7 @@ llvm::Value* CodeGenerator::codegen(const hdk::ir::ExtractExpr* extract_expr,
       cgen_state_->ir_builder_.CreateBr(extract_nullcheck_bb);
       cgen_state_->ir_builder_.SetInsertPoint(null_check.cond_false_);
       auto extract_call =
-          cgen_state_->emitExternalCall(extract_fname,
-                                        get_int_type(64, cgen_state_->context_),
-                                        std::vector<llvm::Value*>{from_expr});
+          cgen_state_->emitCall(extract_fname, std::vector<llvm::Value*>{from_expr});
       cgen_state_->ir_builder_.CreateBr(extract_nullcheck_bb);
 
       cgen_state_->ir_builder_.SetInsertPoint(extract_nullcheck_bb);
@@ -154,9 +152,7 @@ llvm::Value* CodeGenerator::codegen(const hdk::ir::ExtractExpr* extract_expr,
     CHECK(extract_nullcheck_value);
     return extract_nullcheck_value;
   } else {
-    return cgen_state_->emitExternalCall(extract_fname,
-                                         get_int_type(64, cgen_state_->context_),
-                                         std::vector<llvm::Value*>{from_expr});
+    return cgen_state_->emitCall(extract_fname, std::vector<llvm::Value*>{from_expr});
   }
 }
 
@@ -208,12 +204,7 @@ llvm::Value* CodeGenerator::codegen(const hdk::ir::DateAddExpr* dateadd_expr,
     dateadd_args.push_back(cgen_state_->inlineIntNull(datetime_type));
     dateadd_fname += "Nullable";
   }
-  return cgen_state_->emitExternalCall(dateadd_fname,
-                                       get_int_type(64, cgen_state_->context_),
-                                       dateadd_args,
-                                       {llvm::Attribute::NoUnwind,
-                                        llvm::Attribute::ReadNone,
-                                        llvm::Attribute::Speculatable});
+  return cgen_state_->emitCall(dateadd_fname, dateadd_args);
 }
 
 llvm::Value* CodeGenerator::codegen(const hdk::ir::DateDiffExpr* datediff_expr,
@@ -243,8 +234,7 @@ llvm::Value* CodeGenerator::codegen(const hdk::ir::DateDiffExpr* datediff_expr,
     datediff_args.push_back(cgen_state_->inlineIntNull(ret_type));
     datediff_fname += "Nullable";
   }
-  return cgen_state_->emitExternalCall(
-      datediff_fname, get_int_type(64, cgen_state_->context_), datediff_args);
+  return cgen_state_->emitCall(datediff_fname, datediff_args);
 }
 
 llvm::Value* CodeGenerator::codegen(const hdk::ir::DateTruncExpr* datetrunc_expr,
@@ -281,8 +271,7 @@ llvm::Value* CodeGenerator::codegen(const hdk::ir::DateTruncExpr* datetrunc_expr
         cgen_state_, executor(), from_expr, datetrunc_expr_type, "date_trunc_nullcheck");
   }
   char const* const fname = datetrunc_fname_lookup.at((size_t)field);
-  auto ret = cgen_state_->emitExternalCall(
-      fname, get_int_type(64, cgen_state_->context_), {from_expr});
+  auto ret = cgen_state_->emitCall(fname, {from_expr});
   if (is_nullable) {
     ret = nullcheck_codegen->finalize(ll_int(NULL_BIGINT, cgen_state_->context_), ret);
   }
@@ -386,8 +375,7 @@ llvm::Value* CodeGenerator::codegenDateTruncHighPrecisionTimestamps(
         cgen_state_, executor(), ts_lv, type, "date_trunc_hp_nullcheck");
   }
   char const* const fname = datetrunc_fname_lookup.at((size_t)field);
-  ts_lv = cgen_state_->emitExternalCall(
-      fname, get_int_type(64, cgen_state_->context_), {ts_lv});
+  ts_lv = cgen_state_->emitCall(fname, {ts_lv});
   if (is_nullable) {
     ts_lv =
         nullcheck_codegen->finalize(ll_int(NULL_BIGINT, cgen_state_->context_), ts_lv);

--- a/omniscidb/QueryEngine/DateTruncate.cpp
+++ b/omniscidb/QueryEngine/DateTruncate.cpp
@@ -23,8 +23,8 @@
 
 #include "Shared/funcannotations.h"
 
-#ifndef __CUDACC__
-#include <cstdlib>  // abort()
+#ifdef __CUDACC__
+#error This code is not intended to be compiled with a CUDA C++ compiler
 #endif
 
 #include <cmath>
@@ -294,11 +294,8 @@ int64_t DateTruncate(hdk::ir::DateTruncField field, const int64_t timeval) {
     case hdk::ir::DateTruncField::kMillennium:
       return datetrunc_millennium_impl(timeval);
     default:
-#ifdef __CUDACC__
-      return std::numeric_limits<int64_t>::min();
-#else
       abort();
-#endif
+      return std::numeric_limits<int64_t>::min();
   }
 }
 
@@ -415,11 +412,8 @@ struct EraTime {
         return sgn * (millennia - (rem == 0 && ut.sign(MOY) == -1));
       }
       default:
-#ifdef __CUDACC__
-        return std::numeric_limits<int64_t>::min();
-#else
         abort();
-#endif
+        return std::numeric_limits<int64_t>::min();
     }
   }
 };

--- a/omniscidb/QueryEngine/DateTruncate.cpp
+++ b/omniscidb/QueryEngine/DateTruncate.cpp
@@ -456,7 +456,8 @@ DateDiffHighPrecision(const hdk::ir::DateTruncField datepart,
                       const int32_t start_dim,
                       const int32_t end_dim) {
   // Return pow(10,i). Only valid for i = 0, 3, 6, 9.
-  constexpr int pow10[10]{1, 0, 0, 1000, 0, 0, 1000 * 1000, 0, 0, 1000 * 1000 * 1000};
+  static constexpr int pow10[10]{
+      1, 0, 0, 1000, 0, 0, 1000 * 1000, 0, 0, 1000 * 1000 * 1000};
   switch (datepart) {
     case hdk::ir::DateTruncField::kNano:
     case hdk::ir::DateTruncField::kMicro:


### PR DESCRIPTION
This PR fixes an issue with the CUDA path in the case of date-related functions: external calls are replaced with internal ones to account for all the functions in the runtime module.