### PR TITLE
ResultSet refactoring and clean-up [08/N]

### DIFF
--- a/omniscidb/QueryEngine/Execute.h
+++ b/omniscidb/QueryEngine/Execute.h
@@ -902,6 +902,8 @@ class Executor {
   llvm::LLVMContext& getContext() { return *context_.get(); }
   void update_extension_modules(bool update_runtime_modules_only = false);
 
+  bool isLazyFetchAllowed() const { return plan_state_->allow_lazy_fetch_; }
+
  private:
   std::vector<int8_t> serializeLiterals(
       const std::unordered_map<int, CgenState::LiteralValues>& literals,
@@ -1074,7 +1076,6 @@ class Executor {
   friend class HashJoin;  // cgen_state_
   friend class RowFuncBuilder;
   friend class QueryCompilationDescriptor;
-  friend class QueryMemoryDescriptor;
   friend class QueryMemoryInitializer;
   friend class QueryFragmentDescriptor;
   friend class QueryExecutionContext;

--- a/omniscidb/QueryEngine/ExecutionKernel.cpp
+++ b/omniscidb/QueryEngine/ExecutionKernel.cpp
@@ -358,19 +358,20 @@ void ExecutionKernel::runImpl(Executor* executor,
   if (eo.executor_type == ExecutorType::Native) {
     try {
       query_exe_context_owned =
-          query_mem_desc.getQueryExecutionContext(ra_exe_unit_,
-                                                  executor,
-                                                  chosen_device_type,
-                                                  kernel_dispatch_mode,
-                                                  query_comp_desc.useGroupByBufferDesc(),
-                                                  chosen_device_id,
-                                                  total_num_input_rows,
-                                                  fetch_result->col_buffers,
-                                                  fetch_result->frag_offsets,
-                                                  executor->getRowSetMemoryOwner(),
-                                                  compilation_result.output_columnar,
-                                                  query_mem_desc.sortOnGpu(),
-                                                  thread_idx);
+          QueryExecutionContext::create(ra_exe_unit_,
+                                        query_mem_desc,
+                                        executor,
+                                        chosen_device_type,
+                                        kernel_dispatch_mode,
+                                        query_comp_desc.useGroupByBufferDesc(),
+                                        chosen_device_id,
+                                        total_num_input_rows,
+                                        fetch_result->col_buffers,
+                                        fetch_result->frag_offsets,
+                                        executor->getRowSetMemoryOwner(),
+                                        compilation_result.output_columnar,
+                                        query_mem_desc.sortOnGpu(),
+                                        thread_idx);
     } catch (const OutOfHostMemory& e) {
       throw QueryExecutionError(Executor::ERR_OUT_OF_CPU_MEM);
     }
@@ -484,21 +485,22 @@ void KernelSubtask::runImpl(Executor* executor) {
       std::vector<std::vector<uint64_t>> frag_offsets(
           fetch_result_->frag_offsets.size(),
           std::vector<uint64_t>(fetch_result_->frag_offsets[0].size()));
-      query_exe_context_owned = kernel_.query_mem_desc.getQueryExecutionContext(
-          kernel_.ra_exe_unit_,
-          executor,
-          kernel_.chosen_device_type,
-          kernel_.kernel_dispatch_mode,
-          kernel_.query_comp_desc.useGroupByBufferDesc(),
-          kernel_.chosen_device_id,
-          total_num_input_rows_,
-          col_buffers,
-          frag_offsets,
-          executor->getRowSetMemoryOwner(),
-          compilation_result.output_columnar,
-          kernel_.query_mem_desc.sortOnGpu(),
-          // TODO: use TBB thread id to choose allocator
-          thread_idx_);
+      query_exe_context_owned =
+          QueryExecutionContext::create(kernel_.ra_exe_unit_,
+                                        kernel_.query_mem_desc,
+                                        executor,
+                                        kernel_.chosen_device_type,
+                                        kernel_.kernel_dispatch_mode,
+                                        kernel_.query_comp_desc.useGroupByBufferDesc(),
+                                        kernel_.chosen_device_id,
+                                        total_num_input_rows_,
+                                        col_buffers,
+                                        frag_offsets,
+                                        executor->getRowSetMemoryOwner(),
+                                        compilation_result.output_columnar,
+                                        kernel_.query_mem_desc.sortOnGpu(),
+                                        // TODO: use TBB thread id to choose allocator
+                                        thread_idx_);
     } catch (const OutOfHostMemory& e) {
       throw QueryExecutionError(Executor::ERR_OUT_OF_CPU_MEM);
     }

--- a/omniscidb/QueryEngine/MemoryLayoutBuilder.cpp
+++ b/omniscidb/QueryEngine/MemoryLayoutBuilder.cpp
@@ -21,6 +21,7 @@
 #include "QueryEngine/ColRangeInfo.h"
 #include "QueryEngine/HyperLogLog.h"
 #include "QueryEngine/OutputBufferInitialization.h"
+#include "QueryEngine/UsedColumnsCollector.h"
 
 MemoryLayoutBuilder::MemoryLayoutBuilder(const RelAlgExecutionUnit& ra_exe_unit)
     : ra_exe_unit_(ra_exe_unit) {
@@ -486,6 +487,468 @@ CountDistinctDescriptors init_count_distinct_descriptors(
   return count_distinct_descriptors;
 }
 
+template <class T>
+inline std::vector<int8_t> get_col_byte_widths(const T& col_expr_list,
+                                               bool bigint_count) {
+  std::vector<int8_t> col_widths;
+  size_t col_expr_idx = 0;
+  for (const auto& col_expr : col_expr_list) {
+    if (!col_expr) {
+      // row index
+      col_widths.push_back(sizeof(int64_t));
+    } else {
+      const auto agg_info = get_target_info(col_expr, bigint_count);
+      const auto chosen_type = get_compact_type(agg_info);
+      if (chosen_type->isString() || chosen_type->isArray()) {
+        col_widths.push_back(sizeof(int64_t));
+        col_widths.push_back(sizeof(int64_t));
+        ++col_expr_idx;
+        continue;
+      }
+      const auto col_expr_bitwidth = get_bit_width(chosen_type);
+      CHECK_EQ(size_t(0), col_expr_bitwidth % 8);
+      col_widths.push_back(static_cast<int8_t>(col_expr_bitwidth >> 3));
+      // for average, we'll need to keep the count as well
+      if (agg_info.agg_kind == hdk::ir::AggType::kAvg) {
+        CHECK(agg_info.is_agg);
+        col_widths.push_back(sizeof(int64_t));
+      }
+    }
+    ++col_expr_idx;
+  }
+  return col_widths;
+}
+
+bool is_int_and_no_bigger_than(const hdk::ir::Type* type, const size_t byte_width) {
+  if (!type->isInteger()) {
+    return false;
+  }
+  return get_bit_width(type) <= (byte_width * 8);
+}
+
+int8_t pick_target_compact_width(const RelAlgExecutionUnit& ra_exe_unit,
+                                 const std::vector<InputTableInfo>& query_infos,
+                                 const int8_t crt_min_byte_width,
+                                 bool bigint_count) {
+  if (bigint_count) {
+    return sizeof(int64_t);
+  }
+  int8_t compact_width{0};
+  auto col_it = ra_exe_unit.input_col_descs.begin();
+  auto const end = ra_exe_unit.input_col_descs.end();
+  int unnest_array_col_id{std::numeric_limits<int>::min()};
+  for (const auto& groupby_expr : ra_exe_unit.groupby_exprs) {
+    const auto uoper = dynamic_cast<const hdk::ir::UOper*>(groupby_expr.get());
+    if (uoper && uoper->isUnnest()) {
+      auto arg_type = uoper->operand()->type();
+      CHECK(arg_type->isArray());
+      auto elem_type = arg_type->as<hdk::ir::ArrayBaseType>()->elemType();
+      if (elem_type->isExtDictionary()) {
+        unnest_array_col_id = (*col_it)->getColId();
+      } else {
+        compact_width = crt_min_byte_width;
+        break;
+      }
+    }
+    if (col_it != end) {
+      ++col_it;
+    }
+  }
+  if (!compact_width &&
+      (ra_exe_unit.groupby_exprs.size() != 1 || !ra_exe_unit.groupby_exprs.front())) {
+    compact_width = crt_min_byte_width;
+  }
+  if (!compact_width) {
+    col_it = ra_exe_unit.input_col_descs.begin();
+    std::advance(col_it, ra_exe_unit.groupby_exprs.size());
+    for (const auto target : ra_exe_unit.target_exprs) {
+      auto type = target->type();
+      const auto agg = target->as<hdk::ir::AggExpr>();
+      if (agg && agg->arg()) {
+        compact_width = crt_min_byte_width;
+        break;
+      }
+
+      if (agg) {
+        CHECK_EQ(hdk::ir::AggType::kCount, agg->aggType());
+        CHECK(!agg->isDistinct());
+        if (col_it != end) {
+          ++col_it;
+        }
+        continue;
+      }
+
+      if (is_int_and_no_bigger_than(type, 4) || (type->isExtDictionary())) {
+        if (col_it != end) {
+          ++col_it;
+        }
+        continue;
+      }
+
+      const auto uoper = target->as<hdk::ir::UOper>();
+      if (uoper && uoper->isUnnest() && (*col_it)->getColId() == unnest_array_col_id) {
+        auto arg_type = uoper->operand()->type();
+        CHECK(arg_type->isArray());
+        auto elem_type = arg_type->as<hdk::ir::ArrayBaseType>()->elemType();
+        if (elem_type->isExtDictionary()) {
+          if (col_it != end) {
+            ++col_it;
+          }
+          continue;
+        }
+      }
+
+      compact_width = crt_min_byte_width;
+      break;
+    }
+  }
+  if (!compact_width) {
+    size_t total_tuples{0};
+    for (const auto& qi : query_infos) {
+      total_tuples += qi.info.getNumTuples();
+    }
+    return total_tuples <= static_cast<size_t>(std::numeric_limits<uint32_t>::max()) ||
+                   unnest_array_col_id != std::numeric_limits<int>::min()
+               ? 4
+               : crt_min_byte_width;
+  } else {
+    // TODO(miyu): relax this condition to allow more cases just w/o padding
+    for (auto wid : get_col_byte_widths(ra_exe_unit.target_exprs, bigint_count)) {
+      compact_width = std::max(compact_width, wid);
+    }
+    return compact_width;
+  }
+}
+
+bool is_valid_int32_range(const ExpressionRange& range) {
+  return range.getIntMin() > INT32_MIN && range.getIntMax() < EMPTY_KEY_32 - 1;
+}
+
+int8_t pick_baseline_key_component_width(const ExpressionRange& range,
+                                         const size_t group_col_width) {
+  if (range.getType() == ExpressionRangeType::Invalid) {
+    return sizeof(int64_t);
+  }
+  switch (range.getType()) {
+    case ExpressionRangeType::Integer:
+      if (group_col_width == sizeof(int64_t) && range.hasNulls()) {
+        return sizeof(int64_t);
+      }
+      return is_valid_int32_range(range) ? sizeof(int32_t) : sizeof(int64_t);
+    case ExpressionRangeType::Float:
+    case ExpressionRangeType::Double:
+      return sizeof(int64_t);  // No compaction for floating point yet.
+    default:
+      UNREACHABLE();
+  }
+  return sizeof(int64_t);
+}
+
+// TODO(miyu): make sure following setting of compact width is correct in all cases.
+int8_t pick_baseline_key_width(const RelAlgExecutionUnit& ra_exe_unit,
+                               const std::vector<InputTableInfo>& query_infos,
+                               const Executor* executor) {
+  int8_t compact_width{4};
+  for (const auto& groupby_expr : ra_exe_unit.groupby_exprs) {
+    const auto expr_range = getExpressionRange(groupby_expr.get(), query_infos, executor);
+    compact_width = std::max(
+        compact_width,
+        pick_baseline_key_component_width(expr_range, groupby_expr->type()->size()));
+  }
+  return compact_width;
+}
+
+bool use_streaming_top_n(const RelAlgExecutionUnit& ra_exe_unit,
+                         const bool output_columnar,
+                         bool streaming_topn_max) {
+  for (const auto target_expr : ra_exe_unit.target_exprs) {
+    if (dynamic_cast<const hdk::ir::AggExpr*>(target_expr)) {
+      return false;
+    }
+    if (dynamic_cast<const hdk::ir::WindowFunction*>(target_expr)) {
+      return false;
+    }
+  }
+
+  // TODO: Allow streaming top n for columnar output
+  if (!output_columnar && ra_exe_unit.sort_info.order_entries.size() == 1 &&
+      ra_exe_unit.sort_info.limit &&
+      ra_exe_unit.sort_info.algorithm == SortAlgorithm::StreamingTopN) {
+    const auto only_order_entry = ra_exe_unit.sort_info.order_entries.front();
+    CHECK_GT(only_order_entry.tle_no, int(0));
+    CHECK_LE(static_cast<size_t>(only_order_entry.tle_no),
+             ra_exe_unit.target_exprs.size());
+    const auto order_entry_expr = ra_exe_unit.target_exprs[only_order_entry.tle_no - 1];
+    const auto n = ra_exe_unit.sort_info.offset + ra_exe_unit.sort_info.limit;
+    if ((order_entry_expr->type()->isNumber() ||
+         order_entry_expr->type()->isDateTime()) &&
+        n <= streaming_topn_max) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+std::vector<int64_t> target_expr_group_by_indices(
+    const std::list<hdk::ir::ExprPtr>& groupby_exprs,
+    const std::vector<const hdk::ir::Expr*>& target_exprs) {
+  std::vector<int64_t> indices(target_exprs.size(), -1);
+  for (size_t target_idx = 0; target_idx < target_exprs.size(); ++target_idx) {
+    const auto target_expr = target_exprs[target_idx];
+    if (dynamic_cast<const hdk::ir::AggExpr*>(target_expr)) {
+      continue;
+    }
+    const auto var_expr = dynamic_cast<const hdk::ir::Var*>(target_expr);
+    if (var_expr && var_expr->whichRow() == hdk::ir::Var::kGROUPBY) {
+      indices[target_idx] = var_expr->varNo() - 1;
+      continue;
+    }
+  }
+  return indices;
+}
+
+std::vector<int64_t> target_expr_proj_indices(const RelAlgExecutionUnit& ra_exe_unit,
+                                              SchemaProviderPtr schema_provider) {
+  if (ra_exe_unit.input_descs.size() > 1 ||
+      !ra_exe_unit.sort_info.order_entries.empty()) {
+    return {};
+  }
+  std::vector<int64_t> target_indices(ra_exe_unit.target_exprs.size(), -1);
+  UsedColumnsCollector columns_collector;
+  for (const auto& simple_qual : ra_exe_unit.simple_quals) {
+    columns_collector.visit(simple_qual.get());
+  }
+  for (const auto& qual : ra_exe_unit.quals) {
+    columns_collector.visit(qual.get());
+  }
+  for (const auto& target : ra_exe_unit.target_exprs) {
+    const auto col_var = dynamic_cast<const hdk::ir::ColumnVar*>(target);
+    if (col_var && !col_var->isVirtual()) {
+      continue;
+    }
+    columns_collector.visit(target);
+  }
+  const auto& used_columns = columns_collector.result();
+  for (size_t target_idx = 0; target_idx < ra_exe_unit.target_exprs.size();
+       ++target_idx) {
+    const auto target_expr = ra_exe_unit.target_exprs[target_idx];
+    CHECK(target_expr);
+    auto type = target_expr->type();
+    // TODO: add proper lazy fetch for varlen types in result set
+    if (type->isString() || type->isArray()) {
+      continue;
+    }
+    const auto col_var = dynamic_cast<const hdk::ir::ColumnVar*>(target_expr);
+    if (!col_var) {
+      continue;
+    }
+    if (used_columns.find(col_var->columnId()) == used_columns.end()) {
+      // setting target index to be zero so that later it can be decoded properly (in lazy
+      // fetch, the zeroth target index indicates the corresponding rowid column for the
+      // projected entry)
+      target_indices[target_idx] = 0;
+    }
+  }
+  return target_indices;
+}
+
+std::unique_ptr<QueryMemoryDescriptor> build_query_memory_descriptor(
+    const Executor* executor,
+    const RelAlgExecutionUnit& ra_exe_unit,
+    const std::vector<InputTableInfo>& query_infos,
+    const ColRangeInfo& col_range_info,
+    const KeylessInfo& keyless_info,
+    const bool allow_multifrag,
+    const ExecutorDeviceType device_type,
+    const int8_t crt_min_byte_width,
+    const bool sort_on_gpu_hint,
+    const size_t max_groups_buffer_entry_count,
+    const CountDistinctDescriptors count_distinct_descriptors,
+    const bool must_use_baseline_sort,
+    const bool output_columnar_hint,
+    const bool streaming_top_n_hint) {
+  auto group_col_widths = get_col_byte_widths(
+      ra_exe_unit.groupby_exprs, executor->getConfig().exec.group_by.bigint_count);
+  const bool is_group_by{!group_col_widths.empty()};
+
+  auto col_slot_context = ColSlotContext(
+      ra_exe_unit.target_exprs, {}, executor->getConfig().exec.group_by.bigint_count);
+
+  const auto min_slot_size =
+      pick_target_compact_width(ra_exe_unit,
+                                query_infos,
+                                crt_min_byte_width,
+                                executor->getConfig().exec.group_by.bigint_count);
+
+  col_slot_context.setAllSlotsPaddedSize(min_slot_size);
+  col_slot_context.validate();
+
+  if (!is_group_by) {
+    CHECK(!must_use_baseline_sort);
+
+    return std::make_unique<QueryMemoryDescriptor>(
+        executor->getDataMgr(),
+        executor->getConfigPtr(),
+        ra_exe_unit,
+        query_infos,
+        allow_multifrag,
+        false,
+        false,
+        -1,
+        ColRangeInfo{ra_exe_unit.estimator ? QueryDescriptionType::Estimator
+                                           : QueryDescriptionType::NonGroupedAggregate,
+                     0,
+                     0,
+                     0,
+                     false},
+        col_slot_context,
+        std::vector<int8_t>{},
+        /*group_col_compact_width=*/0,
+        std::vector<int64_t>{},
+        /*entry_count=*/1,
+        count_distinct_descriptors,
+        false,
+        output_columnar_hint,
+        must_use_baseline_sort,
+        /*use_streaming_top_n=*/false);
+  }
+
+  size_t entry_count = 1;
+  auto actual_col_range_info = col_range_info;
+  bool interleaved_bins_on_gpu = false;
+  bool keyless_hash = false;
+  bool streaming_top_n = false;
+  int8_t group_col_compact_width = 0;
+  int32_t idx_target_as_key = -1;
+  auto output_columnar = output_columnar_hint;
+  std::vector<int64_t> target_groupby_indices;
+
+  switch (col_range_info.hash_type_) {
+    case QueryDescriptionType::GroupByPerfectHash: {
+      // keyless hash: whether or not group columns are stored at the beginning of the
+      // output buffer
+      keyless_hash =
+          (!sort_on_gpu_hint ||
+           !QueryMemoryDescriptor::many_entries(
+               col_range_info.max, col_range_info.min, col_range_info.bucket)) &&
+          !col_range_info.bucket && !must_use_baseline_sort && keyless_info.keyless;
+
+      // if keyless, then this target index indicates wheter an entry is empty or not
+      // (acts as a key)
+      idx_target_as_key = keyless_info.target_index;
+
+      if (group_col_widths.size() > 1) {
+        // col range info max contains the expected cardinality of the output
+        entry_count = static_cast<size_t>(actual_col_range_info.max);
+        actual_col_range_info.bucket = 0;
+      } else {
+        // single column perfect hash
+        entry_count = std::max(col_range_info.getBucketedCardinality(), int64_t(1));
+        const size_t interleaved_max_threshold{512};
+
+        if (must_use_baseline_sort) {
+          target_groupby_indices = target_expr_group_by_indices(ra_exe_unit.groupby_exprs,
+                                                                ra_exe_unit.target_exprs);
+          col_slot_context =
+              ColSlotContext(ra_exe_unit.target_exprs,
+                             target_groupby_indices,
+                             executor->getConfig().exec.group_by.bigint_count);
+        }
+
+        bool has_varlen_sample_agg = false;
+        for (const auto& target_expr : ra_exe_unit.target_exprs) {
+          if (target_expr->containsAgg()) {
+            const auto agg_expr = target_expr->as<hdk::ir::AggExpr>();
+            CHECK(agg_expr);
+            if (agg_expr->aggType() == hdk::ir::AggType::kSample &&
+                (agg_expr->type()->isString() || agg_expr->type()->isArray())) {
+              has_varlen_sample_agg = true;
+              break;
+            }
+          }
+        }
+
+        interleaved_bins_on_gpu = keyless_hash && !has_varlen_sample_agg &&
+                                  (entry_count <= interleaved_max_threshold) &&
+                                  (device_type == ExecutorDeviceType::GPU) &&
+                                  QueryMemoryDescriptor::countDescriptorsLogicallyEmpty(
+                                      count_distinct_descriptors) &&
+                                  !output_columnar;
+      }
+      break;
+    }
+    case QueryDescriptionType::GroupByBaselineHash: {
+      entry_count = max_groups_buffer_entry_count;
+      target_groupby_indices = target_expr_group_by_indices(ra_exe_unit.groupby_exprs,
+                                                            ra_exe_unit.target_exprs);
+      col_slot_context = ColSlotContext(ra_exe_unit.target_exprs,
+                                        target_groupby_indices,
+                                        executor->getConfig().exec.group_by.bigint_count);
+
+      group_col_compact_width =
+          output_columnar ? 8
+                          : pick_baseline_key_width(ra_exe_unit, query_infos, executor);
+
+      actual_col_range_info =
+          ColRangeInfo{QueryDescriptionType::GroupByBaselineHash, 0, 0, 0, false};
+      break;
+    }
+    case QueryDescriptionType::Projection: {
+      CHECK(!must_use_baseline_sort);
+
+      if (streaming_top_n_hint &&
+          use_streaming_top_n(ra_exe_unit,
+                              output_columnar,
+                              executor->getConfig().exec.streaming_topn_max)) {
+        streaming_top_n = true;
+        entry_count = ra_exe_unit.sort_info.offset + ra_exe_unit.sort_info.limit;
+      } else {
+        if (ra_exe_unit.use_bump_allocator) {
+          output_columnar = false;
+          entry_count = 0;
+        } else {
+          entry_count = ra_exe_unit.scan_limit
+                            ? static_cast<size_t>(ra_exe_unit.scan_limit)
+                            : max_groups_buffer_entry_count;
+        }
+      }
+
+      target_groupby_indices =
+          executor->isLazyFetchAllowed()
+              ? target_expr_proj_indices(ra_exe_unit, executor->getSchemaProvider())
+              : std::vector<int64_t>{};
+
+      col_slot_context = ColSlotContext(ra_exe_unit.target_exprs,
+                                        target_groupby_indices,
+                                        executor->getConfig().exec.group_by.bigint_count);
+      break;
+    }
+    default:
+      UNREACHABLE() << "Unknown query type";
+  }
+
+  return std::make_unique<QueryMemoryDescriptor>(executor->getDataMgr(),
+                                                 executor->getConfigPtr(),
+                                                 ra_exe_unit,
+                                                 query_infos,
+                                                 allow_multifrag,
+                                                 keyless_hash,
+                                                 interleaved_bins_on_gpu,
+                                                 idx_target_as_key,
+                                                 actual_col_range_info,
+                                                 col_slot_context,
+                                                 group_col_widths,
+                                                 group_col_compact_width,
+                                                 target_groupby_indices,
+                                                 entry_count,
+                                                 count_distinct_descriptors,
+                                                 sort_on_gpu_hint,
+                                                 output_columnar,
+                                                 must_use_baseline_sort,
+                                                 streaming_top_n);
+}
+
 std::unique_ptr<QueryMemoryDescriptor> build_query_memory_descriptor(
     const RelAlgExecutionUnit& ra_exe_unit,
     const std::vector<InputTableInfo>& query_infos,
@@ -531,36 +994,36 @@ std::unique_ptr<QueryMemoryDescriptor> build_query_memory_descriptor(
     throw WatchdogException("Query would use too much memory");
   }
   try {
-    return QueryMemoryDescriptor::init(executor,
-                                       ra_exe_unit,
-                                       query_infos,
-                                       col_range_info,
-                                       keyless_info,
-                                       allow_multifrag,
-                                       device_type,
-                                       crt_min_byte_width,
-                                       sort_on_gpu_hint,
-                                       max_groups_buffer_entry_count,
-                                       count_distinct_descriptors,
-                                       must_use_baseline_sort,
-                                       output_columnar_hint,
-                                       /*streaming_top_n_hint=*/true);
+    return build_query_memory_descriptor(executor,
+                                         ra_exe_unit,
+                                         query_infos,
+                                         col_range_info,
+                                         keyless_info,
+                                         allow_multifrag,
+                                         device_type,
+                                         crt_min_byte_width,
+                                         sort_on_gpu_hint,
+                                         max_groups_buffer_entry_count,
+                                         count_distinct_descriptors,
+                                         must_use_baseline_sort,
+                                         output_columnar_hint,
+                                         /*streaming_top_n_hint=*/true);
   } catch (const StreamingTopNOOM& e) {
     LOG(WARNING) << e.what() << " Disabling Streaming Top N.";
-    return QueryMemoryDescriptor::init(executor,
-                                       ra_exe_unit,
-                                       query_infos,
-                                       col_range_info,
-                                       keyless_info,
-                                       allow_multifrag,
-                                       device_type,
-                                       crt_min_byte_width,
-                                       sort_on_gpu_hint,
-                                       max_groups_buffer_entry_count,
-                                       count_distinct_descriptors,
-                                       must_use_baseline_sort,
-                                       output_columnar_hint,
-                                       /*streaming_top_n_hint=*/false);
+    return build_query_memory_descriptor(executor,
+                                         ra_exe_unit,
+                                         query_infos,
+                                         col_range_info,
+                                         keyless_info,
+                                         allow_multifrag,
+                                         device_type,
+                                         crt_min_byte_width,
+                                         sort_on_gpu_hint,
+                                         max_groups_buffer_entry_count,
+                                         count_distinct_descriptors,
+                                         must_use_baseline_sort,
+                                         output_columnar_hint,
+                                         /*streaming_top_n_hint=*/false);
   }
 }
 

--- a/omniscidb/QueryEngine/QueryExecutionContext.cpp
+++ b/omniscidb/QueryEngine/QueryExecutionContext.cpp
@@ -73,6 +73,42 @@ QueryExecutionContext::QueryExecutionContext(
                                                             executor);
 }
 
+std::unique_ptr<QueryExecutionContext> QueryExecutionContext::create(
+    const RelAlgExecutionUnit& ra_exe_unit,
+    const QueryMemoryDescriptor& query_mem_desc,
+    Executor* executor,
+    const ExecutorDeviceType device_type,
+    const ExecutorDispatchMode dispatch_mode,
+    const bool use_groupby_buffer_desc,
+    const int device_id,
+    const int64_t num_rows,
+    const std::vector<std::vector<const int8_t*>>& col_buffers,
+    const std::vector<std::vector<uint64_t>>& frag_offsets,
+    std::shared_ptr<RowSetMemoryOwner> row_set_mem_owner,
+    const bool output_columnar,
+    const bool sort_on_gpu,
+    const size_t thread_idx) {
+  auto timer = DEBUG_TIMER(__func__);
+  if (frag_offsets.empty()) {
+    return nullptr;
+  }
+  return std::unique_ptr<QueryExecutionContext>(
+      new QueryExecutionContext(ra_exe_unit,
+                                query_mem_desc,
+                                executor,
+                                device_type,
+                                dispatch_mode,
+                                use_groupby_buffer_desc,
+                                device_id,
+                                num_rows,
+                                col_buffers,
+                                frag_offsets,
+                                row_set_mem_owner,
+                                output_columnar,
+                                sort_on_gpu,
+                                thread_idx));
+}
+
 ResultSetPtr QueryExecutionContext::groupBufferToDeinterleavedResults(
     const size_t i) const {
   CHECK(!output_columnar_);

--- a/omniscidb/QueryEngine/QueryExecutionContext.h
+++ b/omniscidb/QueryEngine/QueryExecutionContext.h
@@ -51,6 +51,22 @@ class QueryExecutionContext : boost::noncopyable {
                         const bool sort_on_gpu,
                         const size_t thread_idx);
 
+  static std::unique_ptr<QueryExecutionContext> create(
+      const RelAlgExecutionUnit& ra_exe_unit,
+      const QueryMemoryDescriptor& query_mem_desc,
+      Executor* executor,
+      const ExecutorDeviceType device_type,
+      const ExecutorDispatchMode dispatch_mode,
+      const bool use_groupby_buffer_desc,
+      const int device_id,
+      const int64_t num_rows,
+      const std::vector<std::vector<const int8_t*>>& col_buffers,
+      const std::vector<std::vector<uint64_t>>& frag_offsets,
+      std::shared_ptr<RowSetMemoryOwner> row_set_mem_owner,
+      const bool output_columnar,
+      const bool sort_on_gpu,
+      const size_t thread_idx);
+
   ResultSetPtr getRowSet(const RelAlgExecutionUnit& ra_exe_unit,
                          const QueryMemoryDescriptor& query_mem_desc) const;
 

--- a/omniscidb/QueryEngine/RelAlgExecutor.cpp
+++ b/omniscidb/QueryEngine/RelAlgExecutor.cpp
@@ -1859,7 +1859,8 @@ ExecutionResult RelAlgExecutor::executeLogicalValues(
     const hdk::ir::LogicalValues* logical_values,
     const ExecutionOptions& eo) {
   auto timer = DEBUG_TIMER(__func__);
-  QueryMemoryDescriptor query_mem_desc(executor_,
+  QueryMemoryDescriptor query_mem_desc(executor_->getDataMgr(),
+                                       executor_->getConfigPtr(),
                                        logical_values->getNumRows(),
                                        QueryDescriptionType::Projection,
                                        /*is_table_function=*/false);

--- a/omniscidb/QueryEngine/ResultSet.h
+++ b/omniscidb/QueryEngine/ResultSet.h
@@ -525,8 +525,6 @@ class ResultSet {
   class CellCallback;
   void eachCellInColumn(RowIterationState&, CellCallback const&);
 
-  const Executor* getExecutor() const { return query_mem_desc_.getExecutor(); }
-
  private:
   void advanceCursorToNextEntry(ResultSetRowIterator& iter) const;
 

--- a/omniscidb/QueryEngine/ResultSetBuilder.cpp
+++ b/omniscidb/QueryEngine/ResultSetBuilder.cpp
@@ -170,7 +170,8 @@ ResultSet* ResultSetLogicalValuesBuilder::create(
 
   size_t numRows = logical_values.size();
 
-  QueryMemoryDescriptor query_mem_desc(/*executor=*/nullptr,
+  QueryMemoryDescriptor query_mem_desc(/*data_mgr=*/nullptr,
+                                       /*config=*/nullptr,
                                        /*entry_count=*/numRows,
                                        QueryDescriptionType::Projection,
                                        /*is_table_function=*/false);

--- a/omniscidb/QueryEngine/ResultSetIteration.cpp
+++ b/omniscidb/QueryEngine/ResultSetIteration.cpp
@@ -630,8 +630,6 @@ InternalTargetValue ResultSet::getVarlenOrderEntry(const int64_t str_ptr,
   std::vector<int8_t> cpu_buffer;
   if (device_type_ == ExecutorDeviceType::GPU) {
     cpu_buffer.resize(str_len);
-    const auto executor = query_mem_desc_.getExecutor();
-    CHECK(executor);
     getBufferProvider()->copyFromDevice(
         &cpu_buffer[0], reinterpret_cast<const int8_t*>(str_ptr), str_len, device_id_);
     host_str_ptr = reinterpret_cast<char*>(&cpu_buffer[0]);
@@ -1215,9 +1213,7 @@ TargetValue ResultSet::makeVarlenTargetValue(const int8_t* ptr1,
   std::vector<int8_t> cpu_buffer;
   if (varlen_ptr && device_type_ == ExecutorDeviceType::GPU) {
     cpu_buffer.resize(length);
-    const auto executor = query_mem_desc_.getExecutor();
-    CHECK(executor);
-    auto buffer_provider = executor->getBufferProvider();
+    auto buffer_provider = query_mem_desc_.getBufferProvider();
     buffer_provider->copyFromDevice(
         &cpu_buffer[0], reinterpret_cast<const int8_t*>(varlen_ptr), length, device_id_);
     varlen_ptr = reinterpret_cast<int64_t>(&cpu_buffer[0]);

--- a/omniscidb/QueryEngine/ResultSetReductionJIT.cpp
+++ b/omniscidb/QueryEngine/ResultSetReductionJIT.cpp
@@ -579,7 +579,7 @@ ReductionCode ResultSetReductionJIT::codegen() const {
   // Always compile for count distinct aggregation
   if (query_mem_desc_.getCountDistinctDescriptorsSize() == 0 &&
       query_mem_desc_.getEntryCount() < INTERP_THRESHOLD &&
-      (!query_mem_desc_.getExecutor() || query_mem_desc_.blocksShareMemory())) {
+      (!query_mem_desc_.getDataMgr() || query_mem_desc_.blocksShareMemory())) {
     return reduction_code;
   }
   CHECK(executor_);

--- a/omniscidb/QueryEngine/TableFunctions/TableFunctionExecutionContext.cpp
+++ b/omniscidb/QueryEngine/TableFunctions/TableFunctionExecutionContext.cpp
@@ -460,8 +460,11 @@ ResultSetPtr TableFunctionExecutionContext::launchGpuCode(
   kernel_params[ERROR_BUFFER] =
       reinterpret_cast<CUdeviceptr>(gpu_allocator->alloc(sizeof(int32_t)));
   // initialize output memory
-  QueryMemoryDescriptor query_mem_desc(
-      executor, elem_count, QueryDescriptionType::Projection, /*is_table_function=*/true);
+  QueryMemoryDescriptor query_mem_desc(executor->getDataMgr(),
+                                       executor->getConfigPtr(),
+                                       elem_count,
+                                       QueryDescriptionType::Projection,
+                                       /*is_table_function=*/true);
   query_mem_desc.setOutputColumnar(true);
 
   for (size_t i = 0; i < num_out_columns; i++) {

--- a/omniscidb/QueryEngine/TableFunctions/TableFunctionManager.h
+++ b/omniscidb/QueryEngine/TableFunctions/TableFunctionManager.h
@@ -92,7 +92,8 @@ struct TableFunctionManager {
              size_t(-1));  // re-allocation of output buffers is not supported
     output_num_rows_ = output_num_rows;
     auto num_out_columns = get_ncols();
-    QueryMemoryDescriptor query_mem_desc(executor_,
+    QueryMemoryDescriptor query_mem_desc(executor_->getDataMgr(),
+                                         executor_->getConfigPtr(),
                                          output_num_rows,  // divide by row multiplier???
                                          QueryDescriptionType::Projection,
                                          /*is_table_function=*/true);


### PR DESCRIPTION
Remove Executor usages from QueryMemoryDescriptor.

This is achieved by two changes:
1. Use `DataMgr` instead of `Executor`
2. Move a big part of the `QueryMemoryDescriptor` code to `MemoryLayoutBuilder` and `QueryExecutionContext`. The goal is to make `QueryMemoryDescriptor` just a descriptor that shouldn't know about entities using and creating it.