### PR TITLE
Disable check for minimum CLANG version in STL headers on windows

### DIFF
--- a/omniscidb/QueryEngine/DateAdd.cpp
+++ b/omniscidb/QueryEngine/DateAdd.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef _MSC_VER
+#define _ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
+#endif
+
 #include "ExtractFromTime.h"
 #include "IR/DateTimeEnums.h"
 #include "Shared/funcannotations.h"

--- a/omniscidb/QueryEngine/DateTruncate.cpp
+++ b/omniscidb/QueryEngine/DateTruncate.cpp
@@ -18,6 +18,10 @@
  * http://howardhinnant.github.io/date_algorithms.html
  */
 
+#ifdef _MSC_VER
+#define _ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
+#endif
+
 #include "DateTruncate.h"
 #include "ExtractFromTime.h"
 

--- a/omniscidb/QueryEngine/ExtensionFunctions.hpp
+++ b/omniscidb/QueryEngine/ExtensionFunctions.hpp
@@ -1,4 +1,9 @@
 #include "../Shared/funcannotations.h"
+
+#ifdef _MSC_VER
+#define _ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
+#endif
+
 #ifndef __CUDACC__
 #include <cstdint>
 

--- a/omniscidb/QueryEngine/ExtractFromTime.cpp
+++ b/omniscidb/QueryEngine/ExtractFromTime.cpp
@@ -19,6 +19,10 @@
  * http://howardhinnant.github.io/date_algorithms.html
  */
 
+#ifdef _MSC_VER
+#define _ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
+#endif
+
 #include "ExtractFromTime.h"
 
 #include <cmath>

--- a/omniscidb/QueryEngine/RuntimeFunctions.cpp
+++ b/omniscidb/QueryEngine/RuntimeFunctions.cpp
@@ -18,6 +18,10 @@
 #error This code is not intended to be compiled with a CUDA C++ compiler
 #endif  // __CUDACC__
 
+#ifdef _MSC_VER
+#define _ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
+#endif
+
 #include "RuntimeFunctions.h"
 #include "HyperLogLogRank.h"
 #include "MurmurHash.h"


### PR DESCRIPTION
The latest release of MSVC comes with clang-15 therefore they built in a check in STL headers that clang version should not be lower than 15. We currently use clang-14, so this define is necessary to successfully compile sources with clang-14.