### PR TITLE
Resolve cicular dependency from Analyzer to QueryEngine

### DIFF
--- a/omniscidb/Analyzer/Analyzer.cpp
+++ b/omniscidb/Analyzer/Analyzer.cpp
@@ -483,9 +483,10 @@ bool exprs_share_one_and_same_rte_idx(const hdk::ir::ExprPtr& lhs_expr,
   return collector.result().size() == 1ULL;
 }
 
-const hdk::ir::Type* get_str_dict_cast_type(const hdk::ir::Type* lhs_type,
-                                            const hdk::ir::Type* rhs_type,
-                                            const Executor* executor) {
+const hdk::ir::Type* get_str_dict_cast_type(
+    const hdk::ir::Type* lhs_type,
+    const hdk::ir::Type* rhs_type,
+    const StringDictionaryProxyProvider* executor) {
   CHECK(lhs_type->isExtDictionary());
   CHECK(rhs_type->isExtDictionary());
   const auto lhs_dict_id = lhs_type->as<hdk::ir::ExtDictionaryType>()->dictId();
@@ -511,7 +512,7 @@ const hdk::ir::Type* get_str_dict_cast_type(const hdk::ir::Type* lhs_type,
 
 const hdk::ir::Type* common_string_type(const hdk::ir::Type* type1,
                                         const hdk::ir::Type* type2,
-                                        const Executor* executor) {
+                                        const StringDictionaryProxyProvider* executor) {
   auto& ctx = type1->ctx();
   const hdk::ir::Type* common_type;
   auto nullable = type1->nullable() || type2->nullable();
@@ -542,7 +543,7 @@ hdk::ir::ExprPtr normalizeOperExpr(const hdk::ir::OpType optype,
                                    hdk::ir::Qualifier qual,
                                    hdk::ir::ExprPtr left_expr,
                                    hdk::ir::ExprPtr right_expr,
-                                   const Executor* executor) {
+                                   const StringDictionaryProxyProvider* executor) {
   if ((left_expr->type()->isDate() &&
        left_expr->type()->as<hdk::ir::DateType>()->unit() == hdk::ir::TimeUnit::kDay) ||
       (right_expr->type()->isDate() &&
@@ -658,7 +659,7 @@ hdk::ir::ExprPtr normalizeOperExpr(const hdk::ir::OpType optype,
 hdk::ir::ExprPtr normalizeCaseExpr(
     const std::list<std::pair<hdk::ir::ExprPtr, hdk::ir::ExprPtr>>& expr_pair_list,
     const hdk::ir::ExprPtr else_e_in,
-    const Executor* executor) {
+    const StringDictionaryProxyProvider* executor) {
   std::list<std::pair<hdk::ir::ExprPtr, hdk::ir::ExprPtr>> cast_expr_pair_list =
       expr_pair_list;
   const hdk::ir::Type* type = nullptr;

--- a/omniscidb/Analyzer/Analyzer.h
+++ b/omniscidb/Analyzer/Analyzer.h
@@ -27,6 +27,7 @@
 #include "SchemaMgr/ColumnInfo.h"
 #include "Shared/sqldefs.h"
 #include "Shared/sqltypes.h"
+#include "StringDictionary/StringDictionaryProxy.h"
 
 #include <cstdint>
 #include <iostream>
@@ -37,8 +38,6 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
-
-class Executor;
 
 namespace Analyzer {
 
@@ -55,16 +54,17 @@ hdk::ir::ExprPtr analyzeFixedPtValue(const int64_t numericval,
 
 hdk::ir::ExprPtr analyzeStringValue(const std::string& stringval);
 
-hdk::ir::ExprPtr normalizeOperExpr(hdk::ir::OpType optype,
-                                   hdk::ir::Qualifier qual,
-                                   hdk::ir::ExprPtr left_expr,
-                                   hdk::ir::ExprPtr right_expr,
-                                   const Executor* executor = nullptr);
+hdk::ir::ExprPtr normalizeOperExpr(
+    hdk::ir::OpType optype,
+    hdk::ir::Qualifier qual,
+    hdk::ir::ExprPtr left_expr,
+    hdk::ir::ExprPtr right_expr,
+    const StringDictionaryProxyProvider* executor = nullptr);
 
 hdk::ir::ExprPtr normalizeCaseExpr(
     const std::list<std::pair<hdk::ir::ExprPtr, hdk::ir::ExprPtr>>&,
     const hdk::ir::ExprPtr,
-    const Executor* executor = nullptr);
+    const StringDictionaryProxyProvider* executor = nullptr);
 
 hdk::ir::ExprPtr getLikeExpr(hdk::ir::ExprPtr arg_expr,
                              hdk::ir::ExprPtr like_expr,

--- a/omniscidb/Analyzer/CMakeLists.txt
+++ b/omniscidb/Analyzer/CMakeLists.txt
@@ -10,4 +10,4 @@ set(analyzer_source_files
 
 add_library(Analyzer ${analyzer_source_files})
 
-target_link_libraries(Analyzer IR SchemaMgr)
+target_link_libraries(Analyzer IR SchemaMgr StringDictionary)

--- a/omniscidb/QueryEngine/Execute.h
+++ b/omniscidb/QueryEngine/Execute.h
@@ -239,7 +239,7 @@ struct StreamExecutionContext {
       : ra_exe_unit(ra_exe_unit), co(co), eo(eo) {}
 };
 
-class Executor {
+class Executor : public StringDictionaryProxyProvider {
   static_assert(sizeof(float) == 4 && sizeof(double) == 8,
                 "Host hardware not supported, unexpected size of float / double.");
   static_assert(sizeof(time_t) == 8,
@@ -301,8 +301,9 @@ class Executor {
   /**
    * Returns a string dictionary proxy using the currently active row set memory owner.
    */
-  StringDictionaryProxy* getStringDictionaryProxy(const int dict_id,
-                                                  const bool with_generation) const {
+  virtual StringDictionaryProxy* getStringDictionaryProxy(
+      const int dict_id,
+      const bool with_generation) const {
     CHECK(row_set_mem_owner_);
     return getStringDictionaryProxy(dict_id, row_set_mem_owner_, with_generation);
   }

--- a/omniscidb/StringDictionary/StringDictionaryProxy.h
+++ b/omniscidb/StringDictionary/StringDictionaryProxy.h
@@ -255,4 +255,12 @@ class StringDictionaryProxy {
   friend class StringLocalCallback;
   friend class StringNetworkCallback;
 };
+
+class StringDictionaryProxyProvider {
+ public:
+  virtual StringDictionaryProxy* getStringDictionaryProxy(
+      const int dict_id,
+      const bool with_generation) const = 0;
+};
+
 #endif  // STRINGDICTIONARY_STRINGDICTIONARYPROXY_H


### PR DESCRIPTION
Use an abstract class with virtual function to resolve linking circular dependency between Analyzer and QueryEngine