### PR TITLE
Move boost hash include into cpp file

### DIFF
--- a/omniscidb/IR/Datum.cpp
+++ b/omniscidb/IR/Datum.cpp
@@ -31,6 +31,8 @@
 #include <stdexcept>
 #include <string>
 
+#include <boost/functional/hash.hpp>
+
 #include "IR/Context.h"
 #include "IR/Type.h"
 #include "Logger/Logger.h"

--- a/omniscidb/Shared/sqltypes.h
+++ b/omniscidb/Shared/sqltypes.h
@@ -26,8 +26,6 @@
 #include "StringTransform.h"
 #include "funcannotations.h"
 
-#include <boost/functional/hash.hpp>
-
 #include <cassert>
 #include <cfloat>
 #include <cmath>


### PR DESCRIPTION
Prevents cuda code, which eventually includes sqltypes.h, from seeing the hash include.