### PR TITLE
Check for empty table before computing expression ranges

### DIFF
--- a/omniscidb/QueryEngine/ExpressionRange.cpp
+++ b/omniscidb/QueryEngine/ExpressionRange.cpp
@@ -544,12 +544,6 @@ ExpressionRange getLeafColumnRange(const hdk::ir::ColumnVar* col_expr,
       CHECK(ti_idx);
       const auto& query_info = query_infos[*ti_idx].info;
       const auto& fragments = query_info.fragments;
-      if (col_expr->isVirtual()) {
-        CHECK(col_type->isInt64());
-        const int64_t num_tuples = query_info.getNumTuples();
-        return ExpressionRange::makeIntRange(
-            0, std::max(num_tuples - 1, int64_t(0)), 0, has_nulls);
-      }
       if (query_info.getNumTuples() == 0) {
         // The column doesn't contain any values, synthesize an empty range.
         if (col_type->isFloatingPoint()) {
@@ -557,6 +551,12 @@ ExpressionRange getLeafColumnRange(const hdk::ir::ColumnVar* col_expr,
                                        : ExpressionRange::makeDoubleRange(0, -1, false);
         }
         return ExpressionRange::makeIntRange(0, -1, 0, false);
+      }
+      if (col_expr->isVirtual()) {
+        CHECK(col_type->isInt64());
+        const int64_t num_tuples = query_info.getNumTuples();
+        return ExpressionRange::makeIntRange(
+            0, std::max(num_tuples - 1, int64_t(0)), 0, has_nulls);
       }
       std::vector<size_t> nonempty_fragment_indices;
       for (size_t i = 0; i < fragments.size(); ++i) {

--- a/omniscidb/QueryEngine/JoinHashTable/PerfectJoinHashTable.cpp
+++ b/omniscidb/QueryEngine/JoinHashTable/PerfectJoinHashTable.cpp
@@ -992,18 +992,10 @@ llvm::Value* PerfectJoinHashTable::codegenSlot(const CompilationOptions& co,
 
     std::vector<llvm::Value*> hash_join_idx_args{
         executor_->cgen_state_->castToTypeIn(key_lvs.front(), 64)};
-
-    const auto& query_info = getInnerQueryInfo(val_col_var).info;
-    if (query_info.getPhysicalNumTuples() == 0) {
-      // empty inner table, set range to empty / invalid
-      hash_join_idx_args.push_back(executor_->cgen_state_->llInt(/*min=*/int64_t(0)));
-      hash_join_idx_args.push_back(executor_->cgen_state_->llInt(/*max=*/int64_t(-1)));
-    } else {
-      hash_join_idx_args.push_back(
-          executor_->cgen_state_->llInt(rhs_source_col_range_.getIntMin()));
-      hash_join_idx_args.push_back(
-          executor_->cgen_state_->llInt(rhs_source_col_range_.getIntMax()));
-    }
+    hash_join_idx_args.push_back(
+        executor_->cgen_state_->llInt(rhs_source_col_range_.getIntMin()));
+    hash_join_idx_args.push_back(
+        executor_->cgen_state_->llInt(rhs_source_col_range_.getIntMax()));
 
     auto key_col_logical_type = key_col->type()->canonicalize();
     if (key_col_logical_type->nullable() || isBitwiseEq()) {


### PR DESCRIPTION
Ensure expression range for a virtual column over an empty table is properly created.