### PR TITLE
Add debug descriptions and pretty-print for Python ExecutionResult.

### DIFF
--- a/omniscidb/QueryEngine/ResultSet.cpp
+++ b/omniscidb/QueryEngine/ResultSet.cpp
@@ -241,20 +241,29 @@ std::string ResultSet::getStrScalarVal(const ScalarTargetValue& current_scalar,
   return oss.str();
 }
 
-std::string ResultSet::contentToString() const {
+std::string ResultSet::contentToString(bool header) const {
   std::ostringstream oss;
   constexpr char col_delimiter = '|';
-  oss << "ColTypes:\n";
-  for (size_t col = 0; col < colCount(); col++) {
-    oss << colType(col)->toString() << col_delimiter;
+  if (header) {
+    oss << "Column types:\n";
+    for (size_t col = 0; col < colCount(); col++) {
+      if (col) {
+        oss << col_delimiter;
+      }
+      oss << colType(col)->toString();
+    }
+    oss << "\nData:\n";
   }
-  oss << "\nData:\n";
+  moveToBegin();
   while (true) {
     const auto row = getNextRow(false, false);
     if (row.empty()) {
       break;
     } else {
       for (size_t col_idx = 0; col_idx < row.size(); col_idx++) {
+        if (col_idx) {
+          oss << col_delimiter;
+        }
         if (row[col_idx].type() == typeid(ScalarTargetValue)) {
           const auto scalar_col_val = boost::get<ScalarTargetValue>(row[col_idx]);
           oss << getStrScalarVal(scalar_col_val, colType(col_idx));
@@ -271,7 +280,6 @@ std::string ResultSet::contentToString() const {
             oss << "]";
           }
         }
-        oss << col_delimiter;
       }
       oss << "\n";
     }

--- a/omniscidb/QueryEngine/ResultSet.h
+++ b/omniscidb/QueryEngine/ResultSet.h
@@ -206,7 +206,7 @@ class ResultSet {
 
   std::string getStrScalarVal(const ScalarTargetValue& current_scalar,
                               const hdk::ir::Type* col_type) const;
-  std::string contentToString() const;
+  std::string contentToString(bool header = true) const;
   std::string summaryToString() const;
 
   inline ResultSetRowIterator rowIterator(size_t from_logical_index,

--- a/python/pyhdk/_execute.pxd
+++ b/python/pyhdk/_execute.pxd
@@ -81,12 +81,16 @@ cdef extern from "omniscidb/QueryEngine/ResultSet.h":
   cdef cppclass CResultSet "ResultSet":
     size_t rowCount()
 
+    string toString() const
+    string contentToString(bool) const
+    string summaryToString() const
+
 ctypedef shared_ptr[CResultSet] CResultSetPtr
 
 cdef extern from "omniscidb/QueryEngine/TargetMetaInfo.h":
   cdef cppclass CTargetMetaInfo "TargetMetaInfo":
     const string& get_resname()
-    const CType& get_type_info()
+    const CType* type()
 
 cdef extern from "omniscidb/QueryEngine/ArrowResultSet.h":
   cdef cppclass CArrowResultSetConverter "ArrowResultSetConverter":

--- a/python/pyhdk/_sql.pyx
+++ b/python/pyhdk/_sql.pyx
@@ -68,6 +68,35 @@ cdef class ExecutionResult:
   def to_explain_str(self):
     return self.c_result.getExplanation()
 
+  @property
+  def schema(self):
+    cdef const vector[CTargetMetaInfo]* meta = &self.c_result.getTargetsMeta()
+    res = dict()
+    for col_idx in range(meta.size()):
+      key = meta.at(col_idx).get_resname()
+      val = meta.at(col_idx).type().toString()
+      res[key] = val
+    return res
+
+  @property
+  def desc(self):
+    return self.c_result.getRows().get().summaryToString()
+
+  @property
+  def memory_desc(self):
+    return self.c_result.getRows().get().toString()
+
+  def __str__(self):
+    res = "Schema:\n"
+    for key, type_str in self.schema.items():
+      res += f"  {key}: {type_str}\n"
+    res += "Data:\n"
+    res += self.c_result.getRows().get().contentToString(False)
+    return res
+
+  def __repr__(self):
+    return self.__str__()
+
 cdef class RelAlgExecutor:
   cdef shared_ptr[CRelAlgExecutor] c_rel_alg_executor
   # DataMgr is used only to pass it to each produced ExecutionResult


### PR DESCRIPTION
This adds prints for `ExecutionResult` in Python. Also fixes a problem with empty data when printed twice in a row.