### PR TITLE
Move RelLeftDeepInnerJoin code to IR.

### DIFF
--- a/omniscidb/IR/CMakeLists.txt
+++ b/omniscidb/IR/CMakeLists.txt
@@ -5,6 +5,8 @@ set(ir_source_files
     Exception.h
     Expr.cpp
     Expr.h
+    LeftDeepInnerJoin.cpp
+    LeftDeepInnerJoin.h
     Node.cpp
     Node.h
     Type.cpp

--- a/omniscidb/IR/LeftDeepInnerJoin.h
+++ b/omniscidb/IR/LeftDeepInnerJoin.h
@@ -24,14 +24,13 @@
 namespace hdk::ir {
 class Node;
 class LeftDeepInnerJoin;
-}  // namespace hdk::ir
 
 // Gets the start node of a left-deep pattern starting at the node itself or its child.
-std::shared_ptr<const hdk::ir::Node> get_left_deep_join_root(
-    const std::shared_ptr<hdk::ir::Node>& node);
+std::shared_ptr<const Node> get_left_deep_join_root(const std::shared_ptr<Node>& node);
 
-void create_left_deep_join(std::vector<std::shared_ptr<hdk::ir::Node>>& nodes);
+void create_left_deep_join(std::vector<std::shared_ptr<Node>>& nodes);
 
-hdk::ir::ExprPtr rebind_inputs_from_left_deep_join(
-    const hdk::ir::Expr* expr,
-    const hdk::ir::LeftDeepInnerJoin* left_deep_join);
+ExprPtr rebind_inputs_from_left_deep_join(const Expr* expr,
+                                          const LeftDeepInnerJoin* left_deep_join);
+
+}  // namespace hdk::ir

--- a/omniscidb/IR/Node.cpp
+++ b/omniscidb/IR/Node.cpp
@@ -7,8 +7,7 @@
 
 #include "Node.h"
 #include "ExprRewriter.h"
-
-#include "QueryEngine/RelLeftDeepInnerJoin.h"
+#include "LeftDeepInnerJoin.h"
 
 namespace hdk::ir {
 

--- a/omniscidb/QueryEngine/CMakeLists.txt
+++ b/omniscidb/QueryEngine/CMakeLists.txt
@@ -88,7 +88,6 @@ set(query_engine_source_files
     QueryExecutionContext.cpp
     QueryMemoryInitializer.cpp
     RelAlgDagBuilder.cpp
-    RelLeftDeepInnerJoin.cpp
     RelAlgExecutor.cpp
     RelAlgTranslator.cpp
     RelAlgOptimizer.cpp

--- a/omniscidb/QueryEngine/RelAlgDagBuilder.cpp
+++ b/omniscidb/QueryEngine/RelAlgDagBuilder.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "IR/ExprRewriter.h"
+#include "IR/LeftDeepInnerJoin.h"
 
 #include "CalciteDeserializerUtils.h"
 #include "DateTimePlusRewrite.h"
@@ -27,7 +28,6 @@
 #include "JsonAccessors.h"
 #include "RelAlgDagBuilder.h"
 #include "RelAlgOptimizer.h"
-#include "RelLeftDeepInnerJoin.h"
 #include "ScalarExprVisitor.h"
 #include "Shared/sqldefs.h"
 

--- a/omniscidb/Tests/TestRelAlgDagBuilder.h
+++ b/omniscidb/Tests/TestRelAlgDagBuilder.h
@@ -12,8 +12,8 @@
  * limitations under the License.
  */
 
+#include "IR/LeftDeepInnerJoin.h"
 #include "QueryEngine/RelAlgDagBuilder.h"
-#include "QueryEngine/RelLeftDeepInnerJoin.h"
 
 class TestRelAlgDagBuilder : public hdk::ir::QueryDag {
  public:


### PR DESCRIPTION
Currently, there is a dependency of `IR` library on `QueryEngine` library through `LeftDeepInnerJoin` related code. This code movement fixes that.