### PR TITLE
ResultSet refactoring and clean-up [03/N]

### DIFF
--- a/omniscidb/QueryEngine/CardinalityEstimator.cpp
+++ b/omniscidb/QueryEngine/CardinalityEstimator.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "CardinalityEstimator.h"
+#include "CountDistinct.h"
 #include "ErrorHandling.h"
 #include "ExpressionRewrite.h"
 #include "RelAlgExecutor.h"

--- a/omniscidb/QueryEngine/CountDistinct.h
+++ b/omniscidb/QueryEngine/CountDistinct.h
@@ -30,9 +30,6 @@
 #include "ThirdParty/robin_hood.h"
 
 #include <bitset>
-#include <vector>
-
-using CountDistinctDescriptors = std::vector<CountDistinctDescriptor>;
 
 inline size_t bitmap_set_size(const int8_t* bitmap, const size_t bitmap_byte_sz) {
   const auto bitmap_word_count = bitmap_byte_sz >> 3;

--- a/omniscidb/QueryEngine/Descriptors/CountDistinctDescriptor.h
+++ b/omniscidb/QueryEngine/Descriptors/CountDistinctDescriptor.h
@@ -30,6 +30,8 @@
 #include "../CompilationOptions.h"
 #include "Logger/Logger.h"
 
+#include <vector>
+
 inline size_t bitmap_bits_to_bytes(const size_t bitmap_sz) {
   size_t bitmap_byte_sz = bitmap_sz / 8;
   if (bitmap_sz % 8) {
@@ -65,6 +67,8 @@ struct CountDistinctDescriptor {
     return padded_size * sub_bitmap_count;
   }
 };
+
+using CountDistinctDescriptors = std::vector<CountDistinctDescriptor>;
 
 inline bool operator==(const CountDistinctDescriptor& lhs,
                        const CountDistinctDescriptor& rhs) {

--- a/omniscidb/QueryEngine/Descriptors/QueryMemoryDescriptor.h
+++ b/omniscidb/QueryEngine/Descriptors/QueryMemoryDescriptor.h
@@ -26,8 +26,8 @@
 #define QUERYENGINE_QUERYMEMORYDESCRIPTOR_H
 
 #include "../CompilationOptions.h"
-#include "../CountDistinct.h"
 #include "ColSlotContext.h"
+#include "CountDistinctDescriptor.h"
 #include "Types.h"
 
 #include <boost/optional.hpp>

--- a/omniscidb/QueryEngine/JoinHashTable/BaselineJoinHashTable.cpp
+++ b/omniscidb/QueryEngine/JoinHashTable/BaselineJoinHashTable.cpp
@@ -23,6 +23,7 @@
 #include "QueryEngine/ColumnFetcher.h"
 #include "QueryEngine/Execute.h"
 #include "QueryEngine/ExpressionRewrite.h"
+#include "QueryEngine/HyperLogLog.h"
 #include "QueryEngine/JoinHashTable/BaselineHashTable.h"
 #include "QueryEngine/JoinHashTable/Builders/BaselineHashTableBuilder.h"
 #include "QueryEngine/JoinHashTable/PerfectJoinHashTable.h"

--- a/omniscidb/QueryEngine/MemoryLayoutBuilder.cpp
+++ b/omniscidb/QueryEngine/MemoryLayoutBuilder.cpp
@@ -19,6 +19,7 @@
 
 #include "QueryEngine/CardinalityEstimator.h"
 #include "QueryEngine/ColRangeInfo.h"
+#include "QueryEngine/HyperLogLog.h"
 #include "QueryEngine/OutputBufferInitialization.h"
 
 MemoryLayoutBuilder::MemoryLayoutBuilder(const RelAlgExecutionUnit& ra_exe_unit)

--- a/omniscidb/QueryEngine/RelAlgExecutor.cpp
+++ b/omniscidb/QueryEngine/RelAlgExecutor.cpp
@@ -25,6 +25,7 @@
 #include "QueryEngine/ExtensionFunctionsBinding.h"
 #include "QueryEngine/ExternalExecutor.h"
 #include "QueryEngine/FromTableReordering.h"
+#include "QueryEngine/HyperLogLog.h"
 #include "QueryEngine/MemoryLayoutBuilder.h"
 #include "QueryEngine/QueryPhysicalInputsCollector.h"
 #include "QueryEngine/QueryPlanDagExtractor.h"

--- a/omniscidb/QueryEngine/ResultSet.cpp
+++ b/omniscidb/QueryEngine/ResultSet.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "ResultSet.h"
+#include "CountDistinct.h"
 #include "DataMgr/Allocators/GpuAllocator.h"
 #include "DataMgr/BufferMgr/BufferMgr.h"
 #include "Execute.h"

--- a/omniscidb/QueryEngine/ResultSetIteration.cpp
+++ b/omniscidb/QueryEngine/ResultSetIteration.cpp
@@ -22,6 +22,7 @@
  * Copyright (c) 2014 MapD Technologies, Inc.  All rights reserved.
  */
 
+#include "CountDistinct.h"
 #include "Execute.h"
 #include "QueryEngine/TargetValue.h"
 #include "ResultSet.h"

--- a/omniscidb/QueryEngine/ResultSetReduction.cpp
+++ b/omniscidb/QueryEngine/ResultSetReduction.cpp
@@ -22,6 +22,7 @@
  * Copyright (c) 2014 MapD Technologies, Inc.  All rights reserved.
  */
 
+#include "CountDistinct.h"
 #include "DynamicWatchdog.h"
 #include "Execute.h"
 #include "ResultSet.h"

--- a/omniscidb/QueryEngine/ResultSetReductionJIT.cpp
+++ b/omniscidb/QueryEngine/ResultSetReductionJIT.cpp
@@ -19,6 +19,7 @@
 #include "ResultSetReductionInterpreterStubs.h"
 
 #include "CodeGenerator.h"
+#include "CountDistinct.h"
 #include "DynamicWatchdog.h"
 #include "Execute.h"
 #include "IRCodegenUtils.h"


### PR DESCRIPTION
Move `CountDistinctDescriptors` to `CountDistinctDescriptor.h` where it belongs.

This is to remove `QueryMemoryDescriptor.h` dependency on `CountDistinct.h`. The first one is about data format description and will go to the new library eventually, the second one is related to execution and should stay in the `QueryEngine`.