### PR TITLE
Removed field name from initializers because MSVC thinks it is C++20

### DIFF
--- a/omniscidb/QueryEngine/CostModel/DataSources/EmptyDataSource.cpp
+++ b/omniscidb/QueryEngine/CostModel/DataSources/EmptyDataSource.cpp
@@ -3,13 +3,12 @@
 namespace costmodel {
 
 EmptyDataSource::EmptyDataSource()
-    : DataSource(DataSourceConfig{
-          .dataSourceName = "EmptyDataSource",
-          .supportedDevices = {ExecutorDeviceType::CPU, ExecutorDeviceType::GPU},
-          .supportedTemplates = {AnalyticalTemplate::GroupBy,
-                                 AnalyticalTemplate::Join,
-                                 AnalyticalTemplate::Reduce,
-                                 AnalyticalTemplate::Scan}}) {}
+    : DataSource(DataSourceConfig{"EmptyDataSource",
+                                  {ExecutorDeviceType::CPU, ExecutorDeviceType::GPU},
+                                  {AnalyticalTemplate::GroupBy,
+                                   AnalyticalTemplate::Join,
+                                   AnalyticalTemplate::Reduce,
+                                   AnalyticalTemplate::Scan}}) {}
 
 Detail::DeviceMeasurements EmptyDataSource::getMeasurements(
     const std::vector<ExecutorDeviceType>& devices,

--- a/omniscidb/QueryEngine/CostModel/ExtrapolationModels/LinearExtrapolation.cpp
+++ b/omniscidb/QueryEngine/CostModel/ExtrapolationModels/LinearExtrapolation.cpp
@@ -19,7 +19,7 @@ namespace costmodel {
 
 size_t LinearExtrapolation::getExtrapolatedData(size_t bytes) {
   size_t id1, id2;
-  Detail::Measurement tmp = {.bytes = bytes, .milliseconds = 0};
+  Detail::Measurement tmp = {bytes, 0};
 
   auto iter =
       std::upper_bound(measurement.begin(), measurement.end(), tmp, Detail::BytesOrder());

--- a/omniscidb/Tests/CostModel/CostModelTest.cpp
+++ b/omniscidb/Tests/CostModel/CostModelTest.cpp
@@ -21,10 +21,9 @@ using namespace costmodel;
 class DataSourceTest : public DataSource {
  public:
   DataSourceTest()
-      : DataSource(
-            DataSourceConfig{.dataSourceName = "DataSourceTest",
-                             .supportedDevices = {ExecutorDeviceType::CPU},
-                             .supportedTemplates = {AnalyticalTemplate::GroupBy}}) {}
+      : DataSource(DataSourceConfig{"DataSourceTest",
+                                    {ExecutorDeviceType::CPU},
+                                    {AnalyticalTemplate::GroupBy}}) {}
 
   Detail::DeviceMeasurements getMeasurements(
       const std::vector<ExecutorDeviceType>& devices,
@@ -44,9 +43,9 @@ TEST(DataSourceTests, SupportCheckTest) {
 
 TEST(ExtrapolationModelsTests, LinearExtrapolationTest1) {
   LinearExtrapolation le{{
-      {.bytes = 10, .milliseconds = 100},
-      {.bytes = 20, .milliseconds = 200},
-      {.bytes = 30, .milliseconds = 300},
+      {10, 100},
+      {20, 200},
+      {30, 300},
   }};
 
   ASSERT_EQ(le.getExtrapolatedData(15), (size_t)150);


### PR DESCRIPTION
MSVC on windows doesn't allow specifying field names like this. It complains that this is a part of C++20 but enabling C++20 breaks a lot of code.