### PR TITLE
[ArrowResultSet] Support LIMIT and OFFSET

### DIFF
--- a/omniscidb/QueryEngine/ResultSet.h
+++ b/omniscidb/QueryEngine/ResultSet.h
@@ -437,6 +437,8 @@ class ResultSet {
 
   size_t getLimit() const;
 
+  size_t getOffset() const;
+
   void copyColumnIntoBuffer(const size_t column_idx,
                             int8_t* output_buffer,
                             const size_t output_buffer_size) const;


### PR DESCRIPTION
This commit takes into account the limit and offset parameters in the ArrowResultSet.
Also added several tests to check limit/offset with ascending/descending
ordering and joins to ResultSetArrowConversion suit.

Resolves: https://github.com/intel-ai/hdk/issues/183

Signed-off-by: Dmitrii Makarenko <dmitrii.makarenko@intel.com>