### PR TITLE
Directly reference Join nodes in ColumnRef.

### DIFF
--- a/omniscidb/IR/Node.h
+++ b/omniscidb/IR/Node.h
@@ -1269,5 +1269,6 @@ const Type* getColumnType(const Node* node, size_t col_idx);
 ExprPtr getNodeColumnRef(const Node* node, unsigned index);
 ExprPtrVector getNodeColumnRefs(const Node* node);
 size_t getNodeColumnCount(const Node* node);
+ExprPtr getJoinInputColumnRef(const ColumnRef* col_ref);
 
 }  // namespace hdk::ir

--- a/omniscidb/QueryEngine/QueryPhysicalInputsCollector.cpp
+++ b/omniscidb/QueryEngine/QueryPhysicalInputsCollector.cpp
@@ -169,13 +169,13 @@ class PhysicalInputsVisitor
     if (!scan) {
       const auto join = dynamic_cast<const hdk::ir::Join*>(source);
       if (join) {
-        auto input = getNodeColumnRef(join, col_ref->index());
+        auto input = getJoinInputColumnRef(col_ref);
         return visit(input.get());
       }
-      // Filter indirectly uses all columns of its input. So,
-      // walk through filter column references.
-      if (auto filter = source->as<hdk::ir::Filter>()) {
-        auto new_ref = getNodeColumnRef(filter->getInput(0), col_ref->index());
+      // Filter and sort indirectly use all columns of its input.
+      // So, walk through such column references.
+      if (source->is<hdk::ir::Filter>() || source->is<hdk::ir::Scan>()) {
+        auto new_ref = getNodeColumnRef(source->getInput(0), col_ref->index());
         return visit(new_ref.get());
       }
       return InputColDescriptorSet{};

--- a/omniscidb/QueryEngine/RelAlgOptimizer.cpp
+++ b/omniscidb/QueryEngine/RelAlgOptimizer.cpp
@@ -41,12 +41,7 @@ class ProjectInputRedirector : public hdk::ir::ExprRewriter {
       auto new_col_ref = dynamic_cast<const hdk::ir::ColumnRef*>(
           source->getExpr(col_ref->index()).get());
       if (new_col_ref) {
-        if (auto join = dynamic_cast<const hdk::ir::Join*>(new_source)) {
-          CHECK(new_col_ref->node() == join->getInput(0) ||
-                new_col_ref->node() == join->getInput(1));
-        } else {
-          CHECK_EQ(new_col_ref->node(), new_source);
-        }
+        CHECK_EQ(new_col_ref->node(), new_source);
         return new_col_ref->shared();
       }
     }


### PR DESCRIPTION
Currently, when a column of a `Join` node is referenced, appropriate `ColumnRef` actually references one of its input nodes, and `Join` nodes are not used in `ColumnRef` expressions. That was probably convenient in some analysis code and visitors, but for HDK IR as a public API, it creates very nonobvious inconsistency. During my previous refactorings, I was preparing a switch to the direct usage of `Join` nodes in `ColumnRef` expressions. This is the final step that actually starts doing it.

I intentionally didn't modify `LeftDeepInnerJoin` case, because it's not used right now by default and this node is going to be removed anyway.