### PR TITLE
Support gcc12 and upgrade conda dev env

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,9 @@ set(CUDA_USE_STATIC_CUDA_RUNTIME ON CACHE STRING "Use static CUDA runtime")
 
 option(ENABLE_CUDA "Enable CUDA support" OFF)
 if(ENABLE_CUDA)
+  set(CMAKE_CUDA_ARCHITECTURES 60) # Set something here so that we can pick up nvcc
   enable_language(CUDA)
+  
   find_package(CUDAToolkit REQUIRED)
   # A temporary workaround for non-conda envs
   include_directories(${CUDAToolkit_INCLUDE_DIRS})

--- a/omniscidb/CMakeLists.txt
+++ b/omniscidb/CMakeLists.txt
@@ -147,13 +147,14 @@ endif()
 
 option(ENABLE_CUDA "Enable CUDA support" ON)
 if(ENABLE_CUDA)
+  set(CMAKE_CUDA_FLAGS "--allow-unsupported-compiler") # allow gcc > 11 for cuda 11.6
   enable_language(CUDA)
+
   find_package(CUDAToolkit REQUIRED)
   # A temporary workaround for non-conda envs
   include_directories(${CUDAToolkit_INCLUDE_DIRS})
   list(APPEND CUDA_LIBRARIES CUDA::cudart CUDA::cuda_driver)
   add_definitions("-DHAVE_CUDA")
-
 else()
   set(CUDA_LIBRARIES "")
   set(MAPD_PACKAGE_FLAGS "${MAPD_PACKAGE_FLAGS}-cpu")

--- a/omniscidb/CMakeLists.txt
+++ b/omniscidb/CMakeLists.txt
@@ -579,6 +579,15 @@ endif()
 # RapidJSON
 include_directories(ThirdParty/rapidjson)
 add_definitions(-DRAPIDJSON_HAS_STDSTRING)
+if(NOT MSVC)
+  # At the present time the current vcpkg version of rapidjson is 2020-09-14:
+  # https://github.com/microsoft/vcpkg/blob/master/versions/r-/rapidjson.json
+  # and the Windows build fails because it does not have this fix:
+  # https://github.com/Tencent/rapidjson/pull/1568
+  # Once vcpkg's rapidjson has this fix then let's try not making this exception for MSVC.
+  # When this changes, remove this exception from all other similar CMakeLists.txt files too.
+  add_definitions(-DRAPIDJSON_NOMEMBERITERATORCLASS)
+endif()
 
 # SQLite
 include_directories(ThirdParty/sqlite3)

--- a/omniscidb/QueryEngine/RelAlgExecutor.cpp
+++ b/omniscidb/QueryEngine/RelAlgExecutor.cpp
@@ -1014,7 +1014,7 @@ void collect_used_input_desc(
     const hdk::ir::Node* ra_node,
     const ColumnRefSet& source_used_inputs,
     const std::unordered_map<const hdk::ir::Node*, int>& input_to_nest_level) {
-  for (const auto col_ref : source_used_inputs) {
+  for (const auto& col_ref : source_used_inputs) {
     const auto source = col_ref.node();
     const int table_id = table_id_from_ra(source);
     const auto col_id = col_ref.index();

--- a/omniscidb/Shared/DoubleSort.h
+++ b/omniscidb/Shared/DoubleSort.h
@@ -84,12 +84,8 @@ struct Value {
     return *this;
   }
 #endif
-  DEVICE T0 value0() const {
-    return ref_ ? *v0_.ptr_ : v0_.value_;
-  }
-  DEVICE T1 value1() const {
-    return ref_ ? *v1_.ptr_ : v1_.value_;
-  }
+  DEVICE T0 value0() const { return ref_ ? *v0_.ptr_ : v0_.value_; }
+  DEVICE T1 value1() const { return ref_ ? *v1_.ptr_ : v1_.value_; }
 };
 
 #ifndef __CUDACC__
@@ -101,7 +97,13 @@ std::ostream& operator<<(std::ostream& out, Value<T0, T1> const& ds) {
 #endif
 
 template <typename T0, typename T1>
-struct Iterator : public std::iterator<std::input_iterator_tag, Value<T0, T1>> {
+struct Iterator {
+  using iterator_category = std::input_iterator_tag;
+  using value_type = Value<T0, T1>;
+  using difference_type = std::ptrdiff_t;
+  using pointer = value_type*;
+  using reference = value_type&;
+
   Value<T0, T1> this_;  // this_ is always a reference object. I.e. this_.ref_ == true.
   DEVICE Iterator(T0* ptr0, T1* ptr1) : this_(ptr0, ptr1) {}
   DEVICE Iterator(Iterator const& b) : this_(b.this_.v0_.ptr_, b.this_.v1_.ptr_) {}

--- a/omniscidb/Shared/Intervals.h
+++ b/omniscidb/Shared/Intervals.h
@@ -86,13 +86,19 @@ class Intervals {
   }
 
  public:
-  class Iterator : public std::iterator<std::input_iterator_tag, Interval<T>> {
+  class Iterator {
     T begin_;
     U const quot_;
     U rem_;
     U index{0};
 
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = Interval<T>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
     Iterator(T begin, U quot, U rem) : begin_(begin), quot_(quot), rem_(rem) {}
     Interval<T> operator*() const {
       return {begin_, T(begin_ + quot_ + bool(rem_)), index};

--- a/omniscidb/scripts/mapd-deps-conda-dev-env.yml
+++ b/omniscidb/scripts/mapd-deps-conda-dev-env.yml
@@ -13,8 +13,8 @@ channels:
   - conda-forge
 
 dependencies:
-  - gxx_linux-64   9.*
-  - gcc_linux-64   9.*
+  - gxx_linux-64   12.*
+  - gcc_linux-64   12.*
   - ccache
   - sysroot_linux-64 >=2.14
   - arrow-cpp  8.0


### PR DESCRIPTION
Most changes are required to support gcc12 or silence warnings. The compiler has better static analysis and caught two places where null ptrs were accessed. Appears to be copy/paste issues and I made what seemed like reasonable fixes. 

@leshikus can we land this as is and then work on updating the Docker files, etc once we are sure everything works? 