### PR TITLE
Move hdk::ir streaming operators to their namespace.

### DIFF
--- a/omniscidb/IR/DateTime.h
+++ b/omniscidb/IR/DateTime.h
@@ -31,11 +31,6 @@ inline std::string toString(hdk::ir::TimeUnit unit) {
   }
 }
 
-inline std::ostream& operator<<(std::ostream& os, hdk::ir::TimeUnit unit) {
-  os << toString(unit);
-  return os;
-}
-
 inline std::string toString(hdk::ir::DateAddField field) {
   switch (field) {
     case hdk::ir::DateAddField::kYear:
@@ -79,11 +74,6 @@ inline std::string toString(hdk::ir::DateAddField field) {
   }
 }
 
-inline std::ostream& operator<<(std::ostream& os, hdk::ir::DateAddField field) {
-  os << toString(field);
-  return os;
-}
-
 inline std::string toString(hdk::ir::DateTruncField field) {
   switch (field) {
     case hdk::ir::DateTruncField::kYear:
@@ -125,11 +115,6 @@ inline std::string toString(hdk::ir::DateTruncField field) {
     default:
       return "InvalidDateTruncField";
   }
-}
-
-inline std::ostream& operator<<(std::ostream& os, hdk::ir::DateTruncField field) {
-  os << toString(field);
-  return os;
 }
 
 inline std::string toString(hdk::ir::DateExtractField field) {
@@ -178,6 +163,21 @@ inline std::string toString(hdk::ir::DateExtractField field) {
 }
 
 namespace hdk::ir {
+
+inline std::ostream& operator<<(std::ostream& os, TimeUnit unit) {
+  os << toString(unit);
+  return os;
+}
+
+inline std::ostream& operator<<(std::ostream& os, DateAddField field) {
+  os << toString(field);
+  return os;
+}
+
+inline std::ostream& operator<<(std::ostream& os, DateTruncField field) {
+  os << toString(field);
+  return os;
+}
 
 inline int64_t unitsPerSecond(TimeUnit unit) {
   switch (unit) {

--- a/omniscidb/IR/OpType.h
+++ b/omniscidb/IR/OpType.h
@@ -152,10 +152,6 @@ inline std::string toString(hdk::ir::OpType op) {
   return "";
 }
 
-inline std::ostream& operator<<(std::ostream& os, hdk::ir::OpType op) {
-  return os << toString(op);
-}
-
 inline std::string toString(hdk::ir::Qualifier qualifier) {
   switch (qualifier) {
     case hdk::ir::Qualifier::kOne:
@@ -167,10 +163,6 @@ inline std::string toString(hdk::ir::Qualifier qualifier) {
   }
   LOG(FATAL) << "Invalid Qualifier: " << int(qualifier);
   return "";
-}
-
-inline std::ostream& operator<<(std::ostream& os, hdk::ir::Qualifier qualifier) {
-  return os << toString(qualifier);
 }
 
 inline std::string toString(hdk::ir::AggType agg) {
@@ -196,10 +188,6 @@ inline std::string toString(hdk::ir::AggType agg) {
   }
   LOG(FATAL) << "Invalid aggregate kind: " << (int)agg;
   return "";
-}
-
-inline std::ostream& operator<<(std::ostream& os, hdk::ir::AggType agg) {
-  return os << toString(agg);
 }
 
 inline std::string toString(hdk::ir::WindowFunctionKind kind) {
@@ -241,6 +229,22 @@ inline std::string toString(hdk::ir::WindowFunctionKind kind) {
   return "";
 }
 
+namespace hdk::ir {
+
+inline std::ostream& operator<<(std::ostream& os, hdk::ir::OpType op) {
+  return os << toString(op);
+}
+
+inline std::ostream& operator<<(std::ostream& os, hdk::ir::Qualifier qualifier) {
+  return os << toString(qualifier);
+}
+
+inline std::ostream& operator<<(std::ostream& os, hdk::ir::AggType agg) {
+  return os << toString(agg);
+}
+
 inline std::ostream& operator<<(std::ostream& os, hdk::ir::WindowFunctionKind kind) {
   return os << toString(kind);
 }
+
+}  // namespace hdk::ir

--- a/omniscidb/IR/Type.cpp
+++ b/omniscidb/IR/Type.cpp
@@ -515,9 +515,23 @@ std::string ColumnListType::toString() const {
   return ss.str();
 }
 
-}  // namespace hdk::ir
+std::ostream& operator<<(std::ostream& os, hdk::ir::Type::Id type_id) {
+  os << toString(type_id);
+  return os;
+}
 
-std::ostream& operator<<(std::ostream& os, const hdk::ir::Type* precision);
+std::ostream& operator<<(std::ostream& os,
+                         hdk::ir::FloatingPointType::Precision precision) {
+  os << toString(precision);
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const hdk::ir::Type* type) {
+  os << type->toString();
+  return os;
+}
+
+}  // namespace hdk::ir
 
 std::string toString(hdk::ir::Type::Id type_id) {
   switch (type_id) {
@@ -558,11 +572,6 @@ std::string toString(hdk::ir::Type::Id type_id) {
   }
 }
 
-std::ostream& operator<<(std::ostream& os, hdk::ir::Type::Id type_id) {
-  os << toString(type_id);
-  return os;
-}
-
 std::string toString(hdk::ir::FloatingPointType::Precision precision) {
   switch (precision) {
     case hdk::ir::FloatingPointType::kFloat:
@@ -572,15 +581,4 @@ std::string toString(hdk::ir::FloatingPointType::Precision precision) {
     default:
       return "InvalidPrecision";
   }
-}
-
-std::ostream& operator<<(std::ostream& os,
-                         hdk::ir::FloatingPointType::Precision precision) {
-  os << toString(precision);
-  return os;
-}
-
-std::ostream& operator<<(std::ostream& os, const hdk::ir::Type* type) {
-  os << type->toString();
-  return os;
 }

--- a/omniscidb/IR/Type.h
+++ b/omniscidb/IR/Type.h
@@ -489,13 +489,12 @@ class ColumnListType : public Type {
   int length_;
 };
 
+std::ostream& operator<<(std::ostream& os, hdk::ir::Type::Id precision);
+std::ostream& operator<<(std::ostream& os,
+                         hdk::ir::FloatingPointType::Precision precision);
+std::ostream& operator<<(std::ostream& os, const hdk::ir::Type* type);
+
 }  // namespace hdk::ir
 
 std::string toString(hdk::ir::Type::Id precision);
-std::ostream& operator<<(std::ostream& os, hdk::ir::Type::Id precision);
-
 std::string toString(hdk::ir::FloatingPointType::Precision precision);
-std::ostream& operator<<(std::ostream& os,
-                         hdk::ir::FloatingPointType::Precision precision);
-
-std::ostream& operator<<(std::ostream& os, const hdk::ir::Type* precision);


### PR DESCRIPTION
Currently, stream operators for all `hdk::ir` enums are located near their `toString` overloads in the global namespace. But it creates problems with a lookup because it's different for regular functions and operators. This patch should fix the lookup issues by moving operators into the right place (enum's namespace). 