### PR TITLE
Use hdk_log as default log dir.

### DIFF
--- a/omniscidb/Calcite/java/calcite/src/main/resources/log4j2.properties
+++ b/omniscidb/Calcite/java/calcite/src/main/resources/log4j2.properties
@@ -10,8 +10,8 @@ appender.console.filter.threshold.level = fatal
 
 appender.rolling.type = RollingFile
 appender.rolling.name = RollingFile
-appender.rolling.fileName = ${sys:MAPD_LOG_DIR}/log4j.log
-appender.rolling.filePattern = ${sys:MAPD_LOG_DIR}/log4j-%d{yyy-MM-dd-HH-mm-ss}-%i.log.gz
+appender.rolling.fileName = hdk_log/log4j.log
+appender.rolling.filePattern = hdk_log/log4j-%d{yyy-MM-dd-HH-mm-ss}-%i.log.gz
 appender.rolling.layout.type = PatternLayout
 appender.rolling.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%M:%L - %m%n
 appender.rolling.policies.type = Policies

--- a/omniscidb/Calcite/java/calcite/src/test/resources/log4j2.properties
+++ b/omniscidb/Calcite/java/calcite/src/test/resources/log4j2.properties
@@ -10,8 +10,8 @@ appender.console.filter.threshold.level = fatal
 
 appender.rolling.type = RollingFile
 appender.rolling.name = RollingFile
-appender.rolling.fileName = ${sys:MAPD_LOG_DIR}/log4j.log
-appender.rolling.filePattern = ${sys:MAPD_LOG_DIR}/log4j-%d{yyy-MM-dd-HH-mm-ss}-%i.log.gz
+appender.rolling.fileName = hdk_log/log4j.log
+appender.rolling.filePattern = hdk_log/log4j-%d{yyy-MM-dd-HH-mm-ss}-%i.log.gz
 appender.rolling.layout.type = PatternLayout
 appender.rolling.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%M:%L - %m%n
 appender.rolling.policies.type = Policies

--- a/omniscidb/Logger/Logger.cpp
+++ b/omniscidb/Logger/Logger.cpp
@@ -85,7 +85,7 @@ std::string filename(char const* path) {
 }
 
 LogOptions::LogOptions(char const* argv0)
-    : log_dir_(std::make_unique<boost::filesystem::path>("mapd_log")) {
+    : log_dir_(std::make_unique<boost::filesystem::path>("hdk_log")) {
   // Log file base_name matches name of program.
   std::string const base_name =
       argv0 == nullptr ? std::string("omnisci_server") : filename(argv0);


### PR DESCRIPTION
This doesn't allow configuring dir for log4j (or disabling Calcite logs) but it is still a slight improvement compared to the current `${sys:MAPD_LOG_DIR}` which is more annoying. This also puts all logs into a single place (at least by default). 