### PR TITLE
Added toString methods for ResultSet and ArrowResultSet

### DIFF
--- a/omniscidb/QueryEngine/ArrowResultSet.h
+++ b/omniscidb/QueryEngine/ArrowResultSet.h
@@ -138,10 +138,8 @@ class ArrowResultSet {
   size_t colCount() const;
 
   const hdk::ir::Type* colType(size_t col_idx) const;
-  
-  std::string toString() const{
-    return record_batch_->ToString();
-  }
+
+  std::string toString() const { return record_batch_->ToString(); }
   bool definitelyHasNoRows() const;
 
   size_t rowCount() const;

--- a/omniscidb/QueryEngine/ArrowResultSet.h
+++ b/omniscidb/QueryEngine/ArrowResultSet.h
@@ -138,7 +138,10 @@ class ArrowResultSet {
   size_t colCount() const;
 
   const hdk::ir::Type* colType(size_t col_idx) const;
-
+  
+  std::string toString() const{
+    return record_batch_->ToString();
+  }
   bool definitelyHasNoRows() const;
 
   size_t rowCount() const;

--- a/omniscidb/QueryEngine/CMakeLists.txt
+++ b/omniscidb/QueryEngine/CMakeLists.txt
@@ -53,6 +53,7 @@ set(query_engine_source_files
     ExtensionFunctions.ast
     ExtensionsIR.cpp
     ExternalExecutor.cpp
+    ExtractStringFromTime.cpp
     ExtractFromTime.cpp
     FromTableReordering.cpp
     GpuInterrupt.cpp

--- a/omniscidb/QueryEngine/ExtractFromTime.cpp
+++ b/omniscidb/QueryEngine/ExtractFromTime.cpp
@@ -21,9 +21,9 @@
 
 #include "ExtractFromTime.h"
 
-#include <sstream>
-#include <iomanip>
 #include <cmath>
+#include <iomanip>
+#include <sstream>
 
 #ifndef __CUDACC__
 #include <cstdlib>  // abort()
@@ -317,51 +317,53 @@ DEVICE int64_t ExtractFromTime(hdk::ir::DateExtractField field, const int64_t ti
 #endif
 }
 
-
-std::string getStrDayFromSeconds(const int64_t seconds_tstamp){
+std::string getStrDayFromSeconds(const int64_t seconds_tstamp) {
   std::ostringstream oss;
   oss << std::setfill('0') << std::setw(2) << extract_day(seconds_tstamp);
   return oss.str();
 }
 
-std::string getStrMonthFromSeconds(const int64_t seconds_tstamp){
+std::string getStrMonthFromSeconds(const int64_t seconds_tstamp) {
   std::ostringstream oss;
   oss << std::setfill('0') << std::setw(2) << extract_month_fast(seconds_tstamp);
   return oss.str();
 }
 
-std::string getStrYearFromSeconds(const int64_t seconds_tstamp){
+std::string getStrYearFromSeconds(const int64_t seconds_tstamp) {
   std::ostringstream oss;
   oss << std::setfill('0') << std::setw(2) << extract_year_fast(seconds_tstamp);
   return oss.str();
 }
 
-std::string getStrDateFromSeconds(const int64_t seconds_tstamp){
+std::string getStrDateFromSeconds(const int64_t seconds_tstamp) {
   std::ostringstream oss;
-  oss << getStrYearFromSeconds(seconds_tstamp) << "-" \
-  << getStrMonthFromSeconds(seconds_tstamp) << "-" \
-  << getStrDayFromSeconds(seconds_tstamp);
+  oss << getStrYearFromSeconds(seconds_tstamp) << "-"
+      << getStrMonthFromSeconds(seconds_tstamp) << "-"
+      << getStrDayFromSeconds(seconds_tstamp);
   return oss.str();
 }
 
-std::string getStrTimeFromSeconds(const int64_t seconds_tstamp){
+std::string getStrTimeFromSeconds(const int64_t seconds_tstamp) {
   std::ostringstream oss;
-  oss << std::setfill('0') << std::setw(2) << extract_hour(seconds_tstamp) << ":" \
-  << std::setfill('0') << std::setw(2) << extract_minute(seconds_tstamp) << ":" \
-  << std::setfill('0') << std::setw(2) << extract_second(seconds_tstamp);
+  oss << std::setfill('0') << std::setw(2) << extract_hour(seconds_tstamp) << ":"
+      << std::setfill('0') << std::setw(2) << extract_minute(seconds_tstamp) << ":"
+      << std::setfill('0') << std::setw(2) << extract_second(seconds_tstamp);
   return oss.str();
 }
 
-std::string getStrTimeStampSecondsScaled(const int64_t tstamp, const int64_t seconds_scale){
+std::string getStrTimeStampSecondsScaled(const int64_t tstamp,
+                                         const int64_t seconds_scale) {
   std::ostringstream oss;
-  oss << getStrDateFromSeconds(tstamp / seconds_scale) << " " << getStrTimeFromSeconds(tstamp / seconds_scale);
-  if(seconds_scale > 1){
-    oss << "." << std::setfill('0') << std::setw(log10(seconds_scale)) << tstamp % seconds_scale;
+  oss << getStrDateFromSeconds(tstamp / seconds_scale) << " "
+      << getStrTimeFromSeconds(tstamp / seconds_scale);
+  if (seconds_scale > 1) {
+    oss << "." << std::setfill('0') << std::setw(log10(seconds_scale))
+        << tstamp % seconds_scale;
   }
   return oss.str();
 }
 
-std::string getStrTStamp(const int64_t tstamp, hdk::ir::TimeUnit unit){
+std::string getStrTStamp(const int64_t tstamp, hdk::ir::TimeUnit unit) {
   switch (unit) {
     case hdk::ir::TimeUnit::kSecond:
       return getStrTimeStampSecondsScaled(tstamp);

--- a/omniscidb/QueryEngine/ExtractFromTime.cpp
+++ b/omniscidb/QueryEngine/ExtractFromTime.cpp
@@ -363,6 +363,7 @@ std::string getStrTimeStampSecondsScaled(const int64_t tstamp,
   return oss.str();
 }
 
+#ifndef __CUDACC__
 std::string getStrTStamp(const int64_t tstamp, hdk::ir::TimeUnit unit) {
   switch (unit) {
     case hdk::ir::TimeUnit::kSecond:
@@ -379,3 +380,4 @@ std::string getStrTStamp(const int64_t tstamp, hdk::ir::TimeUnit unit) {
       return getStrDayFromSeconds(tstamp);
   }
 }
+#endif

--- a/omniscidb/QueryEngine/ExtractFromTime.cpp
+++ b/omniscidb/QueryEngine/ExtractFromTime.cpp
@@ -21,6 +21,10 @@
 
 #include "ExtractFromTime.h"
 
+#include <sstream>
+#include <iomanip>
+#include <cmath>
+
 #ifndef __CUDACC__
 #include <cstdlib>  // abort()
 #endif
@@ -311,4 +315,65 @@ DEVICE int64_t ExtractFromTime(hdk::ir::DateExtractField field, const int64_t ti
 #else
   abort();
 #endif
+}
+
+
+std::string getStrDayFromSeconds(const int64_t seconds_tstamp){
+  std::ostringstream oss;
+  oss << std::setfill('0') << std::setw(2) << extract_day(seconds_tstamp);
+  return oss.str();
+}
+
+std::string getStrMonthFromSeconds(const int64_t seconds_tstamp){
+  std::ostringstream oss;
+  oss << std::setfill('0') << std::setw(2) << extract_month_fast(seconds_tstamp);
+  return oss.str();
+}
+
+std::string getStrYearFromSeconds(const int64_t seconds_tstamp){
+  std::ostringstream oss;
+  oss << std::setfill('0') << std::setw(2) << extract_year_fast(seconds_tstamp);
+  return oss.str();
+}
+
+std::string getStrDateFromSeconds(const int64_t seconds_tstamp){
+  std::ostringstream oss;
+  oss << getStrYearFromSeconds(seconds_tstamp) << "-" \
+  << getStrMonthFromSeconds(seconds_tstamp) << "-" \
+  << getStrDayFromSeconds(seconds_tstamp);
+  return oss.str();
+}
+
+std::string getStrTimeFromSeconds(const int64_t seconds_tstamp){
+  std::ostringstream oss;
+  oss << std::setfill('0') << std::setw(2) << extract_hour(seconds_tstamp) << ":" \
+  << std::setfill('0') << std::setw(2) << extract_minute(seconds_tstamp) << ":" \
+  << std::setfill('0') << std::setw(2) << extract_second(seconds_tstamp);
+  return oss.str();
+}
+
+std::string getStrTimeStampSecondsScaled(const int64_t tstamp, const int64_t seconds_scale){
+  std::ostringstream oss;
+  oss << getStrDateFromSeconds(tstamp / seconds_scale) << " " << getStrTimeFromSeconds(tstamp / seconds_scale);
+  if(seconds_scale > 1){
+    oss << "." << std::setfill('0') << std::setw(log10(seconds_scale)) << tstamp % seconds_scale;
+  }
+  return oss.str();
+}
+
+std::string getStrTStamp(const int64_t tstamp, hdk::ir::TimeUnit unit){
+  switch (unit) {
+    case hdk::ir::TimeUnit::kSecond:
+      return getStrTimeStampSecondsScaled(tstamp);
+    case hdk::ir::TimeUnit::kMilli:
+      return getStrTimeStampSecondsScaled(tstamp, kMilliSecsPerSec);
+    case hdk::ir::TimeUnit::kMicro:
+      return getStrTimeStampSecondsScaled(tstamp, kMicroSecsPerSec);
+    case hdk::ir::TimeUnit::kNano:
+      return getStrTimeStampSecondsScaled(tstamp, kNanoSecsPerSec);
+    case hdk::ir::TimeUnit::kMonth:
+      return getStrMonthFromSeconds(tstamp);
+    case hdk::ir::TimeUnit::kDay:
+      return getStrDayFromSeconds(tstamp);
+  }
 }

--- a/omniscidb/QueryEngine/ExtractFromTime.cpp
+++ b/omniscidb/QueryEngine/ExtractFromTime.cpp
@@ -22,8 +22,6 @@
 #include "ExtractFromTime.h"
 
 #include <cmath>
-#include <iomanip>
-#include <sstream>
 
 #ifndef __CUDACC__
 #include <cstdlib>  // abort()
@@ -316,68 +314,3 @@ DEVICE int64_t ExtractFromTime(hdk::ir::DateExtractField field, const int64_t ti
   abort();
 #endif
 }
-
-std::string getStrDayFromSeconds(const int64_t seconds_tstamp) {
-  std::ostringstream oss;
-  oss << std::setfill('0') << std::setw(2) << extract_day(seconds_tstamp);
-  return oss.str();
-}
-
-std::string getStrMonthFromSeconds(const int64_t seconds_tstamp) {
-  std::ostringstream oss;
-  oss << std::setfill('0') << std::setw(2) << extract_month_fast(seconds_tstamp);
-  return oss.str();
-}
-
-std::string getStrYearFromSeconds(const int64_t seconds_tstamp) {
-  std::ostringstream oss;
-  oss << std::setfill('0') << std::setw(2) << extract_year_fast(seconds_tstamp);
-  return oss.str();
-}
-
-std::string getStrDateFromSeconds(const int64_t seconds_tstamp) {
-  std::ostringstream oss;
-  oss << getStrYearFromSeconds(seconds_tstamp) << "-"
-      << getStrMonthFromSeconds(seconds_tstamp) << "-"
-      << getStrDayFromSeconds(seconds_tstamp);
-  return oss.str();
-}
-
-std::string getStrTimeFromSeconds(const int64_t seconds_tstamp) {
-  std::ostringstream oss;
-  oss << std::setfill('0') << std::setw(2) << extract_hour(seconds_tstamp) << ":"
-      << std::setfill('0') << std::setw(2) << extract_minute(seconds_tstamp) << ":"
-      << std::setfill('0') << std::setw(2) << extract_second(seconds_tstamp);
-  return oss.str();
-}
-
-std::string getStrTimeStampSecondsScaled(const int64_t tstamp,
-                                         const int64_t seconds_scale) {
-  std::ostringstream oss;
-  oss << getStrDateFromSeconds(tstamp / seconds_scale) << " "
-      << getStrTimeFromSeconds(tstamp / seconds_scale);
-  if (seconds_scale > 1) {
-    oss << "." << std::setfill('0') << std::setw(log10(seconds_scale))
-        << tstamp % seconds_scale;
-  }
-  return oss.str();
-}
-
-#ifndef __CUDACC__
-std::string getStrTStamp(const int64_t tstamp, hdk::ir::TimeUnit unit) {
-  switch (unit) {
-    case hdk::ir::TimeUnit::kSecond:
-      return getStrTimeStampSecondsScaled(tstamp);
-    case hdk::ir::TimeUnit::kMilli:
-      return getStrTimeStampSecondsScaled(tstamp, kMilliSecsPerSec);
-    case hdk::ir::TimeUnit::kMicro:
-      return getStrTimeStampSecondsScaled(tstamp, kMicroSecsPerSec);
-    case hdk::ir::TimeUnit::kNano:
-      return getStrTimeStampSecondsScaled(tstamp, kNanoSecsPerSec);
-    case hdk::ir::TimeUnit::kMonth:
-      return getStrMonthFromSeconds(tstamp);
-    case hdk::ir::TimeUnit::kDay:
-      return getStrDayFromSeconds(tstamp);
-  }
-}
-#endif

--- a/omniscidb/QueryEngine/ExtractFromTime.h
+++ b/omniscidb/QueryEngine/ExtractFromTime.h
@@ -78,7 +78,8 @@ std::string getStrMonthFromSeconds(const int64_t seconds_tstamp);
 std::string getStrYearFromSeconds(const int64_t seconds_tstamp);
 std::string getStrDateFromSeconds(const int64_t seconds_tstamp);
 std::string getStrTimeFromSeconds(const int64_t seconds_tstamp);
-std::string getStrTimeStampSecondsScaled(const int64_t tstamp, const int64_t seconds_scale = 1);
+std::string getStrTimeStampSecondsScaled(const int64_t tstamp,
+                                         const int64_t seconds_scale = 1);
 std::string getStrTStamp(const int64_t tstamp, hdk::ir::TimeUnit field);
 
 // Return floor(dividend / divisor).

--- a/omniscidb/QueryEngine/ExtractFromTime.h
+++ b/omniscidb/QueryEngine/ExtractFromTime.h
@@ -19,7 +19,7 @@
 
 #include <cstdint>
 #include <ctime>
-
+#include <string>
 #include "IR/DateTimeEnums.h"
 #include "Shared/funcannotations.h"
 
@@ -73,6 +73,13 @@ constexpr unsigned MARJAN = 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31 + 30 + 31;
 constexpr unsigned JANMAR = 31 + 28;  // leap day handled separately
 
 DEVICE int64_t ExtractFromTime(hdk::ir::DateExtractField field, const int64_t timeval);
+std::string getStrDayFromSeconds(const int64_t seconds_tstamp);
+std::string getStrMonthFromSeconds(const int64_t seconds_tstamp);
+std::string getStrYearFromSeconds(const int64_t seconds_tstamp);
+std::string getStrDateFromSeconds(const int64_t seconds_tstamp);
+std::string getStrTimeFromSeconds(const int64_t seconds_tstamp);
+std::string getStrTimeStampSecondsScaled(const int64_t tstamp, const int64_t seconds_scale = 1);
+std::string getStrTStamp(const int64_t tstamp, hdk::ir::TimeUnit field);
 
 // Return floor(dividend / divisor).
 // Assumes 0 < divisor.

--- a/omniscidb/QueryEngine/ExtractFromTime.h
+++ b/omniscidb/QueryEngine/ExtractFromTime.h
@@ -72,6 +72,14 @@ static constexpr uint32_t kSecsJanToMar1900 = 5097600;
 constexpr unsigned MARJAN = 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31 + 30 + 31;
 constexpr unsigned JANMAR = 31 + 28;  // leap day handled separately
 
+extern "C" int64_t extract_month(const int64_t timeval);
+extern "C" int64_t extract_day(const int64_t timeval);
+extern "C" int64_t extract_hour(const int64_t timeval);
+extern "C" int64_t extract_minute(const int64_t timeval);
+extern "C" int64_t extract_second(const int64_t timeval);
+extern "C" int32_t extract_month_fast(const int64_t timeval);
+extern "C" int32_t extract_year_fast(const int64_t timeval);
+
 DEVICE int64_t ExtractFromTime(hdk::ir::DateExtractField field, const int64_t timeval);
 std::string getStrDayFromSeconds(const int64_t seconds_tstamp);
 std::string getStrMonthFromSeconds(const int64_t seconds_tstamp);

--- a/omniscidb/QueryEngine/ExtractStringFromTime.cpp
+++ b/omniscidb/QueryEngine/ExtractStringFromTime.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 MapD Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */ 
+
+#ifndef QUERYENGINE_EXTRACTSTRINGFROMTIME_H
+#define QUERYENGINE_EXTRACTSTRINGFROMTIME_H
+
+#include "ExtractFromTime.h"
+
+#include <cmath>
+#include <iomanip>
+#include <sstream>
+
+std::string getStrDayFromSeconds(const int64_t seconds_tstamp) {
+  std::ostringstream oss;
+  oss << std::setfill('0') << std::setw(2) << extract_day(seconds_tstamp);
+  return oss.str();
+}
+
+std::string getStrMonthFromSeconds(const int64_t seconds_tstamp) {
+  std::ostringstream oss;
+  oss << std::setfill('0') << std::setw(2) << extract_month_fast(seconds_tstamp);
+  return oss.str();
+}
+
+std::string getStrYearFromSeconds(const int64_t seconds_tstamp) {
+  std::ostringstream oss;
+  oss << std::setfill('0') << std::setw(2) << extract_year_fast(seconds_tstamp);
+  return oss.str();
+}
+
+std::string getStrDateFromSeconds(const int64_t seconds_tstamp) {
+  std::ostringstream oss;
+  oss << getStrYearFromSeconds(seconds_tstamp) << "-"
+      << getStrMonthFromSeconds(seconds_tstamp) << "-"
+      << getStrDayFromSeconds(seconds_tstamp);
+  return oss.str();
+}
+
+std::string getStrTimeFromSeconds(const int64_t seconds_tstamp) {
+  std::ostringstream oss;
+  oss << std::setfill('0') << std::setw(2) << extract_hour(seconds_tstamp) << ":"
+      << std::setfill('0') << std::setw(2) << extract_minute(seconds_tstamp) << ":"
+      << std::setfill('0') << std::setw(2) << extract_second(seconds_tstamp);
+  return oss.str();
+}
+
+std::string getStrTimeStampSecondsScaled(const int64_t tstamp,
+                                         const int64_t seconds_scale) {
+  std::ostringstream oss;
+  oss << getStrDateFromSeconds(tstamp / seconds_scale) << " "
+      << getStrTimeFromSeconds(tstamp / seconds_scale);
+  if (seconds_scale > 1) {
+    oss << "." << std::setfill('0') << std::setw(log10(seconds_scale))
+        << tstamp % seconds_scale;
+  }
+  return oss.str();
+}
+
+std::string getStrTStamp(const int64_t tstamp, hdk::ir::TimeUnit unit) {
+  switch (unit) {
+    case hdk::ir::TimeUnit::kSecond:
+      return getStrTimeStampSecondsScaled(tstamp);
+    case hdk::ir::TimeUnit::kMilli:
+      return getStrTimeStampSecondsScaled(tstamp, kMilliSecsPerSec);
+    case hdk::ir::TimeUnit::kMicro:
+      return getStrTimeStampSecondsScaled(tstamp, kMicroSecsPerSec);
+    case hdk::ir::TimeUnit::kNano:
+      return getStrTimeStampSecondsScaled(tstamp, kNanoSecsPerSec);
+    case hdk::ir::TimeUnit::kMonth:
+      return getStrMonthFromSeconds(tstamp);
+    case hdk::ir::TimeUnit::kDay:
+      return getStrDayFromSeconds(tstamp);
+  }
+}
+
+#endif  // QUERYENGINE_EXTRACTSTRINGFROMTIME_H

--- a/omniscidb/QueryEngine/ExtractStringFromTime.cpp
+++ b/omniscidb/QueryEngine/ExtractStringFromTime.cpp
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */ 
+ */
 
 #ifndef QUERYENGINE_EXTRACTSTRINGFROMTIME_H
 #define QUERYENGINE_EXTRACTSTRINGFROMTIME_H

--- a/omniscidb/QueryEngine/ResultSet.cpp
+++ b/omniscidb/QueryEngine/ResultSet.cpp
@@ -28,6 +28,7 @@
 #include "InPlaceSort.h"
 #include "OutputBufferInitialization.h"
 #include "RuntimeFunctions.h"
+#include "ExtractFromTime.h"
 #include "Shared/InlineNullValues.h"
 #include "Shared/Intervals.h"
 #include "Shared/SqlTypesLayout.h"
@@ -190,6 +191,96 @@ ResultSet::~ResultSet() {
     CHECK(data_mgr_);
     data_mgr_->free(device_estimator_buffer_);
   }
+}
+
+std::string ResultSet::getStrScalarVal(const ScalarTargetValue& current_scalar, const hdk::ir::Type* col_type) const{
+  std::ostringstream oss;
+  if(current_scalar.type() == typeid(NullableString)){
+    if(boost::get<NullableString>(current_scalar).type() == typeid(void*)){
+      oss << "null";
+    }
+    else{
+      oss << boost::get<std::string>(boost::get<NullableString>(current_scalar));
+    }
+  }
+  else{
+    if(col_type->isExtDictionary()){
+      const int32_t dict_id = col_type->as<hdk::ir::ExtDictionaryType>()->dictId();
+      const auto sdp = getStringDictionaryProxy(dict_id);
+      oss << "idx:" << ((sdp->storageEntryCount()) ? current_scalar : "null") << ", str:" << "\"" << sdp->getString(boost::get<int64_t>(current_scalar)) << "\"";
+    }else{
+      if( (col_type->isInt64() && boost::get<int64_t>(current_scalar) == std::numeric_limits<int64_t>::min()) ||
+      (col_type->isInt32() && boost::get<int64_t>(current_scalar) == std::numeric_limits<int32_t>::min()) || 
+      (col_type->isInt16() && boost::get<int64_t>(current_scalar) == std::numeric_limits<int16_t>::min()) ||
+      (col_type->isInt8() && boost::get<int64_t>(current_scalar) == std::numeric_limits<int8_t>::min()) ||
+      (col_type->isFp32() && boost::get<float>(current_scalar) == std::numeric_limits<float>::min()) || 
+      (col_type->isFp64() && boost::get<double>(current_scalar) == std::numeric_limits<double>::min()) || 
+      (col_type->isDateTime() && boost::get<int64_t>(current_scalar) == std::numeric_limits<int64_t>::min())
+      ){
+        oss << "null";
+      } else {
+        if(col_type->isDate()){
+          oss << getStrDateFromSeconds(boost::get<int64_t>(current_scalar));
+        }
+        else if(col_type->isTime()){
+          oss << getStrTimeFromSeconds(boost::get<int64_t>(current_scalar));
+        }
+        else if(col_type->isTimestamp()){
+          oss << getStrTStamp(boost::get<int64_t>(current_scalar), col_type->as<hdk::ir::DateTimeBaseType>()->unit());
+        } 
+        else{
+          oss << current_scalar;
+        }
+      }
+    }
+  }
+  return oss.str();
+}
+
+std::string ResultSet::contentToString() const {
+  std::ostringstream oss;
+  constexpr char col_delimiter = '|';
+  oss << "ColTypes:\n";
+  for(size_t col = 0; col < colCount(); col++){
+    oss << colType(col)->toString() << col_delimiter;
+  }
+  oss << "\nData:\n";
+  while (true) {
+    const auto row = getNextRow(false, false);
+    if (row.empty()) {
+      break;
+    }
+    else
+    {
+      for(size_t col_idx = 0; col_idx < row.size(); col_idx++)
+      {
+        if(row[col_idx].type() == typeid(ScalarTargetValue))
+        {
+          const auto scalar_col_val = boost::get<ScalarTargetValue>(row[col_idx]);
+          oss << getStrScalarVal(scalar_col_val, colType(col_idx));
+        }
+        else
+        {
+          const auto array_col_val = boost::get<ArrayTargetValue>(&row[col_idx]);
+          if (!array_col_val->is_initialized()) {
+            oss << "null";
+          }
+          else
+          {
+            const auto& scalar_vector = array_col_val->get();
+            oss << "[";
+            for(const auto& scalar_val: scalar_vector){
+              oss << getStrScalarVal(scalar_val, colType(col_idx)) << ",";
+            }
+            oss << "]";
+          }
+        }
+        oss << col_delimiter;
+      }
+      oss << "\n";
+    }
+  }
+  return oss.str();
 }
 
 std::string ResultSet::summaryToString() const {

--- a/omniscidb/QueryEngine/ResultSet.h
+++ b/omniscidb/QueryEngine/ResultSet.h
@@ -204,8 +204,9 @@ class ResultSet {
            ", query_mem_desc=" + ::toString(query_mem_desc_) + ")";
   }
 
-  std::string getStrScalarVal(const ScalarTargetValue& current_scalar, const hdk::ir::Type* col_type) const;
-  std::string contentToString() const; 
+  std::string getStrScalarVal(const ScalarTargetValue& current_scalar,
+                              const hdk::ir::Type* col_type) const;
+  std::string contentToString() const;
   std::string summaryToString() const;
 
   inline ResultSetRowIterator rowIterator(size_t from_logical_index,

--- a/omniscidb/QueryEngine/ResultSet.h
+++ b/omniscidb/QueryEngine/ResultSet.h
@@ -25,6 +25,7 @@
 #ifndef QUERYENGINE_RESULTSET_H
 #define QUERYENGINE_RESULTSET_H
 
+#include <boost/optional/optional_io.hpp>
 #include "BufferProvider/BufferProvider.h"
 #include "CardinalityEstimator.h"
 #include "DataMgr/Chunk/Chunk.h"
@@ -203,6 +204,8 @@ class ResultSet {
            ", query_mem_desc=" + ::toString(query_mem_desc_) + ")";
   }
 
+  std::string getStrScalarVal(const ScalarTargetValue& current_scalar, const hdk::ir::Type* col_type) const;
+  std::string contentToString() const; 
   std::string summaryToString() const;
 
   inline ResultSetRowIterator rowIterator(size_t from_logical_index,


### PR DESCRIPTION
This PR adds "toString" methods for `ResultSet` and `ArrowResultSet`.
`ArrowResultSet::toString()` calls Arrow's `RecordBatch::ToString()`.
`ResultSet::contentToString()` walks over rows and prints columns of the current row.
___________________
Changes outside of `ResultSet` and `ArrowResultSet` files:
`ExtractFromTime` now has methods to retrieve string representation of a timestamp in different formats.
___________________
Clarifying question | possible bug(?):
`ExtractFromTime` contains functions to extract certain time units from a timestamp. When the extraction unit is less than a second (milli, micro, nano), the extraction basically looks like this (e.g., for millisecond):
`unsigned_mod(lcltime, kSecsPerMin * kMilliSecsPerSec)`
so we basically take the remainder of a division by units per _minute_ (for millisecond it is 60000). In `ResultSet` timestamps are stored as seconds with milli/micro/nano scale meaning timestamp extension by 3/6/9 digits respectively. 
The question is why does the subsecond scale extraction requires division by units-per-minute and not by units-per-second? 
These functions for subsecond scales are already used in `ExtractFromTime(hdk::ir::DateExtractField field, const int64_t timeval)`, so if there is no issue with these functions, what is the expected format of `lcltime` for subsecond scales (other functions for year, month, day, hour, minute, second work fine as is)?