### PR TITLE
ResultSet refactoring and clean-up [01/N]

### DIFF
--- a/omniscidb/QueryEngine/Descriptors/QueryMemoryDescriptor.cpp
+++ b/omniscidb/QueryEngine/Descriptors/QueryMemoryDescriptor.cpp
@@ -426,7 +426,6 @@ QueryMemoryDescriptor::QueryMemoryDescriptor(
     const bool must_use_baseline_sort,
     const bool use_streaming_top_n)
     : executor_(executor)
-    , allow_multifrag_(allow_multifrag)
     , query_desc_type_(col_range_info.hash_type_)
     , keyless_hash_(keyless_hash)
     , interleaved_bins_on_gpu_(interleaved_bins_on_gpu)
@@ -497,7 +496,6 @@ QueryMemoryDescriptor::QueryMemoryDescriptor(
 
 QueryMemoryDescriptor::QueryMemoryDescriptor()
     : executor_(nullptr)
-    , allow_multifrag_(false)
     , query_desc_type_(QueryDescriptionType::Projection)
     , keyless_hash_(false)
     , interleaved_bins_on_gpu_(false)
@@ -520,7 +518,6 @@ QueryMemoryDescriptor::QueryMemoryDescriptor(const Executor* executor,
                                              const QueryDescriptionType query_desc_type,
                                              const bool is_table_function)
     : executor_(executor)
-    , allow_multifrag_(false)
     , query_desc_type_(query_desc_type)
     , keyless_hash_(false)
     , interleaved_bins_on_gpu_(false)
@@ -544,7 +541,6 @@ QueryMemoryDescriptor::QueryMemoryDescriptor(const QueryDescriptionType query_de
                                              const bool has_nulls,
                                              const std::vector<int8_t>& group_col_widths)
     : executor_(nullptr)
-    , allow_multifrag_(false)
     , query_desc_type_(query_desc_type)
     , keyless_hash_(false)
     , interleaved_bins_on_gpu_(false)
@@ -1164,7 +1160,6 @@ std::string QueryMemoryDescriptor::queryDescTypeToString() const {
 
 std::string QueryMemoryDescriptor::toString() const {
   auto str = reductionKey();
-  str += "\tAllow Multifrag: " + ::toString(allow_multifrag_) + "\n";
   str += "\tInterleaved Bins on GPU: " + ::toString(interleaved_bins_on_gpu_) + "\n";
   str += "\tBlocks Share Memory: " + ::toString(blocksShareMemory()) + "\n";
   str += "\tThreads Share Memory: " + ::toString(threadsShareMemory()) + "\n";

--- a/omniscidb/QueryEngine/Descriptors/QueryMemoryDescriptor.h
+++ b/omniscidb/QueryEngine/Descriptors/QueryMemoryDescriptor.h
@@ -344,7 +344,6 @@ class QueryMemoryDescriptor {
 
  private:
   const Executor* executor_;
-  bool allow_multifrag_;
   QueryDescriptionType query_desc_type_;
   bool keyless_hash_;
   bool interleaved_bins_on_gpu_;


### PR DESCRIPTION
Remove unused QueryMemoryDescriptor::allow_multifrag_.

I'm starting my work on `ResultSet` refactoring. This is preparation work to make `ResultSet` and related structures independent of the `QueryEngine` library. The ultimate goal is to extract structures describing memory layout and transform `ResultSet` into a class that holds data and provides access to it (and leaving the rest like the reduction in QueryEngine). Basically, that would be kind of an analog of `arrow::Table` but covering all our possible output formats. All related code would go into the separate library which later will be used to create `ResultSetStorage` to unify access to data for the QueryEngine and make `ResultSet` a first-class citizen, enabling queries over ResultSets (would be very useful for Modin and Python API in general where we have to convert and re-import query result to continue processing).

The first part is a trivial clean-up of an unused field I noticed reading through ResultSet-related structures. I'll try to make multiple small PRs in this series rather that a single mega PR.