### PR TITLE
Remove OpType::kExists and OpType::kIsNotNull.

### DIFF
--- a/omniscidb/IR/Expr.cpp
+++ b/omniscidb/IR/Expr.cpp
@@ -1336,9 +1336,6 @@ std::string UOper::toString() const {
     case OpType::kIsNull:
       op = "IS NULL ";
       break;
-    case OpType::kExists:
-      op = "EXISTS ";
-      break;
     case OpType::kCast:
       op = "CAST " + type_->toString() + " ";
       break;

--- a/omniscidb/IR/Expr.h
+++ b/omniscidb/IR/Expr.h
@@ -296,7 +296,7 @@ class Constant : public Expr {
 /*
  * @type UOper
  * @brief represents unary operator expressions.  operator types include
- * kUMINUS, kISNULL, kEXISTS, kCAST
+ * kUMINUS, kISNULL, kCAST
  */
 class UOper : public Expr {
  public:
@@ -317,8 +317,6 @@ class UOper : public Expr {
   bool isNot() const { return op_type_ == OpType::kNot; }
   bool isUMinus() const { return op_type_ == OpType::kUMinus; }
   bool isIsNull() const { return op_type_ == OpType::kIsNull; }
-  bool isIsNotNull() const { return op_type_ == OpType::kIsNotNull; }
-  bool isExists() const { return op_type_ == OpType::kExists; }
   bool isCast() const { return op_type_ == OpType::kCast; }
   bool isUnnest() const { return op_type_ == OpType::kUnnest; }
 
@@ -333,7 +331,7 @@ class UOper : public Expr {
   size_t hash() const override;
 
  protected:
-  OpType op_type_;   // operator type, e.g., kUMINUS, kISNULL, kEXISTS
+  OpType op_type_;   // operator type, e.g., kUMINUS, kISNULL
   ExprPtr operand_;  // operand expression
   bool is_dict_intersection_;
 };

--- a/omniscidb/IR/OpType.h
+++ b/omniscidb/IR/OpType.h
@@ -31,8 +31,6 @@ enum class OpType {
   kMod,
   kUMinus,
   kIsNull,
-  kIsNotNull,
-  kExists,
   kCast,
   kArrayAt,
   kUnnest,
@@ -62,7 +60,7 @@ inline OpType commuteComparison(OpType op) {
 }
 inline bool isUnary(OpType op) {
   return op == OpType::kNot || op == OpType::kUMinus || op == OpType::kIsNull ||
-         op == OpType::kExists || op == OpType::kCast;
+         op == OpType::kCast;
 }
 inline bool isEquivalence(OpType op) {
   return op == OpType::kEq || op == OpType::kBwEq;
@@ -139,10 +137,6 @@ inline std::string toString(hdk::ir::OpType op) {
       return "UMINUS";
     case hdk::ir::OpType::kIsNull:
       return "ISNULL";
-    case hdk::ir::OpType::kIsNotNull:
-      return "ISNOTNULL";
-    case hdk::ir::OpType::kExists:
-      return "EXISTS";
     case hdk::ir::OpType::kCast:
       return "CAST";
     case hdk::ir::OpType::kArrayAt:

--- a/omniscidb/QueryEngine/CalciteDeserializerUtils.h
+++ b/omniscidb/QueryEngine/CalciteDeserializerUtils.h
@@ -77,9 +77,6 @@ inline hdk::ir::OpType to_sql_op(const std::string& op_str) {
   if (op_str == std::string("IS NULL")) {
     return hdk::ir::OpType::kIsNull;
   }
-  if (op_str == std::string("IS NOT NULL")) {
-    return hdk::ir::OpType::kIsNotNull;
-  }
   if (op_str == std::string("PG_UNNEST")) {
     return hdk::ir::OpType::kUnnest;
   }

--- a/omniscidb/QueryEngine/OutputBufferInitialization.cpp
+++ b/omniscidb/QueryEngine/OutputBufferInitialization.cpp
@@ -303,7 +303,7 @@ bool constrained_not_null(const hdk::ir::Expr* expr,
       uoper = uoper->operand()->as<hdk::ir::UOper>();
       is_negated = true;
     }
-    if (uoper && (uoper->isIsNotNull() || (is_negated && uoper->isIsNull()))) {
+    if (uoper && (is_negated && uoper->isIsNull())) {
       if (*uoper->operand() == *expr) {
         return true;
       }

--- a/omniscidb/QueryEngine/RelAlgDagBuilder.cpp
+++ b/omniscidb/QueryEngine/RelAlgDagBuilder.cpp
@@ -503,12 +503,6 @@ hdk::ir::ExprPtr makeUOper(hdk::ir::OpType op,
           ctx.boolean(arg->type()->nullable()), op, arg);
     case hdk::ir::OpType::kIsNull:
       return std::make_shared<hdk::ir::UOper>(ctx.boolean(false), op, arg);
-    case hdk::ir::OpType::kIsNotNull: {
-      auto is_null = std::make_shared<hdk::ir::UOper>(
-          ctx.boolean(false), hdk::ir::OpType::kIsNull, arg);
-      return std::make_shared<hdk::ir::UOper>(
-          ctx.boolean(false), hdk::ir::OpType::kNot, is_null);
-    }
     case hdk::ir::OpType::kMinus: {
       return std::make_shared<hdk::ir::UOper>(
           arg->type(), false, hdk::ir::OpType::kUMinus, arg);
@@ -1147,6 +1141,12 @@ hdk::ir::ExprPtr parseFunctionOperator(const std::string& fn_name,
                                        RelAlgDagBuilder& root_dag_builder) {
   if (fn_name == "PG_ANY"sv || fn_name == "PG_ALL"sv) {
     return hdk::ir::makeExpr<hdk::ir::FunctionOper>(type, fn_name, operands);
+  }
+  if (fn_name == "IS NOT NULL") {
+    CHECK_EQ(operands.size(), (size_t)1);
+    return makeUOper(hdk::ir::OpType::kNot,
+                     makeUOper(hdk::ir::OpType::kIsNull, operands[0], type),
+                     type);
   }
   if (fn_name == "LIKE"sv || fn_name == "PG_ILIKE"sv) {
     return parseLike(fn_name, operands);


### PR DESCRIPTION
Remove `OpType::kExists` which is not used at all and `OpType::kIsNotNull` which is only used for Calcite JSON parsing.