### PR TITLE
Fix sanity_tests run for the top-level CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Force -O0 optimization level for debug builds.
+set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
+
 # set default build type to "Release w/ Debug Info" 
 set(default_build_type "RelWithDebInfo")
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)

--- a/omniscidb/Calcite/CalciteJNI.cpp
+++ b/omniscidb/Calcite/CalciteJNI.cpp
@@ -22,6 +22,7 @@
 #include "OSDependent/omnisci_path.h"
 
 #include <jni.h>
+#include <filesystem>
 
 using namespace std::string_literals;
 
@@ -119,8 +120,19 @@ class JVM {
 
   static std::shared_ptr<JVM> createJVM(size_t max_mem_mb) {
     auto root_abs_path = omnisci::get_root_abs_path();
-    std::string class_path_arg = "-Djava.class.path=" + root_abs_path +
-                                 "/bin/calcite-1.0-SNAPSHOT-jar-with-dependencies.jar";
+    std::string class_path_arg = "-Djava.class.path=";
+    if (std::filesystem::exists(root_abs_path +
+                                "/bin/calcite-1.0-SNAPSHOT-jar-with-dependencies.jar")) {
+      class_path_arg +=
+          root_abs_path + "/bin/calcite-1.0-SNAPSHOT-jar-with-dependencies.jar";
+    } else if (std::filesystem::exists(
+                   root_abs_path +
+                   "/../bin/calcite-1.0-SNAPSHOT-jar-with-dependencies.jar")) {
+      class_path_arg +=
+          root_abs_path + "/../bin/calcite-1.0-SNAPSHOT-jar-with-dependencies.jar";
+    } else {
+      LOG(FATAL) << "Cannot find calcite jar library.";
+    }
     std::string max_mem_arg = "-Xmx" + std::to_string(max_mem_mb) + "m";
     JavaVMInitArgs vm_args;
     auto options = std::make_unique<JavaVMOption[]>(2);

--- a/omniscidb/Shared/DateTimeParser.h
+++ b/omniscidb/Shared/DateTimeParser.h
@@ -45,7 +45,8 @@ int64_t dateTimeParse(std::string_view const s, hdk::ir::TimeUnit unit) {
   if (auto const time = dateTimeParseOptional<TYPE>(s, unit)) {
     return *time;
   } else {
-    throw std::runtime_error(cat("Invalid ", toString(TYPE), " string (", s, ')'));
+    throw std::runtime_error(
+        cat("Invalid date/time (", std::to_string(TYPE), ") string (", s, ')'));
   }
 }
 
@@ -71,7 +72,8 @@ int64_t dateTimeParse(std::string_view const s, int dim) {
   if (auto const time = dateTimeParseOptional<TYPE>(s, unit)) {
     return *time;
   } else {
-    throw std::runtime_error(cat("Invalid ", toString(TYPE), " string (", s, ')'));
+    throw std::runtime_error(
+        cat("Invalid date/time (", std::to_string(TYPE), ") string (", s, ')'));
   }
 }
 

--- a/omniscidb/Tests/ArrowStorageSqlTest.cpp
+++ b/omniscidb/Tests/ArrowStorageSqlTest.cpp
@@ -33,7 +33,7 @@ using namespace TestHelpers::ArrowSQLRunner;
 namespace {
 
 std::string getFilePath(const std::string& file_name) {
-  return std::string("../../Tests/ArrowStorageDataFiles/") + file_name;
+  return TEST_SOURCE_PATH + "/ArrowStorageDataFiles/"s + file_name;
 }
 
 ExecutionResult runSqlQuery(const std::string& sql,

--- a/omniscidb/Tests/ArrowStorageTest.cpp
+++ b/omniscidb/Tests/ArrowStorageTest.cpp
@@ -105,7 +105,7 @@ class TestBuffer : public Data_Namespace::AbstractBuffer {
 };
 
 std::string getFilePath(const std::string& file_name) {
-  return std::string("../../Tests/ArrowStorageDataFiles/") + file_name;
+  return TEST_SOURCE_PATH + "/ArrowStorageDataFiles/"s + file_name;
 }
 
 template <typename T>

--- a/omniscidb/Tests/CMakeLists.txt
+++ b/omniscidb/Tests/CMakeLists.txt
@@ -3,6 +3,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 set(TEST_BASE_PATH "./tmp")
 add_definitions("-DBASE_PATH=\"${TEST_BASE_PATH}\"")
+add_definitions("-DTEST_SOURCE_PATH=\"${CMAKE_CURRENT_SOURCE_DIR}\"")
 
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/Udf/udf_sample.cpp DESTINATION ${CMAKE_BINARY_DIR}/Tests/Udf)
 

--- a/omniscidb/Tests/ResultSetArrowConversion.cpp
+++ b/omniscidb/Tests/ResultSetArrowConversion.cpp
@@ -42,12 +42,9 @@
 #include <gtest/gtest.h>
 
 // Input files' names
-static const char* TABLE6x4_CSV_FILE =
-    "../../Tests/EmbeddedDataFiles/embedded_db_test_6x4table.csv";
-static const char* JOIN_TABLE_CSV_FILE =
-    "../../Tests/EmbeddedDataFiles/embedded_db_test_join_table.csv";
-static const char* NULLSTABLE6x4_CSV_FILE =
-    "../../Tests/EmbeddedDataFiles/embedded_db_test_nulls_table.csv";
+static const char* TABLE6x4_CSV_FILE = "embedded_db_test_6x4table.csv";
+static const char* JOIN_TABLE_CSV_FILE = "embedded_db_test_join_table.csv";
+static const char* NULLSTABLE6x4_CSV_FILE = "embedded_db_test_nulls_table.csv";
 
 //  Content of the table stored in $TABLE6x4_CSV_FILE file
 static std::array<int64_t, 6> table6x4_col_i64 = {0, 0, 0, 1, 1, 1};
@@ -94,14 +91,19 @@ void parse_cli_args(int argc, char* argv[], ConfigPtr config) {
   }
 }
 
+std::string getFilePath(const std::string& file_name) {
+  return TEST_SOURCE_PATH + std::string("/EmbeddedDataFiles/") + file_name;
+}
+
 void import_data() {
-  getStorage()->importCsvFile(TABLE6x4_CSV_FILE, "test");
+  getStorage()->importCsvFile(getFilePath(TABLE6x4_CSV_FILE), "test");
   getStorage()->importCsvFile(
-      TABLE6x4_CSV_FILE, "test_chunked", ArrowStorage::TableOptions{4});
+      getFilePath(TABLE6x4_CSV_FILE), "test_chunked", ArrowStorage::TableOptions{4});
+  getStorage()->importCsvFile(getFilePath(NULLSTABLE6x4_CSV_FILE),
+                              "chunked_nulls",
+                              ArrowStorage::TableOptions{3});
   getStorage()->importCsvFile(
-      NULLSTABLE6x4_CSV_FILE, "chunked_nulls", ArrowStorage::TableOptions{3});
-  getStorage()->importCsvFile(
-      JOIN_TABLE_CSV_FILE, "join_table", ArrowStorage::TableOptions{2});
+      getFilePath(JOIN_TABLE_CSV_FILE), "join_table", ArrowStorage::TableOptions{2});
 }
 
 std::shared_ptr<arrow::RecordBatch> getArrowRecordBatch(const ExecutionResult& res) {

--- a/omniscidb/Tests/ResultSetTest.cpp
+++ b/omniscidb/Tests/ResultSetTest.cpp
@@ -35,6 +35,7 @@
 
 #include <gtest/gtest.h>
 #include <algorithm>
+#include <filesystem>
 #include <queue>
 #include <random>
 
@@ -2962,6 +2963,14 @@ TEST(ReduceRandomGroups, BaselineHashColumnar_Large_NullVal_0075) {
       target_infos, query_mem_desc, gen1, gen2, prct1, prct2, silent, 2);
 }
 
