### PR TITLE
Add test to detect improper working dir.

### DIFF
--- a/python/tests/test_work_dir.py
+++ b/python/tests/test_work_dir.py
@@ -1,0 +1,13 @@
+#
+# Copyright 2023 Intel Corporation.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+
+class TestWorkDir:
+    def test_work_dir(self):
+        assert os.path.exists(
+            "python/tests/test_dir_token"
+        ), "Run pytest from the HDK root dir."


### PR DESCRIPTION
With this test, we enforce pytest run from the root HDK directory. This is to state that we don't support pytest run from arbitrary places to easily locate resource files (like test CSV files) in python tests.