### PR TITLE
ResultSet refactoring and clean-up [07/N]

### DIFF
--- a/omniscidb/QueryEngine/Descriptors/RelAlgExecutionDescriptor.h
+++ b/omniscidb/QueryEngine/Descriptors/RelAlgExecutionDescriptor.h
@@ -120,7 +120,6 @@ class RaExecutionDesc {
                                             QueryMemoryDescriptor(),
                                             nullptr,
                                             nullptr,
-                                            nullptr,
                                             0,
                                             0),
                 {}) {}

--- a/omniscidb/QueryEngine/Execute.cpp
+++ b/omniscidb/QueryEngine/Execute.cpp
@@ -145,7 +145,6 @@ void Executor::resetCodeCache() {
 
 Executor::Executor(const ExecutorId executor_id,
                    Data_Namespace::DataMgr* data_mgr,
-                   BufferProvider* buffer_provider,
                    ConfigPtr config,
                    const std::string& debug_dir,
                    const std::string& debug_file)
@@ -157,7 +156,6 @@ Executor::Executor(const ExecutorId executor_id,
     , debug_dir_(debug_dir)
     , debug_file_(debug_file)
     , data_mgr_(data_mgr)
-    , buffer_provider_(buffer_provider)
     , temporary_tables_(nullptr)
     , input_table_info_cache_(this)
     , thread_id_(logger::thread_id()) {
@@ -386,7 +384,6 @@ Executor::CgenStateManager::~CgenStateManager() {
 }
 
 std::shared_ptr<Executor> Executor::getExecutor(Data_Namespace::DataMgr* data_mgr,
-                                                BufferProvider* buffer_provider,
                                                 ConfigPtr config,
                                                 const std::string& debug_dir,
                                                 const std::string& debug_file) {
@@ -397,7 +394,7 @@ std::shared_ptr<Executor> Executor::getExecutor(Data_Namespace::DataMgr* data_mg
   }
 
   return std::make_shared<Executor>(
-      executor_id_ctr_++, data_mgr, buffer_provider, config, debug_dir, debug_file);
+      executor_id_ctr_++, data_mgr, config, debug_dir, debug_file);
 }
 
 void Executor::clearMemory(const Data_Namespace::MemoryLevel memory_level,
@@ -1119,7 +1116,6 @@ TemporaryTable Executor::resultsUnion(SharedKernelContext& shared_context,
                                        QueryMemoryDescriptor(),
                                        row_set_mem_owner_,
                                        data_mgr_,
-                                       buffer_provider_,
                                        blockSize(),
                                        gridSize());
   }
@@ -1167,7 +1163,6 @@ ResultSetPtr Executor::reduceMultiDeviceResults(
                                        QueryMemoryDescriptor(),
                                        nullptr,
                                        data_mgr_,
-                                       buffer_provider_,
                                        blockSize(),
                                        gridSize());
   }
@@ -1240,7 +1235,6 @@ ResultSetPtr Executor::reduceMultiDeviceResultSets(
                                                   query_mem_desc,
                                                   row_set_mem_owner,
                                                   data_mgr_,
-                                                  buffer_provider_,
                                                   blockSize(),
                                                   gridSize());
     auto result_storage = reduced_results->allocateStorage(plan_state_->init_agg_vals_);
@@ -2003,7 +1997,6 @@ TemporaryTable Executor::executeWorkUnitImpl(
                                      QueryMemoryDescriptor(),
                                      nullptr,
                                      data_mgr_,
-                                     buffer_provider_,
                                      blockSize(),
                                      gridSize());
 }
@@ -2108,7 +2101,6 @@ ResultSetPtr Executor::executeTableFunction(
         ResultSet::fixupQueryMemoryDescriptor(query_mem_desc),
         this->getRowSetMemoryOwner(),
         data_mgr_,
-        buffer_provider_,
         this->blockSize(),
         this->gridSize());
   }
@@ -2305,7 +2297,6 @@ ResultSetPtr build_row_for_empty_input(
                                         query_mem_desc,
                                         row_set_mem_owner,
                                         executor->getDataMgr(),
-                                        executor->getBufferProvider(),
                                         executor->blockSize(),
                                         executor->gridSize());
   rs->allocateStorage();

