### PR TITLE
ResultSet refactoring and clean-up [10/N]

### DIFF
--- a/omniscidb/QueryEngine/Execute.cpp
+++ b/omniscidb/QueryEngine/Execute.cpp
@@ -59,6 +59,7 @@
 #include "QueryEngine/OutputBufferInitialization.h"
 #include "QueryEngine/QueryRewrite.h"
 #include "QueryEngine/QueryTemplateGenerator.h"
+#include "QueryEngine/ResultSetReduction.h"
 #include "QueryEngine/ResultSetReductionJIT.h"
 #include "QueryEngine/RuntimeFunctions.h"
 #include "QueryEngine/SpeculativeTopN.h"
@@ -1246,12 +1247,18 @@ ResultSetPtr Executor::reduceMultiDeviceResultSets(
     reduced_results->initializeStorage();
     switch (query_mem_desc.getEffectiveKeyWidth()) {
       case 4:
-        first->getStorage()->moveEntriesToBuffer<int32_t>(
-            result_storage->getUnderlyingBuffer(), query_mem_desc.getEntryCount());
+        ResultSetReduction::moveEntriesToBuffer<int32_t>(
+            first->getStorage()->getQueryMemDesc(),
+            first->getStorage()->getUnderlyingBuffer(),
+            result_storage->getUnderlyingBuffer(),
+            query_mem_desc.getEntryCount());
         break;
       case 8:
-        first->getStorage()->moveEntriesToBuffer<int64_t>(
-            result_storage->getUnderlyingBuffer(), query_mem_desc.getEntryCount());
+        ResultSetReduction::moveEntriesToBuffer<int64_t>(
+            first->getStorage()->getQueryMemDesc(),
+            first->getStorage()->getUnderlyingBuffer(),
+            result_storage->getUnderlyingBuffer(),
+            query_mem_desc.getEntryCount());
         break;
       default:
         CHECK(false);
@@ -1274,10 +1281,12 @@ ResultSetPtr Executor::reduceMultiDeviceResultSets(
         (ResultSetStorage*)nullptr,
         [&](auto r, ResultSetStorage* res) {
           for (auto i = r.begin() + 1; i != r.end(); ++i) {
-            (*r.begin())->reduce(**i, {}, reduction_code, getConfig(), this);
+            ResultSetReduction::reduce(
+                **r.begin(), **i, {}, reduction_code, getConfig(), this);
           }
           if (res) {
-            res->reduce(*(*r.begin()), {}, reduction_code, getConfig(), this);
+            ResultSetReduction::reduce(
+                *res, *(*r.begin()), {}, reduction_code, getConfig(), this);
             return res;
           }
           return *r.begin();
@@ -1289,16 +1298,17 @@ ResultSetPtr Executor::reduceMultiDeviceResultSets(
           if (!rhs) {
             return lhs;
           }
-          lhs->reduce(*rhs, {}, reduction_code, getConfig(), this);
+          ResultSetReduction::reduce(*lhs, *rhs, {}, reduction_code, getConfig(), this);
           return lhs;
         });
   } else {
     for (size_t i = 1; i < results_per_device.size(); ++i) {
-      reduced_results->getStorage()->reduce(*(results_per_device[i].first->getStorage()),
-                                            {},
-                                            reduction_code,
-                                            getConfig(),
-                                            this);
+      ResultSetReduction::reduce(*reduced_results->getStorage(),
+                                 *(results_per_device[i].first->getStorage()),
+                                 {},
+                                 reduction_code,
+                                 getConfig(),
+                                 this);
     }
   }
   reduced_results->addCompilationQueueTime(compilation_queue_time);

--- a/omniscidb/QueryEngine/QueryExecutionContext.cpp
+++ b/omniscidb/QueryEngine/QueryExecutionContext.cpp
@@ -25,6 +25,7 @@
 #include "QueryMemoryInitializer.h"
 #include "RelAlgExecutionUnit.h"
 #include "ResultSet.h"
+#include "ResultSetReduction.h"
 #include "Shared/likely.h"
 #include "SpeculativeTopN.h"
 #include "StreamingTopN.h"
@@ -143,14 +144,14 @@ ResultSetPtr QueryExecutionContext::groupBufferToDeinterleavedResults(
     memcpy(&agg_vals[0],
            &executor_->plan_state_->init_agg_vals_[0],
            agg_col_count * sizeof(agg_vals[0]));
-    ResultSetStorage::reduceSingleRow(rows_ptr + bin_base_off,
-                                      executor_->warpSize(),
-                                      false,
-                                      true,
-                                      agg_vals,
-                                      query_mem_desc_,
-                                      result_set->getTargetInfos(),
-                                      executor_->plan_state_->init_agg_vals_);
+    ResultSetReduction::reduceSingleRow(rows_ptr + bin_base_off,
+                                        executor_->warpSize(),
+                                        false,
+                                        true,
+                                        agg_vals,
+                                        query_mem_desc_,
+                                        result_set->getTargetInfos(),
+                                        executor_->plan_state_->init_agg_vals_);
     for (size_t agg_idx = 0; agg_idx < agg_col_count;
          ++agg_idx, ++deinterleaved_buffer_idx) {
       deinterleaved_buffer[deinterleaved_buffer_idx] = agg_vals[agg_idx];

--- a/omniscidb/QueryEngine/ResultSetReduction.h
+++ b/omniscidb/QueryEngine/ResultSetReduction.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2023 Intel Corporation
+ * Copyright 2020 OmniSci, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "ResultSetStorage.h"
+
+struct ReductionCode;
+
+class ResultSetReduction {
+ public:
+  static void reduce(const ResultSetStorage& this_,
+                     const ResultSetStorage& that,
+                     const std::vector<std::string>& serialized_varlen_buffer,
+                     const ReductionCode& reduction_code,
+                     const Config& config,
+                     const Executor* executor);
+
+  // Reduces results for a single row when using interleaved bin layouts
+  static bool reduceSingleRow(const int8_t* row_ptr,
+                              const int8_t warp_count,
+                              const bool is_columnar,
+                              const bool replace_bitmap_ptr_with_bitmap_sz,
+                              std::vector<int64_t>& agg_vals,
+                              const QueryMemoryDescriptor& query_mem_desc,
+                              const std::vector<TargetInfo>& targets,
+                              const std::vector<int64_t>& agg_init_vals);
+
+  template <class KeyType>
+  static void moveEntriesToBuffer(const QueryMemoryDescriptor& query_mem_desc,
+                                  const int8_t* old_buff,
+                                  int8_t* new_buff,
+                                  const size_t new_entry_count);
+
+  template <class KeyType>
+  static void moveOneEntryToBuffer(const QueryMemoryDescriptor& query_mem_desc,
+                                   const size_t entry_index,
+                                   int64_t* new_buff_i64,
+                                   const size_t new_entry_count,
+                                   const size_t key_count,
+                                   const size_t row_qw_count,
+                                   const int64_t* src_buff,
+                                   const size_t key_byte_width);
+
+ private:
+  static void reduceOneEntryBaseline(const ResultSetStorage& this_,
+                                     const ResultSetStorage& that,
+                                     int8_t* this_buff,
+                                     const int8_t* that_buff,
+                                     const size_t that_entry_idx,
+                                     bool enable_dynamic_watchdog);
+  static void reduceOneEntrySlotsBaseline(const ResultSetStorage& this_,
+                                          const ResultSetStorage& that,
+                                          int64_t* this_entry_slots,
+                                          const int64_t* that_buff,
+                                          const size_t that_entry_idx);
+  static void reduceOneSlotBaseline(const ResultSetStorage& this_,
+                                    const ResultSetStorage& that,
+                                    int64_t* this_buff,
+                                    const size_t this_slot,
+                                    const int64_t* that_buff,
+                                    const size_t that_slot,
+                                    const TargetInfo& target_info,
+                                    const size_t target_logical_idx,
+                                    const size_t target_slot_idx,
+                                    const size_t init_agg_val_idx);
+  static void reduceEntriesNoCollisionsColWise(
+      const ResultSetStorage& this_,
+      const ResultSetStorage& that,
+      int8_t* this_buff,
+      const int8_t* that_buff,
+      const size_t start_index,
+      const size_t end_index,
+      const std::vector<std::string>& serialized_varlen_buffer,
+      const Executor* executor);
+  static void reduceOneSlot(const ResultSetStorage& this_,
+                            const ResultSetStorage& that,
+                            int8_t* this_ptr1,
+                            int8_t* this_ptr2,
+                            const int8_t* that_ptr1,
+                            const int8_t* that_ptr2,
+                            const TargetInfo& target_info,
+                            const size_t target_logical_idx,
+                            const size_t target_slot_idx,
+                            const size_t init_agg_val_idx,
+                            const size_t first_slot_idx_for_target,
+                            const std::vector<std::string>& serialized_varlen_buffer);
+  ALWAYS_INLINE
+  static void reduceOneSlotSingleValue(const QueryMemoryDescriptor& query_mem_desc,
+                                       int8_t* this_ptr1,
+                                       const TargetInfo& target_info,
+                                       const size_t target_slot_idx,
+                                       const int64_t init_val,
+                                       const int8_t* that_ptr1);
+  static void reduceOneApproxQuantileSlot(const QueryMemoryDescriptor& query_mem_desc,
+                                          int8_t* this_ptr1,
+                                          const int8_t* that_ptr1,
+                                          const size_t target_logical_idx);
+  static void reduceOneCountDistinctSlot(const ResultSetStorage& this_,
+                                         const ResultSetStorage& that,
+                                         int8_t* this_ptr1,
+                                         const int8_t* that_ptr1,
+                                         const size_t target_logical_idx);
+};

--- a/omniscidb/QueryEngine/ResultSetStorage.cpp
+++ b/omniscidb/QueryEngine/ResultSetStorage.cpp
@@ -26,11 +26,6 @@
 
 #include "DataMgr/Allocators/GpuAllocator.h"
 #include "DataMgr/BufferMgr/BufferMgr.h"
-#include "Execute.h"
-#include "GpuMemUtils.h"
-#include "InPlaceSort.h"
-#include "OutputBufferInitialization.h"
-#include "RuntimeFunctions.h"
 #include "Shared/SqlTypesLayout.h"
 #include "Shared/checked_alloc.h"
 #include "Shared/likely.h"

--- a/omniscidb/Tests/GpuSharedMemoryTest.cpp
+++ b/omniscidb/Tests/GpuSharedMemoryTest.cpp
@@ -17,6 +17,7 @@
 #include "GpuSharedMemoryTest.h"
 #include "QueryEngine/LLVMGlobalContext.h"
 #include "QueryEngine/OutputBufferInitialization.h"
+#include "QueryEngine/ResultSetReduction.h"
 #include "QueryEngine/ResultSetReductionJIT.h"
 
 extern bool g_is_test_env;
@@ -271,8 +272,12 @@ void perform_reduction_on_cpu(std::vector<std::unique_ptr<ResultSet>>& result_se
                                       executor.get());
   const auto reduction_code = reduction_jit.codegen();
   for (auto& result_set : result_sets) {
-    cpu_result_storage->reduce(
-        *(result_set->getStorage()), {}, reduction_code, config, executor.get());
+    ResultSetReduction::reduce(*cpu_result_storage,
+                               *(result_set->getStorage()),
+                               {},
+                               reduction_code,
+                               config,
+                               executor.get());
   }
 }
 

--- a/omniscidb/Tests/ResultSetTest.cpp
+++ b/omniscidb/Tests/ResultSetTest.cpp
@@ -29,6 +29,7 @@
 #include "QueryEngine/Descriptors/RowSetMemoryOwner.h"
 #include "QueryEngine/Execute.h"
 #include "QueryEngine/ResultSet.h"
+#include "QueryEngine/ResultSetReduction.h"
 #include "QueryEngine/ResultSetReductionJIT.h"
 #include "QueryEngine/RuntimeFunctions.h"
 #include "StringDictionary/StringDictionary.h"
@@ -2017,7 +2018,8 @@ TEST(MoreReduce, MissingValues) {
                                       config(),
                                       executor.get());
   const auto reduction_code = reduction_jit.codegen();
-  storage1->reduce(*storage2, {}, reduction_code, config(), executor.get());
+  ResultSetReduction::reduce(
+      *storage1, *storage2, {}, reduction_code, config(), executor.get());
   {
     const auto row = rs1->getNextRow(false, false);
     CHECK_EQ(size_t(2), row.size());
@@ -2089,7 +2091,8 @@ TEST(MoreReduce, MissingValuesKeyless) {
                                       config(),
                                       executor.get());
   const auto reduction_code = reduction_jit.codegen();
-  storage1->reduce(*storage2, {}, reduction_code, config(), executor.get());
+  ResultSetReduction::reduce(
+      *storage1, *storage2, {}, reduction_code, config(), executor.get());
   {
     const auto row = rs1->getNextRow(false, false);
     CHECK_EQ(size_t(2), row.size());
@@ -2180,8 +2183,12 @@ TEST(MoreReduce, OffsetRewrite) {
                                       config(),
                                       executor.get());
   const auto reduction_code = reduction_jit.codegen();
-  storage1->reduce(
-      *storage2, serialized_varlen_buffer, reduction_code, config(), executor.get());
+  ResultSetReduction::reduce(*storage1,
+                             *storage2,
+                             serialized_varlen_buffer,
+                             reduction_code,
+                             config(),
+                             executor.get());
   rs1->setSeparateVarlenStorageValid(true);
   {
     const auto row = rs1->getNextRow(false, false);


### PR DESCRIPTION
`ResultSetStorage` class has a lot of methods related to reduction. All implementations are actually in `ResultSetReduction.cpp`. To make `ResultSetStorage` class simpler and be unaware of `Executor`, `ReductionCode`, etc. I moved this code into a new `ResultSetReduction` class. Later `ResultSetStorage` will become a part of `ResultSet` library and reduction related code will be kept in `QueryEngine`.