+namespace {
+
+std::string getFilePath(const std::string& file_name) {
+  return std::string(TEST_SOURCE_PATH) + "/Import/datafiles/" + file_name;
+}
+
+}  // namespace
+
 TEST(ResultsetConversion, EnforceParallelColumnarConversion) {
   // if we try to columnarize intermediate result which 1) is not truncated and
   // has more than 20000 rows, i.e., rows.entryCount() >= 20000, then
@@ -2974,17 +2983,16 @@ TEST(ResultsetConversion, EnforceParallelColumnarConversion) {
       "t_large",
       {{"x", ctx().int64(false)}, {"y", ctx().int64(false)}, {"z", ctx().int64(false)}},
       {100000000});
-  getStorage()->appendParquetFile(
-      "../../Tests/Import/datafiles/interrupt_table_very_large.parquet", "t_large");
+  getStorage()->appendParquetFile(getFilePath("interrupt_table_very_large.parquet"),
+                                  "t_large");
 
   // load 50M rows - two frags (use default frag size)
   createTable(
       "t_large_multi_frag",
       {{"x", ctx().int64(false)}, {"y", ctx().int64(false)}, {"z", ctx().int64(false)}},
       {32000000});
-  getStorage()->appendParquetFile(
-      "../../Tests/Import/datafiles/interrupt_table_very_large.parquet",
-      "t_large_multi_frag");
+  getStorage()->appendParquetFile(getFilePath("interrupt_table_very_large.parquet"),
+                                  "t_large_multi_frag");
 
   createTable(
       "t_small",

--- a/omniscidb/Tests/Udf/udf_sample.cpp
+++ b/omniscidb/Tests/Udf/udf_sample.cpp
@@ -2,7 +2,7 @@
 #include <limits>
 #include <type_traits>
 
-#include "../../QueryEngine/OmniSciTypes.h"
+#include "QueryEngine/OmniSciTypes.h"
 
 EXTENSION_NOINLINE
 bool array_is_null_double(Array<double> arr) {

--- a/omniscidb/ThirdParty/sqlite3/CMakeLists.txt
+++ b/omniscidb/ThirdParty/sqlite3/CMakeLists.txt
@@ -6,7 +6,7 @@ else()
   set_source_files_properties(sqlite3.c PROPERTIES COMPILE_FLAGS "-O0 -Wno-unused-value")
 endif()
 
-add_library(sqlite3 STATIC sqlite3.c sqlite3.h)
+add_library(sqlite3 sqlite3.c sqlite3.h)
 if(MSVC)
   target_link_libraries(sqlite3 ${CMAKE_DL_LIBS})
 else()

--- a/omniscidb/UdfCompiler/CMakeLists.txt
+++ b/omniscidb/UdfCompiler/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(udf_compiler_source_files
     UdfCompiler.cpp)
 
+add_definitions("-DUDF_INCLUDE_PATH=\"${CMAKE_CURRENT_SOURCE_DIR}/..\"")
+
 # Suppress multi-line comment warning which is not disabled by a diagnostic pragma
 # for some reason.
 if(NOT WIN32)

--- a/omniscidb/UdfCompiler/UdfCompiler.cpp
+++ b/omniscidb/UdfCompiler/UdfCompiler.cpp
@@ -591,6 +591,7 @@ std::string UdfCompiler::compileToLLVMIR(const std::string& udf_file_name) const
                                         cpu_out_filename,
                                         "-std=c++17",
                                         "-DNO_BOOST",
+                                        "-I" UDF_INCLUDE_PATH,
                                         udf_file_name};
   auto res = compileFromCommandLine(command_line);
   if (res != 0) {
@@ -616,6 +617,7 @@ void UdfCompiler::generateAST(const std::string& file_name) const {
   arg_vector.emplace_back("--");
   arg_vector.emplace_back("-DNO_BOOST");
   arg_vector.emplace_back(include_option);
+  arg_vector.emplace_back("-I" UDF_INCLUDE_PATH);
   arg_vector.emplace_back("-std=c++17");
 
   if (clang_options_.size() > 0) {

--- a/omniscidb/Utils/CMakeLists.txt
+++ b/omniscidb/Utils/CMakeLists.txt
@@ -1,6 +1,5 @@
 set(utils_source_files
     ChunkIter.cpp
-    CommandLineOptions.cpp
     Regexp.cpp
     StringLike.cpp
 )


### PR DESCRIPTION
Currently, we have to use `omniscidb/CMakeLists.txt` directly to build and run sanity tests mostly due to relative paths used in tests to reach the test data and runtime libs.

This PR introduces a few changes to enable tests run from the top-level build dir:
- configure data files and headers (for UdfTest) paths through macroses
- allow alternative java classpath to properly find calcite library
- do not force static sqlite library to avoid multiple global sqlite states linked into different shared libraries (causing segfaults on testing)
- enforce `-O0` for debug build (we had a similar patch for omnisci fork)
- avoid unexpected dependencies for `Shared` on `IR` library through `toString` method
- avoid unexpected dependencies for `Util` library through globals by excluding unused code from build (don't completely remove it to probably move part of it to `ConfigBuilder` later)

@kurapov-peter This PR finally allows us to build and run sanity_tests for HDK from any place, not necessarily from the dir created at the top of the source tree. 