--- a/omniscidb/QueryEngine/Execute.h
+++ b/omniscidb/QueryEngine/Execute.h
@@ -256,7 +256,6 @@ class Executor {
   // executors map is populated
   Executor(const ExecutorId id,
            Data_Namespace::DataMgr* data_mgr,
-           BufferProvider* buffer_provider,
            ConfigPtr config,
            const std::string& debug_dir,
            const std::string& debug_file);
@@ -266,7 +265,6 @@ class Executor {
   void reset(const bool discard_runtime_modules_only = false);
 
   static std::shared_ptr<Executor> getExecutor(Data_Namespace::DataMgr* data_mgr,
-                                               BufferProvider* buffer_provider,
                                                ConfigPtr config = nullptr,
                                                const std::string& debug_dir = "",
                                                const std::string& debug_file = "");
@@ -353,8 +351,8 @@ class Executor {
   }
 
   BufferProvider* getBufferProvider() const {
-    CHECK(buffer_provider_);
-    return buffer_provider_;
+    CHECK(data_mgr_);
+    return data_mgr_->getBufferProvider();
   }
 
   const Config& getConfig() const { return *config_; }
@@ -1002,7 +1000,6 @@ class Executor {
 
   SchemaProviderPtr schema_provider_;
   Data_Namespace::DataMgr* data_mgr_;
-  BufferProvider* buffer_provider_;
   const TemporaryTables* temporary_tables_;
   TableIdToNodeMap table_id_to_node_map_;
 

--- a/omniscidb/QueryEngine/ExternalExecutor.cpp
+++ b/omniscidb/QueryEngine/ExternalExecutor.cpp
@@ -439,7 +439,6 @@ std::unique_ptr<ResultSet> SqliteMemDatabase::runSelect(
                                         query_mem_desc,
                                         output_spec.executor->getRowSetMemoryOwner(),
                                         nullptr,
-                                        nullptr,
                                         0,
                                         0);
   const auto storage = rs->allocateStorage();

--- a/omniscidb/QueryEngine/QueryExecutionContext.cpp
+++ b/omniscidb/QueryEngine/QueryExecutionContext.cpp
@@ -93,7 +93,6 @@ ResultSetPtr QueryExecutionContext::groupBufferToDeinterleavedResults(
                                   deinterleaved_query_mem_desc,
                                   row_set_mem_owner_,
                                   executor_->getDataMgr(),
-                                  executor_->getBufferProvider(),
                                   executor_->blockSize(),
                                   executor_->gridSize());
   auto deinterleaved_storage =
@@ -414,11 +413,8 @@ std::vector<int64_t*> QueryExecutionContext::launchGpuCode(
         shared_memory_size ? 1 : block_size_x * grid_size_x * num_fragments;
     const auto output_buffer_size_per_agg = num_results_per_agg_col * sizeof(int64_t);
     if (ra_exe_unit.estimator) {
-      estimator_result_set_.reset(new ResultSet(ra_exe_unit.estimator,
-                                                ExecutorDeviceType::GPU,
-                                                device_id,
-                                                data_mgr,
-                                                buffer_provider));
+      estimator_result_set_.reset(new ResultSet(
+          ra_exe_unit.estimator, ExecutorDeviceType::GPU, device_id, data_mgr));
       out_vec_dev_buffers.push_back(
           reinterpret_cast<int8_t*>(estimator_result_set_->getDeviceEstimatorBuffer()));
     } else {
@@ -564,8 +560,8 @@ std::vector<int64_t*> QueryExecutionContext::launchCpuCode(
     // Subfragments collect the result from multiple runs in a single
     // result set.
     if (!estimator_result_set_) {
-      estimator_result_set_.reset(new ResultSet(
-          ra_exe_unit.estimator, ExecutorDeviceType::CPU, 0, nullptr, nullptr));
+      estimator_result_set_.reset(
+          new ResultSet(ra_exe_unit.estimator, ExecutorDeviceType::CPU, 0, nullptr));
     }
     out_vec.push_back(
         reinterpret_cast<int64_t*>(estimator_result_set_->getHostEstimatorBuffer()));

--- a/omniscidb/QueryEngine/QueryMemoryInitializer.cpp
+++ b/omniscidb/QueryEngine/QueryMemoryInitializer.cpp
@@ -396,7 +396,6 @@ QueryMemoryInitializer::QueryMemoryInitializer(
         ResultSet::fixupQueryMemoryDescriptor(query_mem_desc),
         row_set_mem_owner_,
         executor->getDataMgr(),
-        executor->getBufferProvider(),
         executor->blockSize(),
         executor->gridSize()));
     result_sets_.back()->allocateStorage(reinterpret_cast<int8_t*>(group_by_buffer),
@@ -491,7 +490,6 @@ QueryMemoryInitializer::QueryMemoryInitializer(
       ResultSet::fixupQueryMemoryDescriptor(query_mem_desc),
       row_set_mem_owner_,
       executor->getDataMgr(),
-      executor->getBufferProvider(),
       executor->blockSize(),
       executor->gridSize()));
   result_sets_.back()->allocateStorage(reinterpret_cast<int8_t*>(group_by_buffer),

--- a/omniscidb/QueryEngine/RelAlgExecutor.cpp
+++ b/omniscidb/QueryEngine/RelAlgExecutor.cpp
@@ -1649,7 +1649,6 @@ ExecutionResult RelAlgExecutor::executeTableFunction(
                                                      QueryMemoryDescriptor(),
                                                      nullptr,
                                                      executor_->getDataMgr(),
-                                                     executor_->getBufferProvider(),
                                                      executor_->blockSize(),
                                                      executor_->gridSize()),
                          {}};
@@ -2285,7 +2284,6 @@ ExecutionResult RelAlgExecutor::executeWorkUnit(
                                                      QueryMemoryDescriptor(),
                                                      nullptr,
                                                      executor_->getDataMgr(),
-                                                     executor_->getBufferProvider(),
                                                      executor_->blockSize(),
                                                      executor_->gridSize()),
                          {}};
@@ -2453,16 +2451,14 @@ ExecutionResult RelAlgExecutor::handleOutOfMemoryRetry(
   auto ra_exe_unit_in = work_unit.exe_unit;
   ra_exe_unit_in.use_bump_allocator = false;
 
-  auto result =
-      ExecutionResult{std::make_shared<ResultSet>(std::vector<TargetInfo>{},
-                                                  co.device_type,
-                                                  QueryMemoryDescriptor(),
-                                                  nullptr,
-                                                  executor_->getDataMgr(),
-                                                  executor_->getBufferProvider(),
-                                                  executor_->blockSize(),
-                                                  executor_->gridSize()),
-                      {}};
+  auto result = ExecutionResult{std::make_shared<ResultSet>(std::vector<TargetInfo>{},
+                                                            co.device_type,
+                                                            QueryMemoryDescriptor(),
+                                                            nullptr,
+                                                            executor_->getDataMgr(),
+                                                            executor_->blockSize(),
+                                                            executor_->gridSize()),
+                                {}};
 
   const auto table_infos = get_table_infos(ra_exe_unit_in, executor_);
   auto max_groups_buffer_entry_guess = work_unit.max_groups_buffer_entry_guess;

--- a/omniscidb/QueryEngine/ResultSet.h
+++ b/omniscidb/QueryEngine/ResultSet.h
@@ -168,7 +168,6 @@ class ResultSet {
             const QueryMemoryDescriptor& query_mem_desc,
             const std::shared_ptr<RowSetMemoryOwner> row_set_mem_owner,
             Data_Namespace::DataMgr* data_mgr,
-            BufferProvider* buffer_provider,
             const unsigned block_size,
             const unsigned grid_size);
 
@@ -182,15 +181,13 @@ class ResultSet {
             const QueryMemoryDescriptor& query_mem_desc,
             const std::shared_ptr<RowSetMemoryOwner> row_set_mem_owner,
             Data_Namespace::DataMgr* data_mgr,
-            BufferProvider* buffer_provider,
             const unsigned block_size,
             const unsigned grid_size);
 
   ResultSet(const std::shared_ptr<const Analyzer::Estimator>,
             const ExecutorDeviceType device_type,
             const int device_id,
-            Data_Namespace::DataMgr* data_mgr,
-            BufferProvider* buffer_provider);
+            Data_Namespace::DataMgr* data_mgr);
 
   ResultSet(const std::string& explanation);
 
@@ -803,6 +800,7 @@ class ResultSet {
   size_t rowCountImpl(const bool force_parallel) const;
 
   Data_Namespace::DataMgr* getDataManager() const;
+  BufferProvider* getBufferProvider() const;
 
   int getGpuCount() const;
 
@@ -855,7 +853,6 @@ class ResultSet {
   Data_Namespace::AbstractBuffer* device_estimator_buffer_{nullptr};
   mutable int8_t* host_estimator_buffer_{nullptr};
   Data_Namespace::DataMgr* data_mgr_{nullptr};
-  BufferProvider* buffer_provider_{nullptr};
 
   // only used by serialization
   using SerializedVarlenBufferStorage = std::vector<std::string>;

--- a/omniscidb/QueryEngine/ResultSetBuilder.cpp
+++ b/omniscidb/QueryEngine/ResultSetBuilder.cpp
@@ -36,7 +36,6 @@ ResultSet* ResultSetBuilder::makeResultSet(
                        query_mem_desc,
                        row_set_mem_owner,
                        executor ? executor->getDataMgr() : nullptr,
-                       executor ? executor->getBufferProvider() : nullptr,
                        executor ? executor->blockSize() : 0,
                        executor ? executor->gridSize() : 0);
 }

--- a/omniscidb/QueryEngine/ResultSetIteration.cpp
+++ b/omniscidb/QueryEngine/ResultSetIteration.cpp
@@ -632,7 +632,7 @@ InternalTargetValue ResultSet::getVarlenOrderEntry(const int64_t str_ptr,
     cpu_buffer.resize(str_len);
     const auto executor = query_mem_desc_.getExecutor();
     CHECK(executor);
-    buffer_provider_->copyFromDevice(
+    getBufferProvider()->copyFromDevice(
         &cpu_buffer[0], reinterpret_cast<const int8_t*>(str_ptr), str_len, device_id_);
     host_str_ptr = reinterpret_cast<char*>(&cpu_buffer[0]);
   } else {

--- a/omniscidb/QueryEngine/ResultSetReduction.cpp
+++ b/omniscidb/QueryEngine/ResultSetReduction.cpp
@@ -1038,7 +1038,6 @@ ResultSet* ResultSetManager::reduce(std::vector<ResultSet*>& result_sets,
                             query_mem_desc,
                             row_set_mem_owner,
                             result_rs->data_mgr_,
-                            result_rs->buffer_provider_,
                             0,
                             0));
     auto result_storage = rs_->allocateStorage(first_result.target_init_vals_);

--- a/omniscidb/QueryEngine/ResultSetSort.cpp
+++ b/omniscidb/QueryEngine/ResultSetSort.cpp
@@ -107,25 +107,25 @@ void ResultSet::doBaselineSort(const ExecutorDeviceType device_type,
             if (device_type == ExecutorDeviceType::GPU) {
               set_cuda_context(data_mgr, start);
             }
-            strided_permutations[start] = (key_bytewidth == 4)
-                                              ? baseline_sort<int32_t>(device_type,
-                                                                       start,
-                                                                       buffer_provider_,
-                                                                       groupby_buffer,
-                                                                       pod_oe,
-                                                                       layout,
-                                                                       top_n,
-                                                                       start,
-                                                                       step)
-                                              : baseline_sort<int64_t>(device_type,
-                                                                       start,
-                                                                       buffer_provider_,
-                                                                       groupby_buffer,
-                                                                       pod_oe,
-                                                                       layout,
-                                                                       top_n,
-                                                                       start,
-                                                                       step);
+            strided_permutations[start] =
+                (key_bytewidth == 4) ? baseline_sort<int32_t>(device_type,
+                                                              start,
+                                                              getBufferProvider(),
+                                                              groupby_buffer,
+                                                              pod_oe,
+                                                              layout,
+                                                              top_n,
+                                                              start,
+                                                              step)
+                                     : baseline_sort<int64_t>(device_type,
+                                                              start,
+                                                              getBufferProvider(),
+                                                              groupby_buffer,
+                                                              pod_oe,
+                                                              layout,
+                                                              top_n,
+                                                              start,
+                                                              step);
           }));
     }
     for (auto& top_future : top_futures) {
@@ -150,7 +150,7 @@ void ResultSet::doBaselineSort(const ExecutorDeviceType device_type,
   } else {
     permutation_ = (key_bytewidth == 4) ? baseline_sort<int32_t>(device_type,
                                                                  0,
-                                                                 buffer_provider_,
+                                                                 getBufferProvider(),
                                                                  groupby_buffer,
                                                                  pod_oe,
                                                                  layout,
@@ -159,7 +159,7 @@ void ResultSet::doBaselineSort(const ExecutorDeviceType device_type,
                                                                  1)
                                         : baseline_sort<int64_t>(device_type,
                                                                  0,
-                                                                 buffer_provider_,
+                                                                 getBufferProvider(),
                                                                  groupby_buffer,
                                                                  pod_oe,
                                                                  layout,

--- a/omniscidb/QueryEngine/SpeculativeTopN.cpp
+++ b/omniscidb/QueryEngine/SpeculativeTopN.cpp
@@ -135,7 +135,6 @@ std::shared_ptr<ResultSet> SpeculativeTopNMap::asRows(
       query_mem_desc_rs,
       row_set_mem_owner,
       executor->getDataMgr(),
-      executor->getBufferProvider(),
       executor->blockSize(),
       executor->gridSize());
   auto rs_storage = rs->allocateStorage();

--- a/omniscidb/Tests/ArrowSQLRunner/ArrowSQLRunner.cpp
+++ b/omniscidb/Tests/ArrowSQLRunner/ArrowSQLRunner.cpp
@@ -331,8 +331,7 @@ class ArrowSQLRunnerImpl {
     auto* ps_mgr = data_mgr_->getPersistentStorageMgr();
     ps_mgr->registerDataProvider(TEST_SCHEMA_ID, storage_);
 
-    executor_ = Executor::getExecutor(
-        data_mgr_.get(), data_mgr_->getBufferProvider(), config_, "", "");
+    executor_ = Executor::getExecutor(data_mgr_.get(), config_, "", "");
     executor_->setSchemaProvider(storage_);
 
     table_functions::TableFunctionsFactory::init();

--- a/omniscidb/Tests/CachedHashTableTest.cpp
+++ b/omniscidb/Tests/CachedHashTableTest.cpp
@@ -111,7 +111,7 @@ struct QueryPlanDagInfo {
 
 QueryPlanDagInfo getQueryInfoForDataRecyclerTest(const std::string& query_str) {
   const auto query_ra = getSqlQueryRelAlg(query_str);
-  auto executor = Executor::getExecutor(getDataMgr(), getDataMgr()->getBufferProvider());
+  auto executor = Executor::getExecutor(getDataMgr());
   executor->setSchemaProvider(getStorage());
   auto dag = std::make_unique<RelAlgDagBuilder>(
       query_ra, TEST_DB_ID, getStorage(), executor->getConfigPtr());
@@ -129,7 +129,7 @@ QueryPlanDagInfo getQueryInfoForDataRecyclerTest(const std::string& query_str) {
 ExtractedPlanDag extractQueryPlanDag(const std::string& query_str) {
   auto query_dag_info = getQueryInfoForDataRecyclerTest(query_str);
   auto data_mgr = getDataMgr();
-  auto executor = Executor::getExecutor(data_mgr, data_mgr->getBufferProvider()).get();
+  auto executor = Executor::getExecutor(data_mgr).get();
   auto extracted_dag_info =
       QueryPlanDagExtractor::extractQueryPlanDag(query_dag_info.root_node.get(),
                                                  executor->getSchemaProvider(),

--- a/omniscidb/Tests/ColumnarResultsTest.cpp
+++ b/omniscidb/Tests/ColumnarResultsTest.cpp
@@ -85,7 +85,6 @@ void test_columnar_conversion(const std::vector<TargetInfo>& target_infos,
                        query_mem_desc,
                        row_set_mem_owner,
                        nullptr,
-                       nullptr,
                        0,
                        0);
 
@@ -196,7 +195,6 @@ TEST(Construct, Empty) {
                        ExecutorDeviceType::CPU,
                        query_mem_desc,
                        row_set_mem_owner,
-                       nullptr,
                        nullptr,
                        0,
                        0);

--- a/omniscidb/Tests/DataRecyclerTest.cpp
+++ b/omniscidb/Tests/DataRecyclerTest.cpp
@@ -1077,7 +1077,7 @@ TEST(DataRecycler, Hashtable_For_Dict_Encoded_Column) {
   createTable("TT1", {{"c1", ctx().extDict(ctx().text(), 0)}, {"id1", ctx().int32()}});
   createTable("TT2", {{"c2", ctx().extDict(ctx().text(), 0)}, {"id2", ctx().int32()}});
   auto data_mgr = getDataMgr();
-  auto executor = Executor::getExecutor(data_mgr, data_mgr->getBufferProvider()).get();
+  auto executor = Executor::getExecutor(data_mgr).get();
   auto clear_caches = [&executor, data_mgr](ExecutorDeviceType dt) {
     auto memory_level =
         dt == ExecutorDeviceType::CPU ? MemoryLevel::CPU_LEVEL : MemoryLevel::GPU_LEVEL;

--- a/omniscidb/Tests/GpuSharedMemoryTest.cpp
+++ b/omniscidb/Tests/GpuSharedMemoryTest.cpp
@@ -217,7 +217,6 @@ std::vector<std::unique_ptr<ResultSet>> create_and_fill_input_result_sets(
                                                       query_mem_desc,
                                                       row_set_mem_owner,
                                                       nullptr,
-                                                      nullptr,
                                                       0,
                                                       0));
     const auto storage = result_sets.back()->allocateStorage();
@@ -240,7 +239,6 @@ create_and_init_output_result_sets(std::shared_ptr<RowSetMemoryOwner> row_set_me
                                                     query_mem_desc,
                                                     row_set_mem_owner,
                                                     nullptr,
-                                                    nullptr,
                                                     0,
                                                     0);
   auto cpu_storage_result = cpu_result_set->allocateStorage();
@@ -252,7 +250,6 @@ create_and_init_output_result_sets(std::shared_ptr<RowSetMemoryOwner> row_set_me
                                                     ExecutorDeviceType::GPU,
                                                     query_mem_desc,
                                                     row_set_mem_owner,
-                                                    nullptr,
                                                     nullptr,
                                                     0,
                                                     0);
@@ -266,7 +263,7 @@ void perform_reduction_on_cpu(std::vector<std::unique_ptr<ResultSet>>& result_se
   CHECK(result_sets.size() > 0);
   Config config;
   // for codegen only
-  auto executor = Executor::getExecutor(nullptr, nullptr);
+  auto executor = Executor::getExecutor(nullptr);
   ResultSetReductionJIT reduction_jit(result_sets.front()->getQueryMemDesc(),
                                       result_sets.front()->getTargetInfos(),
                                       result_sets.front()->getTargetInitVals(),

--- a/omniscidb/Tests/GroupByTest.cpp
+++ b/omniscidb/Tests/GroupByTest.cpp
@@ -58,7 +58,7 @@ class HighCardinalityStringEnv : public ::testing::Test {
 
 TEST_F(HighCardinalityStringEnv, PerfectHashNoFallback) {
   // make our own executor with a custom col ranges cache
-  auto executor = Executor::getExecutor(getDataMgr(), getDataMgr()->getBufferProvider());
+  auto executor = Executor::getExecutor(getDataMgr());
   auto storage = getStorage();
   executor->setSchemaProvider(storage);
 
@@ -151,7 +151,7 @@ std::unordered_set<InputColDescriptor> setup_str_col_caching(
 
 TEST_F(HighCardinalityStringEnv, BaselineFallbackTest) {
   // make our own executor with a custom col ranges cache
-  auto executor = Executor::getExecutor(getDataMgr(), getDataMgr()->getBufferProvider());
+  auto executor = Executor::getExecutor(getDataMgr());
   auto storage = getStorage();
   executor->setSchemaProvider(storage);
 
@@ -236,7 +236,7 @@ TEST_F(HighCardinalityStringEnv, BaselineFallbackTest) {
 
 TEST_F(HighCardinalityStringEnv, BaselineNoFilters) {
   // make our own executor with a custom col ranges cache
-  auto executor = Executor::getExecutor(getDataMgr(), getDataMgr()->getBufferProvider());
+  auto executor = Executor::getExecutor(getDataMgr());
   auto storage = getStorage();
   executor->setSchemaProvider(storage);
 

--- a/omniscidb/Tests/JoinHashTableTest.cpp
+++ b/omniscidb/Tests/JoinHashTableTest.cpp
@@ -122,7 +122,7 @@ std::shared_ptr<HashJoin> buildKeyed(std::shared_ptr<const hdk::ir::BinOper> op,
 
 std::pair<std::string, std::shared_ptr<HashJoin>> checkProperQualDetection(
     std::vector<std::shared_ptr<const hdk::ir::BinOper>> quals) {
-  auto executor = Executor::getExecutor(getDataMgr(), getDataMgr()->getBufferProvider());
+  auto executor = Executor::getExecutor(getDataMgr());
   CHECK(executor);
   auto storage = getStorage();
   executor->setSchemaProvider(storage);
@@ -145,7 +145,7 @@ std::pair<std::string, std::shared_ptr<HashJoin>> checkProperQualDetection(
 }
 
 TEST(Build, PerfectOneToOne1) {
-  auto executor = Executor::getExecutor(getDataMgr(), getDataMgr()->getBufferProvider());
+  auto executor = Executor::getExecutor(getDataMgr());
 
   for (auto dt : {ExecutorDeviceType::CPU, ExecutorDeviceType::GPU}) {
     SKIP_NO_GPU();
@@ -184,7 +184,7 @@ TEST(Build, PerfectOneToOne1) {
 }
 
 TEST(Build, PerfectOneToOne2) {
-  auto executor = Executor::getExecutor(getDataMgr(), getDataMgr()->getBufferProvider());
+  auto executor = Executor::getExecutor(getDataMgr());
 
   for (auto dt : {ExecutorDeviceType::CPU, ExecutorDeviceType::GPU}) {
     SKIP_NO_GPU();
@@ -221,7 +221,7 @@ TEST(Build, PerfectOneToOne2) {
 }
 
 TEST(Build, PerfectOneToMany1) {
-  auto executor = Executor::getExecutor(getDataMgr(), getDataMgr()->getBufferProvider());
+  auto executor = Executor::getExecutor(getDataMgr());
 
   for (auto dt : {ExecutorDeviceType::CPU, ExecutorDeviceType::GPU}) {
     SKIP_NO_GPU();
@@ -253,7 +253,7 @@ TEST(Build, PerfectOneToMany1) {
 }
 
 TEST(Build, PerfectOneToMany2) {
-  auto executor = Executor::getExecutor(getDataMgr(), getDataMgr()->getBufferProvider());
+  auto executor = Executor::getExecutor(getDataMgr());
 
   for (auto dt : {ExecutorDeviceType::CPU, ExecutorDeviceType::GPU}) {
     SKIP_NO_GPU();
@@ -285,7 +285,7 @@ TEST(Build, PerfectOneToMany2) {
 }
 
 TEST(Build, detectProperJoinQual) {
-  auto executor = Executor::getExecutor(getDataMgr(), getDataMgr()->getBufferProvider());
+  auto executor = Executor::getExecutor(getDataMgr());
   CHECK(executor);
   auto storage = getStorage();
   executor->setSchemaProvider(storage);
@@ -372,7 +372,7 @@ TEST(Build, detectProperJoinQual) {
 }
 
 TEST(Build, KeyedOneToOne) {
-  auto executor = Executor::getExecutor(getDataMgr(), getDataMgr()->getBufferProvider());
+  auto executor = Executor::getExecutor(getDataMgr());
   CHECK(executor);
   auto storage = getStorage();
   executor->setSchemaProvider(storage);
@@ -417,7 +417,7 @@ TEST(Build, KeyedOneToOne) {
 }
 
 TEST(Build, KeyedOneToMany) {
-  auto executor = Executor::getExecutor(getDataMgr(), getDataMgr()->getBufferProvider());
+  auto executor = Executor::getExecutor(getDataMgr());
   CHECK(executor);
   auto storage = getStorage();
   executor->setSchemaProvider(storage);
@@ -463,7 +463,7 @@ TEST(Build, KeyedOneToMany) {
 }
 
 TEST(MultiFragment, PerfectOneToOne) {
-  auto executor = Executor::getExecutor(getDataMgr(), getDataMgr()->getBufferProvider());
+  auto executor = Executor::getExecutor(getDataMgr());
 
   for (auto dt : {ExecutorDeviceType::CPU, ExecutorDeviceType::GPU}) {
     SKIP_NO_GPU();
@@ -502,7 +502,7 @@ TEST(MultiFragment, PerfectOneToOne) {
 }
 
 TEST(MultiFragment, PerfectOneToMany) {
-  auto executor = Executor::getExecutor(getDataMgr(), getDataMgr()->getBufferProvider());
+  auto executor = Executor::getExecutor(getDataMgr());
 
   for (auto dt : {ExecutorDeviceType::CPU, ExecutorDeviceType::GPU}) {
     SKIP_NO_GPU();
@@ -542,7 +542,7 @@ TEST(MultiFragment, PerfectOneToMany) {
 }
 
 TEST(MultiFragment, KeyedOneToOne) {
-  auto executor = Executor::getExecutor(getDataMgr(), getDataMgr()->getBufferProvider());
+  auto executor = Executor::getExecutor(getDataMgr());
   CHECK(executor);
   auto storage = getStorage();
   executor->setSchemaProvider(storage);
@@ -608,7 +608,7 @@ TEST(MultiFragment, KeyedOneToOne) {
 }
 
 TEST(MultiFragment, KeyedOneToMany) {
-  auto executor = Executor::getExecutor(getDataMgr(), getDataMgr()->getBufferProvider());
+  auto executor = Executor::getExecutor(getDataMgr());
   CHECK(executor);
   auto storage = getStorage();
   executor->setSchemaProvider(storage);

--- a/omniscidb/Tests/NoCatalogRelAlgTest.cpp
+++ b/omniscidb/Tests/NoCatalogRelAlgTest.cpp
@@ -175,8 +175,7 @@ class NoCatalogRelAlgTest : public ::testing::Test {
     ps_mgr->registerDataProvider(TEST_SCHEMA_ID2,
                                  std::make_shared<TestDataProvider2>(schema_provider_));
 
-    executor_ = Executor::getExecutor(
-        data_mgr_.get(), data_mgr_->getBufferProvider(), config_, "", "");
+    executor_ = Executor::getExecutor(data_mgr_.get(), config_, "", "");
   }
 
   static void TearDownTestSuite() {}

--- a/omniscidb/Tests/NoCatalogSqlTest.cpp
+++ b/omniscidb/Tests/NoCatalogSqlTest.cpp
@@ -152,8 +152,7 @@ class NoCatalogSqlTest : public ::testing::Test {
     ps_mgr->registerDataProvider(TEST_SCHEMA_ID,
                                  std::make_shared<TestDataProvider>(schema_provider_));
 
-    executor_ = Executor::getExecutor(
-        data_mgr_.get(), data_mgr_->getBufferProvider(), config_, "", "");
+    executor_ = Executor::getExecutor(data_mgr_.get(), config_, "", "");
 
     init_calcite("");
   }
@@ -327,8 +326,7 @@ TEST_F(NoCatalogSqlTest, MultipleCalciteMultipleThreads) {
   threads.resize(TEST_NTHREADS);
   std::vector<std::shared_ptr<Executor>> executors;
   for (size_t i = 0; i < TEST_NTHREADS; ++i) {
-    executors.push_back(
-        Executor::getExecutor(data_mgr_.get(), data_mgr_->getBufferProvider(), config_));
+    executors.push_back(Executor::getExecutor(data_mgr_.get(), config_));
     threads[i] = std::async(std::launch::async, [this, i, &res, &executors]() {
       auto calcite = std::make_unique<CalciteJNI>(schema_provider_, config_);
       auto query_ra = calcite->process(

--- a/omniscidb/Tests/ResultSetBaselineRadixSortTest.cpp
+++ b/omniscidb/Tests/ResultSetBaselineRadixSortTest.cpp
@@ -236,7 +236,6 @@ void SortBaselineIntegersTestImpl(const bool desc) {
                                               query_mem_desc,
                                               row_set_mem_owner,
                                               nullptr,
-                                              nullptr,
                                               0,
                                               0));
   auto storage = rs->allocateStorage();
@@ -279,7 +278,6 @@ TEST(SortBaseline, Floats) {
                                                   query_mem_desc,
                                                   row_set_mem_owner,
                                                   nullptr,
-                                                  nullptr,
                                                   0,
                                                   0));
       auto storage = rs->allocateStorage();
@@ -309,7 +307,6 @@ TEST(SortBaseline, FloatsNotNull) {
                                                   ExecutorDeviceType::CPU,
                                                   query_mem_desc,
                                                   row_set_mem_owner,
-                                                  nullptr,
                                                   nullptr,
                                                   0,
                                                   0));

--- a/omniscidb/Tests/ResultSetTest.cpp
+++ b/omniscidb/Tests/ResultSetTest.cpp
@@ -69,7 +69,6 @@ TEST(Construct, Allocate) {
                        std::make_shared<RowSetMemoryOwner>(g_data_provider.get(),
                                                            Executor::getArenaBlockSize()),
                        nullptr,
-                       nullptr,
                        0,
                        0);
   result_set.allocateStorage();
@@ -891,7 +890,6 @@ void test_iterate(const std::vector<TargetInfo>& target_infos,
                        query_mem_desc,
                        row_set_mem_owner,
                        nullptr,
-                       nullptr,
                        0,
                        0);
   for (size_t i = 0; i < query_mem_desc.getEntryCount(); ++i) {
@@ -1020,7 +1018,7 @@ void run_reduction(const std::vector<TargetInfo>& target_infos,
   const ResultSetStorage* storage1{nullptr};
   const ResultSetStorage* storage2{nullptr};
   // for codegen only
-  auto executor = Executor::getExecutor(getDataMgr(), getDataMgr()->getBufferProvider());
+  auto executor = Executor::getExecutor(getDataMgr());
   const auto row_set_mem_owner = std::make_shared<RowSetMemoryOwner>(
       g_data_provider.get(), Executor::getArenaBlockSize());
   row_set_mem_owner->addStringDict(g_sd, 1, g_sd->storageEntryCount());
@@ -1028,7 +1026,6 @@ void run_reduction(const std::vector<TargetInfo>& target_infos,
                                                ExecutorDeviceType::CPU,
                                                query_mem_desc,
                                                row_set_mem_owner,
-                                               nullptr,
                                                nullptr,
                                                0,
                                                0);
@@ -1039,7 +1036,6 @@ void run_reduction(const std::vector<TargetInfo>& target_infos,
                                                ExecutorDeviceType::CPU,
                                                query_mem_desc,
                                                row_set_mem_owner,
-                                               nullptr,
                                                nullptr,
                                                0,
                                                0);
@@ -1060,7 +1056,7 @@ void test_reduce(const std::vector<TargetInfo>& target_infos,
   const ResultSetStorage* storage1{nullptr};
   const ResultSetStorage* storage2{nullptr};
   // for codegen only
-  auto executor = Executor::getExecutor(getDataMgr(), getDataMgr()->getBufferProvider());
+  auto executor = Executor::getExecutor(getDataMgr());
   const auto row_set_mem_owner = std::make_shared<RowSetMemoryOwner>(
       g_data_provider.get(), Executor::getArenaBlockSize());
   row_set_mem_owner->addStringDict(g_sd, 1, g_sd->storageEntryCount());
@@ -1068,7 +1064,6 @@ void test_reduce(const std::vector<TargetInfo>& target_infos,
                                                ExecutorDeviceType::CPU,
                                                query_mem_desc,
                                                row_set_mem_owner,
-                                               nullptr,
                                                nullptr,
                                                0,
                                                0);
@@ -1079,7 +1074,6 @@ void test_reduce(const std::vector<TargetInfo>& target_infos,
                                                ExecutorDeviceType::CPU,
                                                query_mem_desc,
                                                row_set_mem_owner,
-                                               nullptr,
                                                nullptr,
                                                0,
                                                0);
@@ -1165,7 +1159,7 @@ void test_reduce_random_groups(const std::vector<TargetInfo>& target_infos,
   std::unique_ptr<ResultSet> rs1;
   std::unique_ptr<ResultSet> rs2;
   // for codegen only
-  auto executor = Executor::getExecutor(getDataMgr(), getDataMgr()->getBufferProvider());
+  auto executor = Executor::getExecutor(getDataMgr());
   const auto row_set_mem_owner = std::make_shared<RowSetMemoryOwner>(
       g_data_provider.get(), Executor::getArenaBlockSize());
   switch (query_mem_desc.getQueryDescriptionType()) {
@@ -1175,7 +1169,6 @@ void test_reduce_random_groups(const std::vector<TargetInfo>& target_infos,
                               query_mem_desc,
                               row_set_mem_owner,
                               nullptr,
-                              nullptr,
                               0,
                               0));
       storage1 = rs1->allocateStorage();
@@ -1183,7 +1176,6 @@ void test_reduce_random_groups(const std::vector<TargetInfo>& target_infos,
                               ExecutorDeviceType::CPU,
                               query_mem_desc,
                               row_set_mem_owner,
-                              nullptr,
                               nullptr,
                               0,
                               0));
@@ -1196,7 +1188,6 @@ void test_reduce_random_groups(const std::vector<TargetInfo>& target_infos,
                               query_mem_desc,
                               row_set_mem_owner,
                               nullptr,
-                              nullptr,
                               0,
                               0));
       storage1 = rs1->allocateStorage();
@@ -1204,7 +1195,6 @@ void test_reduce_random_groups(const std::vector<TargetInfo>& target_infos,
                               ExecutorDeviceType::CPU,
                               query_mem_desc,
                               row_set_mem_owner,
-                              nullptr,
                               nullptr,
                               0,
                               0));
@@ -1978,14 +1968,13 @@ TEST(MoreReduce, MissingValues) {
   auto query_mem_desc = perfect_hash_one_col_desc(target_infos, 8, 7, 9);
   query_mem_desc.setHasKeylessHash(false);
   // for codegen only
-  auto executor = Executor::getExecutor(getDataMgr(), getDataMgr()->getBufferProvider());
+  auto executor = Executor::getExecutor(getDataMgr());
   const auto row_set_mem_owner = std::make_shared<RowSetMemoryOwner>(
       g_data_provider.get(), Executor::getArenaBlockSize());
   const auto rs1 = std::make_unique<ResultSet>(target_infos,
                                                ExecutorDeviceType::CPU,
                                                query_mem_desc,
                                                row_set_mem_owner,
-                                               nullptr,
                                                nullptr,
                                                0,
                                                0);
@@ -1994,7 +1983,6 @@ TEST(MoreReduce, MissingValues) {
                                                ExecutorDeviceType::CPU,
                                                query_mem_desc,
                                                row_set_mem_owner,
-                                               nullptr,
                                                nullptr,
                                                0,
                                                0);
@@ -2058,14 +2046,13 @@ TEST(MoreReduce, MissingValuesKeyless) {
   auto query_mem_desc = perfect_hash_one_col_desc(target_infos, 8, 7, 9);
   query_mem_desc.setHasKeylessHash(true);
   // for codegen only
-  auto executor = Executor::getExecutor(getDataMgr(), getDataMgr()->getBufferProvider());
+  auto executor = Executor::getExecutor(getDataMgr());
   const auto row_set_mem_owner = std::make_shared<RowSetMemoryOwner>(
       g_data_provider.get(), Executor::getArenaBlockSize());
   const auto rs1 = std::make_unique<ResultSet>(target_infos,
                                                ExecutorDeviceType::CPU,
                                                query_mem_desc,
                                                row_set_mem_owner,
-                                               nullptr,
                                                nullptr,
                                                0,
                                                0);
@@ -2074,7 +2061,6 @@ TEST(MoreReduce, MissingValuesKeyless) {
                                                ExecutorDeviceType::CPU,
                                                query_mem_desc,
                                                row_set_mem_owner,
-                                               nullptr,
                                                nullptr,
                                                0,
                                                0);
@@ -2134,7 +2120,7 @@ TEST(MoreReduce, OffsetRewrite) {
   auto query_mem_desc = perfect_hash_one_col_desc(target_infos, 8, 7, 9);
   query_mem_desc.setHasKeylessHash(false);
   // for codegen only
-  auto executor = Executor::getExecutor(getDataMgr(), getDataMgr()->getBufferProvider());
+  auto executor = Executor::getExecutor(getDataMgr());
   const auto row_set_mem_owner = std::make_shared<RowSetMemoryOwner>(
       g_data_provider.get(), Executor::getArenaBlockSize());
 
@@ -2143,7 +2129,6 @@ TEST(MoreReduce, OffsetRewrite) {
                                                query_mem_desc,
                                                row_set_mem_owner,
                                                nullptr,
-                                               nullptr,
                                                0,
                                                0);
   const auto storage1 = rs1->allocateStorage();
@@ -2151,7 +2136,6 @@ TEST(MoreReduce, OffsetRewrite) {
                                                ExecutorDeviceType::CPU,
                                                query_mem_desc,
                                                row_set_mem_owner,
-                                               nullptr,
                                                nullptr,
                                                0,
                                                0);

--- a/python/pyhdk/_execute.pxd
+++ b/python/pyhdk/_execute.pxd
@@ -101,7 +101,7 @@ cdef extern from "omniscidb/QueryEngine/ArrowResultSet.h":
 cdef extern from "omniscidb/QueryEngine/Execute.h":
   cdef cppclass CExecutor "Executor":
     @staticmethod
-    shared_ptr[CExecutor] getExecutor(CDataMgr*, CBufferProvider*, shared_ptr[CConfig], const string&, const string&)
+    shared_ptr[CExecutor] getExecutor(CDataMgr*, shared_ptr[CConfig], const string&, const string&)
 
     const CConfig &getConfig()
     shared_ptr[CConfig] getConfigPtr()

--- a/python/pyhdk/_execute.pyx
+++ b/python/pyhdk/_execute.pyx
@@ -10,5 +10,4 @@ cdef class Executor:
   def __cinit__(self, DataMgr data_mgr, Config config):
     cdef string debug_dir = "".encode('UTF-8')
     cdef string debug_file = "".encode('UTF-8')
-    cdef CBufferProvider *buffer_provider = data_mgr.c_data_mgr.get().getBufferProvider()
-    self.c_executor = CExecutor.getExecutor(data_mgr.c_data_mgr.get(), buffer_provider, config.c_config, debug_dir, debug_file)
+    self.c_executor = CExecutor.getExecutor(data_mgr.c_data_mgr.get(), config.c_config, debug_dir, debug_file)

--- a/src/HDK.cpp
+++ b/src/HDK.cpp
@@ -96,11 +96,8 @@ HDK::HDK() : internal_(std::make_unique<Internal>()) {
                                                     /*calcite_max_mem_mb=*/1024);
 
   // Executor
-  internal_->executor = Executor::getExecutor(internal_->data_mgr.get(),
-                                              internal_->data_mgr->getBufferProvider(),
-                                              internal_->config,
-                                              "",
-                                              "");
+  internal_->executor =
+      Executor::getExecutor(internal_->data_mgr.get(), internal_->config, "", "");
   internal_->executor->setSchemaProvider(internal_->storage);
 }
 


### PR DESCRIPTION
Get `BufferProvider` from `DataMgr` in `Executor` and `ResultSet`.

This is just to avoid unnecessary fields and args and make it more explicit that `BufferProvider` is always provided by `DataMgr`. 