### PR TITLE
ResultSet refactoring and clean-up [12/N]

### DIFF
--- a/omniscidb/DataMgr/StreamDecode.h
+++ b/omniscidb/DataMgr/StreamDecode.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
+template <typename T,
+          std::enable_if_t<!std::is_same<T, bool>::value && std::is_integral<T>::value,
+                           int> = 0>
+int64_t decodeInt(const int8_t* byte_stream, const int64_t pos) {
+  static_assert(sizeof(T) <= 8);
+#ifdef WITH_DECODERS_BOUNDS_CHECKING
+  assert(pos >= 0);
+#endif  // WITH_DECODERS_BOUNDS_CHECKING
+  return *(reinterpret_cast<const T*>(&byte_stream[pos * sizeof(T)]));
+}
+
+inline int64_t decodeInt(const int8_t* byte_stream, int32_t byte_width, int64_t pos) {
+  switch (byte_width) {
+    case 1:
+      return decodeInt<int8_t>(byte_stream, pos);
+    case 2:
+      return decodeInt<int16_t>(byte_stream, pos);
+    case 4:
+      return decodeInt<int32_t>(byte_stream, pos);
+    case 8:
+      return decodeInt<int64_t>(byte_stream, pos);
+    default:
+      return std::numeric_limits<int64_t>::min() + 1;
+  }
+}
+
+inline int64_t decodeUnsignedInt(const int8_t* byte_stream,
+                                 int32_t byte_width,
+                                 int64_t pos) {
+  switch (byte_width) {
+    case 1:
+      return decodeInt<uint8_t>(byte_stream, pos);
+    case 2:
+      return decodeInt<uint16_t>(byte_stream, pos);
+    case 4:
+      return decodeInt<uint32_t>(byte_stream, pos);
+    case 8:
+      return decodeInt<uint64_t>(byte_stream, pos);
+    default:
+      return std::numeric_limits<int64_t>::min() + 1;
+  }
+}
+
+int64_t decodeSmallDate(const int8_t* byte_stream,
+                        int32_t byte_width,
+                        int32_t null_val,
+                        int64_t ret_null_val,
+                        int64_t pos) {
+  auto val = decodeInt(byte_stream, byte_width, pos);
+  return val == null_val ? ret_null_val : val * 86400;
+}
+
+template <typename T, std::enable_if_t<std::is_floating_point<T>::value, int> = 0>
+T decodeFp(const int8_t* byte_stream, int64_t pos) {
+#ifdef WITH_DECODERS_BOUNDS_CHECKING
+  assert(pos >= 0);
+#endif  // WITH_DECODERS_BOUNDS_CHECKING
+  return *(reinterpret_cast<const T*>(&byte_stream[pos * sizeof(T)]));
+}

--- a/omniscidb/QueryEngine/RuntimeFunctions.h
+++ b/omniscidb/QueryEngine/RuntimeFunctions.h
@@ -17,6 +17,7 @@
 #ifndef QUERYENGINE_RUNTIMEFUNCTIONS_H
 #define QUERYENGINE_RUNTIMEFUNCTIONS_H
 
+#include "Shared/EmptyKeyValues.h"
 #include "Shared/funcannotations.h"
 
 #include <cstdint>
@@ -143,11 +144,6 @@ extern "C" RUNTIME_EXPORT void agg_min_float_skip_val(GENERIC_ADDR_SPACE int32_t
 extern "C" RUNTIME_EXPORT void agg_count_distinct_bitmap(GENERIC_ADDR_SPACE int64_t* agg,
                                                          const int64_t val,
                                                          const int64_t min_val);
-
-#define EMPTY_KEY_64 std::numeric_limits<int64_t>::max()
-#define EMPTY_KEY_32 std::numeric_limits<int32_t>::max()
-#define EMPTY_KEY_16 std::numeric_limits<int16_t>::max()
-#define EMPTY_KEY_8 std::numeric_limits<int8_t>::max()
 
 extern "C" RUNTIME_EXPORT uint32_t key_hash(GENERIC_ADDR_SPACE const int64_t* key,
                                             const uint32_t key_qw_count,
@@ -277,17 +273,5 @@ extern "C" RUNTIME_EXPORT GENERIC_ADDR_SPACE int8_t* extract_str_ptr_noinline(
     const uint64_t str_and_len);
 
 extern "C" RUNTIME_EXPORT int32_t extract_str_len_noinline(const uint64_t str_and_len);
-
-template <typename T = int64_t>
-inline T get_empty_key() {
-  static_assert(std::is_same<T, int64_t>::value,
-                "Unsupported template parameter other than int64_t for now");
-  return EMPTY_KEY_64;
-}
-
-template <>
-inline int32_t get_empty_key() {
-  return EMPTY_KEY_32;
-}
 
 #endif  // QUERYENGINE_RUNTIMEFUNCTIONS_H

--- a/omniscidb/Shared/EmptyKeyValues.h
+++ b/omniscidb/Shared/EmptyKeyValues.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2023 Intel Corporation
+ * Copyright 2017 MapD Technologies, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
+#define EMPTY_KEY_64 std::numeric_limits<int64_t>::max()
+#define EMPTY_KEY_32 std::numeric_limits<int32_t>::max()
+#define EMPTY_KEY_16 std::numeric_limits<int16_t>::max()
+#define EMPTY_KEY_8 std::numeric_limits<int8_t>::max()
+
+template <typename T = int64_t>
+inline T get_empty_key() {
+  static_assert(std::is_same<T, int64_t>::value,
+                "Unsupported template parameter other than int64_t for now");
+  return EMPTY_KEY_64;
+}
+
+template <>
+inline int32_t get_empty_key() {
+  return EMPTY_KEY_32;
+}


### PR DESCRIPTION
`ResultSetStorage` uses decoders from the runtime which makes it dependent on the `QueryEngine`. I added new decoders to be used in statically compiled code only to avoid this dependency.

Also, moved empty key declarations to Shared lib.