### PR TITLE
ResultSet refactoring and clean-up [04/N]

### DIFF
--- a/omniscidb/QueryEngine/CompilationOptions.cpp
+++ b/omniscidb/QueryEngine/CompilationOptions.cpp
@@ -17,10 +17,6 @@
 #include "QueryEngine/CompilationOptions.h"
 #include <ostream>
 
-std::string deviceToString(const ExecutorDeviceType& dt) {
-  return (dt == ExecutorDeviceType::CPU ? "CPU" : "GPU");
-}
-
 #ifndef __CUDACC__
 std::ostream& operator<<(std::ostream& os, const ExecutionOptions& eo) {
   os << "output_columnar_hint=" << eo.output_columnar_hint << "\n"

--- a/omniscidb/QueryEngine/CompilationOptions.h
+++ b/omniscidb/QueryEngine/CompilationOptions.h
@@ -21,27 +21,14 @@
 #include <ostream>
 #include <vector>
 
-#ifndef __CUDACC__
-#include <ostream>
-#endif
-
 #include "Shared/Config.h"
-
-enum class ExecutorDeviceType { CPU = 0, GPU };
-#ifndef __CUDACC__
-inline std::ostream& operator<<(std::ostream& os, ExecutorDeviceType const dt) {
-  constexpr char const* strings[]{"CPU", "GPU"};
-  return os << strings[static_cast<int>(dt)];
-}
-#endif
+#include "Shared/DeviceType.h"
 
 enum class ExecutorOptLevel { Default, ReductionJIT };
 
 enum class ExecutorExplainType { Default, Optimized };
 
 enum class ExecutorDispatchMode { KernelPerFragment, MultifragmentKernel };
-
-std::string deviceToString(const ExecutorDeviceType& dt);
 
 struct CompilationOptions {
   ExecutorDeviceType device_type;

--- a/omniscidb/QueryEngine/Descriptors/QueryMemoryDescriptor.h
+++ b/omniscidb/QueryEngine/Descriptors/QueryMemoryDescriptor.h
@@ -41,8 +41,9 @@
 #include <unordered_map>
 #include <vector>
 
-#include <Shared/SqlTypesLayout.h>
-#include <Shared/TargetInfo.h>
+#include "Shared/DeviceType.h"
+#include "Shared/SqlTypesLayout.h"
+#include "Shared/TargetInfo.h"
 
 class Executor;
 class QueryExecutionContext;

--- a/omniscidb/Shared/DeviceType.h
+++ b/omniscidb/Shared/DeviceType.h
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2022 OmniSci, Inc.
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <string>
+
+#ifndef __CUDACC__
+#include <ostream>
+#endif
+
+enum class ExecutorDeviceType { CPU = 0, GPU };
+
+#ifndef __CUDACC__
+inline std::ostream& operator<<(std::ostream& os, ExecutorDeviceType dt) {
+  constexpr char const* strings[]{"CPU", "GPU"};
+  return os << strings[static_cast<int>(dt)];
+}
+#endif
+
+inline std::string deviceToString(ExecutorDeviceType dt) {
+  return (dt == ExecutorDeviceType::CPU ? "CPU" : "GPU");
+}


### PR DESCRIPTION
`ExecutorDeviceType` is a very common enum actually, so move to the Shared lib.

How about renaming it to simply `DeviceType`?
