### PR TITLE
Support partial scheme specification on CSV import.

### DIFF
--- a/omniscidb/Tests/ArrowStorageTest.cpp
+++ b/omniscidb/Tests/ArrowStorageTest.cpp
@@ -942,6 +942,76 @@ TEST_F(ArrowStorageTest, ImportCsv_DateTime) {
       getFilePath("date_time.csv"), "table1", table_options, parse_options);
 }
 
+TEST_F(ArrowStorageTest, ImportCsv_PartialSchema_Header1) {
+  ArrowStorage storage(TEST_SCHEMA_ID, "test", TEST_DB_ID);
+  ArrowStorage::TableOptions table_options;
+  ArrowStorage::CsvParseOptions parse_options;
+  TableInfoPtr tinfo = storage.importCsvFile(getFilePath("numbers_header.csv"),
+                                             "table1",
+                                             {{"col1", ctx.int32()}},
+                                             table_options,
+                                             parse_options);
+  checkData(storage,
+            tinfo->table_id,
+            9,
+            table_options.fragment_size,
+            range(9, (int32_t)1),
+            range(9, 10.0));
+}
+
+TEST_F(ArrowStorageTest, ImportCsv_PartialSchema_Header2) {
+  ArrowStorage storage(TEST_SCHEMA_ID, "test", TEST_DB_ID);
+  ArrowStorage::TableOptions table_options;
+  ArrowStorage::CsvParseOptions parse_options;
+  TableInfoPtr tinfo = storage.importCsvFile(getFilePath("numbers_header.csv"),
+                                             "table1",
+                                             {{"col2", ctx.fp32()}},
+                                             table_options,
+                                             parse_options);
+  checkData(storage,
+            tinfo->table_id,
+            9,
+            table_options.fragment_size,
+            range(9, (int64_t)1),
+            range(9, 10.0f));
+}
+
+TEST_F(ArrowStorageTest, ImportCsv_PartialSchema_NoHeader1) {
+  ArrowStorage storage(TEST_SCHEMA_ID, "test", TEST_DB_ID);
+  ArrowStorage::TableOptions table_options;
+  ArrowStorage::CsvParseOptions parse_options;
+  parse_options.header = false;
+  TableInfoPtr tinfo = storage.importCsvFile(getFilePath("numbers_noheader.csv"),
+                                             "table1",
+                                             {{"col1", ctx.int32()}, {"col2", nullptr}},
+                                             table_options,
+                                             parse_options);
+  checkData(storage,
+            tinfo->table_id,
+            9,
+            table_options.fragment_size,
+            range(9, (int32_t)1),
+            range(9, 10.0));
+}
+
+TEST_F(ArrowStorageTest, ImportCsv_PartialSchema_NoHeader2) {
+  ArrowStorage storage(TEST_SCHEMA_ID, "test", TEST_DB_ID);
+  ArrowStorage::TableOptions table_options;
+  ArrowStorage::CsvParseOptions parse_options;
+  parse_options.header = false;
+  TableInfoPtr tinfo = storage.importCsvFile(getFilePath("numbers_noheader.csv"),
+                                             "table1",
+                                             {{"col1", nullptr}, {"col2", ctx.fp32()}},
+                                             table_options,
+                                             parse_options);
+  checkData(storage,
+            tinfo->table_id,
+            9,
+            table_options.fragment_size,
+            range(9, (int64_t)1),
+            range(9, 10.0f));
+}
+
 TEST_F(ArrowStorageTest, AppendCsvData) {
   ArrowStorage storage(TEST_SCHEMA_ID, "test", TEST_DB_ID);
   TableInfoPtr tinfo =


### PR DESCRIPTION
Currently, we can import a CSV file without specifying the schema, but if we want to specify column names or types then we have to provide the full table schema. With this change, we can specify types for some of the columns and use auto-typing for the rest. Also, we can use `nullptr` for the type in case we only want to specify column names.

This feature will be used for the `pyhdk.HDK.import_csv` implementation in the upcoming PR.
