### PR TITLE
ResultSet refactoring and clean-up [05/N]

### DIFF
--- a/omniscidb/QueryEngine/Descriptors/RowSetMemoryOwner.h
+++ b/omniscidb/QueryEngine/Descriptors/RowSetMemoryOwner.h
@@ -29,7 +29,6 @@
 #include "DataMgr/DataMgr.h"
 #include "DataProvider/DataProvider.h"
 #include "Logger/Logger.h"
-#include "QueryEngine/StringDictionaryGenerations.h"
 #include "Shared/quantile.h"
 #include "StringDictionary/StringDictionaryProxy.h"
 #include "ThirdParty/robin_hood.h"
@@ -174,7 +173,7 @@ class RowSetMemoryOwner final : public SimpleAllocator, boost::noncopyable {
   }
 
   StringDictionaryProxy* getOrAddStringDictProxy(const int dict_id_in,
-                                                 const bool with_generation);
+                                                 const int64_t generation = -1);
 
   void addLiteralStringDictProxy(
       std::shared_ptr<StringDictionaryProxy> lit_str_dict_proxy) {
@@ -189,8 +188,9 @@ class RowSetMemoryOwner final : public SimpleAllocator, boost::noncopyable {
 
   const StringDictionaryProxy::IdMap* getOrAddStringProxyTranslationMap(
       const int source_dict_id_in,
+      const int64_t source_generation,
       const int dest_dict_id_in,
-      const bool with_generation,
+      const int64_t dest_generation,
       const StringTranslationType translation_map_type);
 
   void addColBuffer(const void* col_buffer) {
@@ -225,14 +225,6 @@ class RowSetMemoryOwner final : public SimpleAllocator, boost::noncopyable {
     return rtn;
   }
 
-  void setDictionaryGenerations(StringDictionaryGenerations generations) {
-    string_dictionary_generations_ = generations;
-  }
-
-  StringDictionaryGenerations& getStringDictionaryGenerations() {
-    return string_dictionary_generations_;
-  }
-
   quantile::TDigest* nullTDigest(double const q);
 
  private:
@@ -254,7 +246,6 @@ class RowSetMemoryOwner final : public SimpleAllocator, boost::noncopyable {
   std::map<std::pair<int, int>, StringDictionaryProxy::IdMap>
       str_proxy_union_translation_maps_owned_;
   std::shared_ptr<StringDictionaryProxy> lit_str_dict_proxy_;
-  StringDictionaryGenerations string_dictionary_generations_;
   std::vector<void*> col_buffers_;
   std::vector<Data_Namespace::AbstractBuffer*> varlen_input_buffers_;
   std::vector<std::unique_ptr<quantile::TDigest>> t_digests_;

--- a/omniscidb/QueryEngine/Execute.h
+++ b/omniscidb/QueryEngine/Execute.h
@@ -977,6 +977,7 @@ class Executor {
 
   std::unique_ptr<PlanState> plan_state_;
   std::shared_ptr<RowSetMemoryOwner> row_set_mem_owner_;
+  StringDictionaryGenerations string_dictionary_generations_;
 
   static const int max_gpu_count{16};
   std::mutex gpu_exec_mutex_[max_gpu_count];

--- a/omniscidb/QueryEngine/RelAlgExecutor.cpp
+++ b/omniscidb/QueryEngine/RelAlgExecutor.cpp
@@ -623,7 +623,7 @@ void RelAlgExecutor::prepareLeafExecution(
   queue_time_ms_ = timer_stop(clock_begin);
   executor_->row_set_mem_owner_ = std::make_shared<RowSetMemoryOwner>(
       data_provider_, Executor::getArenaBlockSize(), cpu_threads());
-  executor_->row_set_mem_owner_->setDictionaryGenerations(string_dictionary_generations);
+  executor_->string_dictionary_generations_ = string_dictionary_generations;
   executor_->table_generations_ = table_generations;
   executor_->agg_col_range_cache_ = agg_col_range;
 }

--- a/omniscidb/QueryEngine/ResultSet.cpp
+++ b/omniscidb/QueryEngine/ResultSet.cpp
@@ -417,8 +417,7 @@ const hdk::ir::Type* ResultSet::colType(const size_t col_idx) const {
 }
 
 StringDictionaryProxy* ResultSet::getStringDictionaryProxy(int const dict_id) const {
-  constexpr bool with_generation = true;
-  return row_set_mem_owner_->getOrAddStringDictProxy(dict_id, with_generation);
+  return row_set_mem_owner_->getOrAddStringDictProxy(dict_id);
 }
 
 class ResultSet::CellCallback {
@@ -1412,8 +1411,7 @@ size_t ResultSet::getLimit() const {
 
 const std::vector<std::string> ResultSet::getStringDictionaryPayloadCopy(
     const int dict_id) const {
-  const auto sdp =
-      row_set_mem_owner_->getOrAddStringDictProxy(dict_id, /*with_generation=*/true);
+  const auto sdp = row_set_mem_owner_->getOrAddStringDictProxy(dict_id);
   CHECK(sdp);
   return sdp->getDictionary()->copyStrings();
 }
@@ -1447,8 +1445,7 @@ ResultSet::getUniqueStringsForDictEncodedTargetCol(const size_t col_idx) const {
   }
 
   const int32_t dict_id = col_type->as<hdk::ir::ExtDictionaryType>()->dictId();
-  const auto sdp = row_set_mem_owner_->getOrAddStringDictProxy(dict_id,
-                                                               /*with_generation=*/true);
+  const auto sdp = row_set_mem_owner_->getOrAddStringDictProxy(dict_id);
   CHECK(sdp);
 
   return std::make_pair(unique_string_ids, sdp->getStrings(unique_string_ids));

--- a/omniscidb/QueryEngine/ResultSetIteration.cpp
+++ b/omniscidb/QueryEngine/ResultSetIteration.cpp
@@ -807,9 +807,7 @@ TargetValue build_string_array_target_value(
           values.emplace_back(sdp->getString(string_id));
         } else {
           values.emplace_back(NullableString(
-              row_set_mem_owner
-                  ->getOrAddStringDictProxy(dict_id, /*with_generation=*/false)
-                  ->getString(string_id)));
+              row_set_mem_owner->getOrAddStringDictProxy(dict_id)->getString(string_id)));
         }
       }
     }
@@ -1339,11 +1337,9 @@ TargetValue ResultSet::makeTargetValue(const int8_t* ptr,
       if (!dict_id) {
         sdp = row_set_mem_owner_->getLiteralStringDictProxy();
       } else {
-        sdp = data_mgr_
-                  ? row_set_mem_owner_->getOrAddStringDictProxy(dict_id,
-                                                                /*with_generation=*/false)
-                  : row_set_mem_owner_->getStringDictProxy(
-                        dict_id);  // unit tests bypass the catalog
+        sdp = data_mgr_ ? row_set_mem_owner_->getOrAddStringDictProxy(dict_id)
+                        : row_set_mem_owner_->getStringDictProxy(
+                              dict_id);  // unit tests bypass the DataMgr
       }
       return NullableString(sdp->getString(ival));
     } else {


### PR DESCRIPTION
Move dictionary generations from `RowSetMemoryOwner` to `Executor`. This is because these generations are part of a query state and are not used afterward, so no reason for `ResultSet` to depend on this structure.
