### PR TITLE
Added dependency on Logger and OSDependent libraries

### DIFF
--- a/omniscidb/CudaMgr/CMakeLists.txt
+++ b/omniscidb/CudaMgr/CMakeLists.txt
@@ -4,4 +4,4 @@ else()
     add_library(CudaMgr CudaMgrNoCuda.cpp)
 endif()
 
-target_link_libraries(CudaMgr ${CUDA_LIBRARIES})
+target_link_libraries(CudaMgr Logger ${CUDA_LIBRARIES})

--- a/omniscidb/L0Mgr/CMakeLists.txt
+++ b/omniscidb/L0Mgr/CMakeLists.txt
@@ -5,5 +5,5 @@ else()
 endif()
 
 add_library(L0Mgr ${L0_SOURCES})
-target_link_libraries(L0Mgr ${LevelZero_LIBRARIES})
+target_link_libraries(L0Mgr Logger ${LevelZero_LIBRARIES})
 

--- a/omniscidb/OSDependent/Windows/CMakeLists.txt
+++ b/omniscidb/OSDependent/Windows/CMakeLists.txt
@@ -1,1 +1,4 @@
 add_library(OSDependent ${OSDEPENDENT_SOURCE_FILES})
+set_target_properties(OSDependent PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/..)
+
+target_link_libraries(OSDependent Logger)

--- a/omniscidb/SqliteConnector/CMakeLists.txt
+++ b/omniscidb/SqliteConnector/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_library(SqliteConnector SqliteConnector.cpp SqliteConnector.h)
 
-target_link_libraries(SqliteConnector PUBLIC sqlite3 PRIVATE ${Boost_THREAD_LIBRARY})
+target_link_libraries(SqliteConnector PUBLIC sqlite3 PRIVATE Logger ${Boost_THREAD_LIBRARY})

--- a/omniscidb/UdfCompiler/CMakeLists.txt
+++ b/omniscidb/UdfCompiler/CMakeLists.txt
@@ -16,5 +16,5 @@ find_package(Clang REQUIRED)
 include_directories(${CLANG_INCLUDE_DIRS})
 add_definitions(${CLANG_DEFINITIONS})
 
-target_link_libraries(UdfCompiler Logger ${clang_libs})
+target_link_libraries(UdfCompiler OSDependent ${clang_libs})
 


### PR DESCRIPTION
Added explicit dependencies from Logger and OSDependent libraries. They are required on windows because unresolved symbols are not allowed.