### PR TITLE
Simple toString() method for ArrowResultSet

### DIFF
--- a/omniscidb/QueryEngine/ArrowResultSet.h
+++ b/omniscidb/QueryEngine/ArrowResultSet.h
@@ -139,6 +139,10 @@ class ArrowResultSet {
 
   const hdk::ir::Type* colType(size_t col_idx) const;
 
+  std::string toString() const{
+    return record_batch_->ToString();
+  }
+
   bool definitelyHasNoRows() const;
 
   size_t rowCount() const;

--- a/omniscidb/Tests/ArrowBasedExecuteTest.cpp
+++ b/omniscidb/Tests/ArrowBasedExecuteTest.cpp
@@ -11304,23 +11304,26 @@ TEST_F(Select, DesugarTransform) {
 }
 
 TEST_F(Select, ArrowOutput) {
+  const bool print_res = false;
   for (auto dt : {ExecutorDeviceType::CPU, ExecutorDeviceType::GPU}) {
     SKIP_NO_GPU();
-    c_arrow("SELECT str, COUNT(*) FROM test GROUP BY str ORDER BY str ASC;", dt);
-    c_arrow("SELECT x, y, w, z, t, f, d, str, ofd, ofq FROM test ORDER BY x ASC, y ASC;",
+    c_arrow("SELECT str, COUNT(*) FROM test GROUP BY str ORDER BY str ASC;", print_res, dt);
+    c_arrow("SELECT x, y, w, z, t, f, d, str, ofd, ofq FROM test ORDER BY x ASC, y ASC;", print_res,
             dt);
-    c_arrow("SELECT null_str, COUNT(*) FROM test GROUP BY null_str;", dt);
-    c_arrow("SELECT m,m_3,m_6,m_9 from test", dt);
-    c_arrow("SELECT o, o1, o2 from test", dt);
-    c_arrow("SELECT n from test", dt);
+    c_arrow("SELECT null_str, COUNT(*) FROM test GROUP BY null_str;", print_res, dt);
+    c_arrow("SELECT m,m_3,m_6,m_9 from test", print_res, dt);
+    c_arrow("SELECT o, o1, o2 from test", print_res, dt);
+    c_arrow("SELECT n from test", print_res, dt);
     c_arrow(
         "SELECT x, CASE WHEN x = 7 THEN 'foo' ELSE 'bar' END AS case_x FROM test "
-        "WHERE str IN ('bar', 'baz') ORDER BY x ASC;",
+        "WHERE str IN ('bar', 'baz') ORDER BY x ASC;", 
+        print_res,
         dt);
   }
 }
 
 TEST_F(Select, ArrowDictionaries) {
+  const bool print_res = false;
   for (auto dt : {ExecutorDeviceType::CPU, ExecutorDeviceType::GPU}) {
     SKIP_NO_GPU();
 
@@ -11330,6 +11333,7 @@ TEST_F(Select, ArrowDictionaries) {
         "ORDER "
         "BY "
         "t ASC;",
+        print_res,
         dt,
         10000L,
         0.25);
@@ -11338,6 +11342,7 @@ TEST_F(Select, ArrowDictionaries) {
     c_arrow(
         "SELECT t_unique FROM test_window_func_large_multi_frag WHERE i_1000 < 40 "
         "AND t <> 'd' ORDER BY t_unique ASC;",
+        print_res,
         dt,
         10000L,
         0.25);
@@ -11346,6 +11351,7 @@ TEST_F(Select, ArrowDictionaries) {
     c_arrow(
         "SELECT t, COUNT(*) as n FROM test_window_func_large_multi_frag WHERE "
         "i_1000 < 800 AND t <> 'd' GROUP by t ORDER BY n DESC;",
+        print_res,
         dt,
         3L,
         2.0);
@@ -11355,6 +11361,7 @@ TEST_F(Select, ArrowDictionaries) {
         "SELECT t_unique, COUNT(*) as n FROM test_window_func_large_multi_frag WHERE "
         "i_1000 < 40 and t <> 'd' GROUP by t_unique ORDER BY "
         "t_unique ASC;",
+        print_res,
         dt,
         10000L,
         0.25);

--- a/omniscidb/Tests/ArrowSQLRunner/ArrowSQLRunner.cpp
+++ b/omniscidb/Tests/ArrowSQLRunner/ArrowSQLRunner.cpp
@@ -268,7 +268,8 @@ class ArrowSQLRunnerImpl {
     }
   }
 
-  void c_arrow(const std::string& query_string,
+  void c_arrow(const std::string& query_string, 
+               const bool print_res,
                const ExecutorDeviceType device_type,
                size_t min_result_size_for_bulk_dictionary_fetch,
                double max_dictionary_to_result_size_ratio_for_bulk_dictionary_fetch) {
@@ -279,6 +280,15 @@ class ArrowSQLRunnerImpl {
         device_type,
         min_result_size_for_bulk_dictionary_fetch,
         max_dictionary_to_result_size_ratio_for_bulk_dictionary_fetch);
+    
+    if(print_res){
+      std::cout << "________________________________________" << '\n';
+      std::cout << "For Query:" << query_string << std::endl;
+      std::cout << "Output:" << std::endl;
+      std::cout << arrow_omnisci_results->toString() << std::endl;
+      std::cout << "________________________________________" << '\n';
+    }
+
     sqlite_comparator_.compare_arrow_output(
         arrow_omnisci_results, query_string, device_type);
     // Below we test the newly added sparse dictionary capability,
@@ -491,11 +501,13 @@ void cta(const std::string& query_string, const ExecutorDeviceType device_type) 
 }
 
 void c_arrow(const std::string& query_string,
+             const bool print_res,
              const ExecutorDeviceType device_type,
              size_t min_result_size_for_bulk_dictionary_fetch,
              double max_dictionary_to_result_size_ratio_for_bulk_dictionary_fetch) {
   ArrowSQLRunnerImpl::get()->c_arrow(
       query_string,
+      print_res,
       device_type,
       min_result_size_for_bulk_dictionary_fetch,
       max_dictionary_to_result_size_ratio_for_bulk_dictionary_fetch);

--- a/omniscidb/Tests/ArrowSQLRunner/ArrowSQLRunner.h
+++ b/omniscidb/Tests/ArrowSQLRunner/ArrowSQLRunner.h
@@ -100,6 +100,7 @@ void cta(const std::string& query_string, const ExecutorDeviceType device_type);
 
 void c_arrow(
     const std::string& query_string,
+    const bool print_res,
     const ExecutorDeviceType device_type,
     size_t min_result_size_for_bulk_dictionary_fetch =
         ArrowResultSetConverter::default_min_result_size_for_bulk_dictionary_fetch,


### PR DESCRIPTION
This commit adds a simple `toString()` method in [omniscidb/QueryEngine/ArrowResultSet.h](https://github.com/intel-ai/hdk/compare/main...akroviakov:hdk:akroviak/arrow_res_print?expand=1#diff-062062dc8d485c4c7f31d81129e4c641ee0c821b1170774e38c5fd16380488af) that utilizes Apache Arrow `RecordBatch` method `ToString()` for printing its contents.
It is tested in [omniscidb/Tests/ArrowBasedExecuteTest.cpp](https://github.com/intel-ai/hdk/compare/main...akroviakov:hdk:akroviak/arrow_res_print?expand=1#diff-d1c6de126cd483e52b9c42852207585c39b237e589c8b041f5a36f57fb37b69b), inside `c_arrow()` calls in the form of a simple print statement:
 `std::cout << arrow_omnisci_results->toString() << std::endl;`
 that is invoked by setting a flag parameter `print_res` to true in each `c_arrow()` call.