### PR TITLE
ResultSet refactoring and clean-up [02/N]

### DIFF
--- a/omniscidb/QueryEngine/AggregateUtils.h
+++ b/omniscidb/QueryEngine/AggregateUtils.h
@@ -17,11 +17,11 @@
 #ifndef QUERYENGINE_AGGREGATEUTILS_H
 #define QUERYENGINE_AGGREGATEUTILS_H
 
-#include "../Shared/sqltypes.h"
-#include "BufferCompaction.h"
 #include "TypePunning.h"
 
 #include "Logger/Logger.h"
+#include "Shared/BufferCompaction.h"
+#include "Shared/sqltypes.h"
 
 inline void set_component(int8_t* group_by_buffer,
                           const size_t comp_sz,

--- a/omniscidb/QueryEngine/Descriptors/ColSlotContext.cpp
+++ b/omniscidb/QueryEngine/Descriptors/ColSlotContext.cpp
@@ -24,10 +24,9 @@
 
 #include "ColSlotContext.h"
 
-#include "../BufferCompaction.h"
-
 #include <IR/Expr.h>
 #include <Shared/SqlTypesLayout.h>
+#include "Shared/BufferCompaction.h"
 
 #include <numeric>
 #include <stdexcept>

--- a/omniscidb/QueryEngine/Descriptors/CountDistinctDescriptor.h
+++ b/omniscidb/QueryEngine/Descriptors/CountDistinctDescriptor.h
@@ -26,9 +26,9 @@
 #ifndef QUERYENGINE_COUNTDISTINCTDESCRIPTOR_H
 #define QUERYENGINE_COUNTDISTINCTDESCRIPTOR_H
 
-#include "../BufferCompaction.h"
 #include "../CompilationOptions.h"
 #include "Logger/Logger.h"
+#include "Shared/BufferCompaction.h"
 
 inline size_t bitmap_bits_to_bytes(const size_t bitmap_sz) {
   size_t bitmap_byte_sz = bitmap_sz / 8;

--- a/omniscidb/QueryEngine/Execute.h
+++ b/omniscidb/QueryEngine/Execute.h
@@ -40,7 +40,6 @@
 
 #include "BufferProvider/BufferProvider.h"
 #include "QueryEngine/AggregatedColRange.h"
-#include "QueryEngine/BufferCompaction.h"
 #include "QueryEngine/CartesianProduct.h"
 #include "QueryEngine/CgenState.h"
 #include "QueryEngine/CodeCache.h"

--- a/omniscidb/QueryEngine/GpuInitGroups.cu
+++ b/omniscidb/QueryEngine/GpuInitGroups.cu
@@ -1,6 +1,7 @@
-#include "BufferCompaction.h"
 #include "GpuInitGroups.h"
 #include "GpuRtConstants.h"
+
+#include "Shared/BufferCompaction.h"
 
 template <typename T>
 __device__ int8_t* init_columnar_buffer(T* buffer_ptr,

--- a/omniscidb/QueryEngine/HyperLogLogRank.h
+++ b/omniscidb/QueryEngine/HyperLogLogRank.h
@@ -22,6 +22,8 @@
 #include <intrin.h>
 #endif
 
+#include <algorithm>
+
 #ifdef __CUDACC__
 inline __device__ int32_t get_rank(uint64_t x, uint32_t b) {
   return min(b, static_cast<uint32_t>(x ? __clzll(x) : 64)) + 1;

--- a/omniscidb/QueryEngine/OutputBufferInitialization.cpp
+++ b/omniscidb/QueryEngine/OutputBufferInitialization.cpp
@@ -15,11 +15,11 @@
  */
 
 #include "OutputBufferInitialization.h"
-#include "BufferCompaction.h"
 #include "Descriptors/QueryMemoryDescriptor.h"
 #include "TypePunning.h"
 
 #include "../Analyzer/Analyzer.h"
+#include "Shared/BufferCompaction.h"
 
 std::vector<int64_t> init_agg_val_vec(const std::vector<TargetInfo>& targets,
                                       const QueryMemoryDescriptor& query_mem_desc) {

--- a/omniscidb/QueryEngine/ResultSetBufferAccessors.h
+++ b/omniscidb/QueryEngine/ResultSetBufferAccessors.h
@@ -23,7 +23,7 @@
 #ifndef QUERYENGINE_RESULTSETBUFFERACCESSORS_H
 #define QUERYENGINE_RESULTSETBUFFERACCESSORS_H
 
-#include "BufferCompaction.h"
+#include "Shared/BufferCompaction.h"
 #include "Shared/SqlTypesLayout.h"
 #include "Shared/misc.h"
 #include "TypePunning.h"

--- a/omniscidb/QueryEngine/RowFuncBuilder.h
+++ b/omniscidb/QueryEngine/RowFuncBuilder.h
@@ -26,7 +26,6 @@
 
 #include "IR/Expr.h"
 #include "Logger/Logger.h"
-#include "QueryEngine/BufferCompaction.h"
 #include "QueryEngine/ColumnarResults.h"
 #include "QueryEngine/CompilationOptions.h"
 #include "QueryEngine/GpuMemUtils.h"

--- a/omniscidb/QueryEngine/RuntimeFunctions.cpp
+++ b/omniscidb/QueryEngine/RuntimeFunctions.cpp
@@ -19,10 +19,10 @@
 #endif  // __CUDACC__
 
 #include "RuntimeFunctions.h"
-#include "../Shared/funcannotations.h"
-#include "BufferCompaction.h"
 #include "HyperLogLogRank.h"
 #include "MurmurHash.h"
+#include "Shared/BufferCompaction.h"
+#include "Shared/funcannotations.h"
 #include "Shared/quantile.h"
 #include "TypePunning.h"
 

--- a/omniscidb/QueryEngine/cuda_mapd_rt.cu
+++ b/omniscidb/QueryEngine/cuda_mapd_rt.cu
@@ -3,10 +3,10 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <limits>
-#include "BufferCompaction.h"
 #include "ExtensionFunctions.hpp"
 #include "GpuRtConstants.h"
 #include "HyperLogLogRank.h"
+#include "Shared/BufferCompaction.h"
 #include "gen-cpp/TableFunctionsFactory_init_gpu.hpp"
 
 #if CUDA_VERSION < 10000

--- a/omniscidb/Shared/BufferCompaction.h
+++ b/omniscidb/Shared/BufferCompaction.h
@@ -26,7 +26,7 @@
 #define BUFFER_COMPACTION_H
 
 #include <cstdint>
-#include "../Shared/funcannotations.h"
+#include "funcannotations.h"
 
 #ifndef __CUDACC__
 #include <algorithm>


### PR DESCRIPTION
BufferCompaction.h header holds quite simple common functions, so move them to the Shared.
