### PR TITLE
ResultSet refactoring and clean-up [13/N]

### DIFF
--- a/omniscidb/ConfigBuilder/ConfigBuilder.cpp
+++ b/omniscidb/ConfigBuilder/ConfigBuilder.cpp
@@ -166,6 +166,15 @@ bool ConfigBuilder::parseCommandLineArgs(int argc,
       po::value<size_t>(&config_->exec.group_by.baseline_threshold)
           ->default_value(config_->exec.group_by.baseline_threshold),
       "Prefer baseline hash if number of entries exceeds this threshold.");
+  opt_desc.add_options()("large-ndv-threshold",
+                         po::value<int64_t>(&config_->exec.group_by.large_ndv_threshold)
+                             ->default_value(config_->exec.group_by.large_ndv_threshold),
+                         "Value range threshold at which large NDV estimator is used.");
+  opt_desc.add_options()(
+      "large-ndv-multiplier",
+      po::value<size_t>(&config_->exec.group_by.large_ndv_multiplier)
+          ->default_value(config_->exec.group_by.large_ndv_multiplier),
+      "A multiplier applied to NDV estimator buffer size for large ranges.");
 
   // exec.window
   opt_desc.add_options()("enable-window-functions",

--- a/omniscidb/IR/CardinalityEstimator.h
+++ b/omniscidb/IR/CardinalityEstimator.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2023 Intel Corporation
+ * Copyright 2017 MapD Technologies, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "Expr.h"
+
+namespace hdk::ir {
+
+/*
+ * @type  Estimator
+ * @brief Infrastructure to define estimators which take an expression tuple, are called
+ * for every row and need a buffer to track state.
+ */
+class Estimator : public Expr {
+ public:
+  Estimator() : Expr(Context::defaultCtx().int32(false)){};
+
+  // The tuple argument received by the estimator for every row.
+  virtual const ExprPtrList& getArgument() const = 0;
+
+  // The size of the working buffer used by the estimator.
+  virtual size_t getBufferSize() const = 0;
+
+  // The name for the estimator runtime function which is called for every row.
+  // The runtime function will receive four arguments:
+  //   uint8_t* the pointer to the beginning of the estimator buffer
+  //   uint32_t the size of the estimator buffer, in bytes
+  //   uint8_t* the concatenated bytes for the argument tuple
+  //   uint32_t the size of the argument tuple, in bytes
+  virtual std::string getRuntimeFunctionName() const = 0;
+
+  ExprPtr withType(const Type* new_type) const override {
+    CHECK(false);
+    return nullptr;
+  }
+
+  bool operator==(const Expr& rhs) const override {
+    CHECK(false);
+    return false;
+  }
+
+  std::string toString() const override {
+    CHECK(false);
+    return "";
+  }
+};
+
+/*
+ * @type  NDVEstimator
+ * @brief Provides an estimate for the number of distinct tuples. Not a real
+ *        expression, it's only used in execution units synthesized
+ *        for the cardinality estimation before running an user-provided query.
+ */
+class NDVEstimator : public Estimator {
+ public:
+  NDVEstimator(const hdk::ir::ExprPtrList& expr_tuple, size_t buffer_size_multiplier)
+      : expr_tuple_(expr_tuple), buffer_size_multiplier_(buffer_size_multiplier) {}
+
+  const hdk::ir::ExprPtrList& getArgument() const override { return expr_tuple_; }
+
+  size_t getBufferSize() const override { return 1024 * 1024 * buffer_size_multiplier_; }
+
+  std::string getRuntimeFunctionName() const override {
+    return "linear_probabilistic_count";
+  }
+
+ private:
+  const hdk::ir::ExprPtrList expr_tuple_;
+  size_t buffer_size_multiplier_;
+};
+
+}  // namespace hdk::ir

--- a/omniscidb/QueryEngine/Compiler/Backend.cpp
+++ b/omniscidb/QueryEngine/Compiler/Backend.cpp
@@ -17,6 +17,7 @@
 
 #include "QueryEngine/CodeGenerator.h"
 #include "QueryEngine/ExecutionEngineWrapper.h"
+#include "QueryEngine/ExtensionFunctionsWhitelist.h"
 
 #include <llvm/IR/DebugInfo.h>
 #include <llvm/IR/InstIterator.h>

--- a/omniscidb/QueryEngine/Execute.cpp
+++ b/omniscidb/QueryEngine/Execute.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "QueryEngine/Execute.h"
+#include "CardinalityEstimator.h"
 
 #include <llvm/Transforms/Utils/BasicBlockUtils.h>
 #include <boost/filesystem/operations.hpp>

--- a/omniscidb/QueryEngine/RelAlgExecutionUnit.h
+++ b/omniscidb/QueryEngine/RelAlgExecutionUnit.h
@@ -107,12 +107,9 @@ namespace hdk::ir {
 class Expr;
 class ColumnVar;
 struct OrderEntry;
+class Estimator;
 
 }  // namespace hdk::ir
-
-namespace Analyzer {
-class Estimator;
-}
 
 struct SortInfo {
   std::list<hdk::ir::OrderEntry> order_entries;
@@ -136,7 +133,7 @@ struct RelAlgExecutionUnit {
   const JoinQualsPerNestingLevel join_quals;
   const std::list<hdk::ir::ExprPtr> groupby_exprs;
   std::vector<const hdk::ir::Expr*> target_exprs;
-  const std::shared_ptr<Analyzer::Estimator> estimator;
+  const std::shared_ptr<hdk::ir::Estimator> estimator;
   const SortInfo sort_info;
   size_t scan_limit;
   QueryPlan query_plan_dag{EMPTY_QUERY_PLAN};

--- a/omniscidb/QueryEngine/ResultSet.cpp
+++ b/omniscidb/QueryEngine/ResultSet.cpp
@@ -113,7 +113,7 @@ ResultSet::ResultSet(const std::vector<TargetInfo>& targets,
     , for_validation_only_(false)
     , cached_row_count_(uninitialized_cached_row_count) {}
 
-ResultSet::ResultSet(const std::shared_ptr<const Analyzer::Estimator> estimator,
+ResultSet::ResultSet(const std::shared_ptr<const hdk::ir::Estimator> estimator,
                      const ExecutorDeviceType device_type,
                      const int device_id,
                      Data_Namespace::DataMgr* data_mgr)
@@ -989,7 +989,7 @@ std::vector<size_t> ResultSet::getSlotIndicesForTargetIndices() const {
 }
 
 size_t ResultSet::getNDVEstimator() const {
-  CHECK(dynamic_cast<const Analyzer::NDVEstimator*>(estimator_.get()));
+  CHECK(dynamic_cast<const hdk::ir::NDVEstimator*>(estimator_.get()));
   CHECK(host_estimator_buffer_);
   auto bits_set = bitmap_set_size(host_estimator_buffer_, estimator_->getBufferSize());
   if (bits_set == 0) {

--- a/omniscidb/QueryEngine/ResultSet.h
+++ b/omniscidb/QueryEngine/ResultSet.h
@@ -27,8 +27,8 @@
 
 #include <boost/optional/optional_io.hpp>
 #include "BufferProvider/BufferProvider.h"
-#include "CardinalityEstimator.h"
 #include "DataMgr/Chunk/Chunk.h"
+#include "IR/CardinalityEstimator.h"
 #include "ResultSetBufferAccessors.h"
 #include "ResultSetStorage.h"
 #include "Shared/quantile.h"
@@ -183,7 +183,7 @@ class ResultSet {
             const unsigned block_size,
             const unsigned grid_size);
 
-  ResultSet(const std::shared_ptr<const Analyzer::Estimator>,
+  ResultSet(const std::shared_ptr<const hdk::ir::Estimator>,
             const ExecutorDeviceType device_type,
             const int device_id,
             Data_Namespace::DataMgr* data_mgr);
@@ -770,7 +770,7 @@ class ResultSet {
   std::vector<std::vector<std::vector<int64_t>>> frag_offsets_;
   std::vector<std::vector<int64_t>> consistent_frag_sizes_;
 
-  const std::shared_ptr<const Analyzer::Estimator> estimator_;
+  const std::shared_ptr<const hdk::ir::Estimator> estimator_;
   Data_Namespace::AbstractBuffer* device_estimator_buffer_{nullptr};
   mutable int8_t* host_estimator_buffer_{nullptr};
   Data_Namespace::DataMgr* data_mgr_{nullptr};

--- a/omniscidb/QueryEngine/WorkUnitBuilder.h
+++ b/omniscidb/QueryEngine/WorkUnitBuilder.h
@@ -133,7 +133,7 @@ class WorkUnitBuilder {
   JoinQualsPerNestingLevel join_quals_;
   std::list<hdk::ir::ExprPtr> groupby_exprs_;
   std::vector<ir::ExprPtrVector> target_exprs_;
-  std::shared_ptr<Analyzer::Estimator> estimator_;
+  std::shared_ptr<hdk::ir::Estimator> estimator_;
   SortInfo sort_info_ = {{}, SortAlgorithm::Default, 0, 0};
   size_t scan_limit_ = 0;
   QueryPlan query_plan_dag_ = EMPTY_QUERY_PLAN;

--- a/omniscidb/Shared/Config.h
+++ b/omniscidb/Shared/Config.h
@@ -48,6 +48,8 @@ struct GroupByConfig {
   size_t gpu_smem_threshold = 4096;
   unsigned hll_precision_bits = 11;
   size_t baseline_threshold = 1'000'000;
+  int64_t large_ndv_threshold = 10'000'000;
+  size_t large_ndv_multiplier = 256;
 };
 
 struct WindowFunctionsConfig {

--- a/omniscidb/Tests/GroupByTest.cpp
+++ b/omniscidb/Tests/GroupByTest.cpp
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-#include "ArrowSQLRunner/ArrowSQLRunner.h"
 #include "TestHelpers.h"
+
+#include "ArrowSQLRunner/ArrowSQLRunner.h"
+#include "DataMgr/DataMgrBufferProvider.h"
+#include "DataMgr/DataMgrDataProvider.h"
+#include "QueryEngine/CardinalityEstimator.h"
+#include "QueryEngine/Execute.h"
+#include "QueryEngine/InputMetadata.h"
 
 #include <boost/filesystem.hpp>
 #include <fstream>
-
-#include "../QueryEngine/Execute.h"
-#include "../QueryEngine/InputMetadata.h"
-
-#include "DataMgr/DataMgrBufferProvider.h"
-#include "DataMgr/DataMgrDataProvider.h"
 
 extern bool g_is_test_env;
 

--- a/omniscidb/Utils/CommandLineOptions.cpp
+++ b/omniscidb/Utils/CommandLineOptions.cpp
@@ -32,8 +32,6 @@
 
 bool g_use_table_device_offset;  // TODO(adb): where did this go?
 extern bool g_cache_string_hash;
-extern int64_t g_large_ndv_threshold;
-extern size_t g_large_ndv_multiplier;
 extern int64_t g_bitmap_memory_limit;
 extern size_t g_approx_quantile_buffer;
 extern size_t g_approx_quantile_centroids;
@@ -235,12 +233,6 @@ void CommandLineOptions::fillAdvancedOptions() {
                                po::value<std::vector<std::string>>(&udf_compiler_options),
                                "Specify compiler options to tailor udf compilation.");
 
-  developer_desc.add_options()(
-      "large-ndv-threshold",
-      po::value<int64_t>(&g_large_ndv_threshold)->default_value(g_large_ndv_threshold));
-  developer_desc.add_options()(
-      "large-ndv-multiplier",
-      po::value<size_t>(&g_large_ndv_multiplier)->default_value(g_large_ndv_multiplier));
   developer_desc.add_options()("approx_quantile_buffer",
                                po::value<size_t>(&g_approx_quantile_buffer)
                                    ->default_value(g_approx_quantile_buffer));


### PR DESCRIPTION
Move the cardinality expression to IR. Also, move related global flags to `Config`. Also, a single estimator implementation is enough, for now, the large version adds nothing new.

It reveals some implementation details to IR level, but otherwise, we cannot interpret `ResultSet` with estimator results without a dependency on `QueryEngine`. I think having estimator expressions in IR is better.