### PR TITLE
Add support for hash join on rowid

### DIFF
--- a/omniscidb/QueryEngine/GroupByRuntime.cpp
+++ b/omniscidb/QueryEngine/GroupByRuntime.cpp
@@ -284,6 +284,14 @@ bucketized_hash_join_idx(int64_t hash_buff,
 }
 
 extern "C" RUNTIME_EXPORT ALWAYS_INLINE DEVICE int64_t
+rowid_hash_join_idx(const int64_t key, const int64_t min_key, const int64_t max_key) {
+  if (key >= min_key && key <= max_key) {
+    return key;
+  }
+  return -1;
+}
+
+extern "C" RUNTIME_EXPORT ALWAYS_INLINE DEVICE int64_t
 hash_join_idx(int64_t hash_buff,
               const int64_t key,
               const int64_t min_key,
@@ -331,6 +339,14 @@ bucketized_hash_join_idx_bitwise(int64_t hash_buff,
                                                     min_key,
                                                     translated_val,
                                                     bucket_normalization);
+}
+
+extern "C" RUNTIME_EXPORT ALWAYS_INLINE DEVICE int64_t
+rowid_hash_join_idx_nullable(const int64_t key,
+                             const int64_t min_key,
+                             const int64_t max_key,
+                             const int64_t null_val) {
+  return key != null_val ? rowid_hash_join_idx(key, min_key, max_key) : -1;
 }
 
 extern "C" RUNTIME_EXPORT ALWAYS_INLINE DEVICE int64_t


### PR DESCRIPTION
Support join on rowid by skipping the hash table build and computing the row offset in the probe. Offset computation consists of null handling and range handling. For an empty table, we use roughly the expression range of (0, -1) which always returns -1 inside the newly added `rowid_hash_join_idx` runtime function. 

There is one limitation -- because of this approach of not building the table we cannot support a query of the form `t1.rowid = t2.rowid AND .... `. Loop joins still work of course. If this query becomes something we need to support with hash join, we can push the secondary join expression into filters and run a mini-loop join on each row that passes the rowid "hash". 

Added a bunch of tests but could probably use some more coverage. Open to ideas. The way I force the hash table builder to skip the build is by marking it empty during construction. This is kind of a hack, but I think it's ok for now with the checks I've added. 

Closes #165 