### PR TITLE
Removed extern declaration to use declaration from Logger.h

### DIFF
--- a/omniscidb/Shared/measure.h
+++ b/omniscidb/Shared/measure.h
@@ -24,8 +24,6 @@
 
 #include "Logger/Logger.h"
 
-extern bool g_enable_debug_timer;
-
 template <typename TimeT = std::chrono::milliseconds>
 struct measure {
   template <typename F, typename... Args>

--- a/src/HDK.cpp
+++ b/src/HDK.cpp
@@ -16,8 +16,6 @@
 #include "QueryEngine/RelAlgExecutor.h"
 #include "Shared/Config.h"
 
-extern bool g_enable_debug_timer;
-
 // Stores objects needed for various endpoints. Allows us to avoid including all headers
 // in the externally available API header.
 struct Internal {


### PR DESCRIPTION
Remove local declarations to use declaration from Logger.h. On windows that declaration includes `__declspec(dllimport)` which is necessary for successful linking.