### PR TITLE
Enable compile_commands.json generation by default.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ project(
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # set default build type to "Release w/ Debug Info" 
 set(default_build_type "RelWithDebInfo")
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)


### PR DESCRIPTION
Enable default `compile_commands.json` in the top-level `CMakeLists.txt` for more convenient IntelliSense usage.