### PR TITLE
ResultSet refactoring and clean-up [16/N]

### DIFF
--- a/omniscidb/QueryEngine/ResultSet.h
+++ b/omniscidb/QueryEngine/ResultSet.h
@@ -603,6 +603,13 @@ class ResultSet {
 
   Data_Namespace::DataMgr* getDataManager() const { return data_mgr_; }
 
+  // only used by serialization
+  using SerializedVarlenBufferStorage = std::vector<std::string>;
+
+  const std::vector<SerializedVarlenBufferStorage>& getSerializedVarlenBuffer() const {
+    return serialized_varlen_buffer_;
+  }
+
  private:
   void advanceCursorToNextEntry(ResultSetRowIterator& iter) const;
 
@@ -769,9 +776,6 @@ class ResultSet {
   mutable int8_t* host_estimator_buffer_{nullptr};
   Data_Namespace::DataMgr* data_mgr_{nullptr};
 
-  // only used by serialization
-  using SerializedVarlenBufferStorage = std::vector<std::string>;
-
   std::vector<SerializedVarlenBufferStorage> serialized_varlen_buffer_;
   bool separate_varlen_storage_valid_;
   std::string explanation_;
@@ -780,7 +784,6 @@ class ResultSet {
   mutable std::atomic<int64_t> cached_row_count_;
   mutable std::mutex row_iteration_mutex_;
 
-  friend class ResultSetManager;
   friend class ResultSetRowIterator;
   friend class ColumnarResults;
 };
@@ -809,18 +812,6 @@ inline ResultSetRowIterator& ResultSetRowIterator::operator++(void) {
   }
   return *this;
 }
-
-class ResultSetManager {
- public:
-  ResultSet* reduce(std::vector<ResultSet*>&, const Config& config, Executor* executor);
-
-  std::shared_ptr<ResultSet> getOwnResultSet();
-
-  void rewriteVarlenAggregates(ResultSet*);
-
- private:
-  std::shared_ptr<ResultSet> rs_;
-};
 
 class RowSortException : public std::runtime_error {
  public:

--- a/omniscidb/QueryEngine/ResultSetReduction.cpp
+++ b/omniscidb/QueryEngine/ResultSetReduction.cpp
@@ -905,12 +905,12 @@ ResultSet* ResultSetManager::reduce(std::vector<ResultSet*>& result_sets,
                                     Executor* executor) {
   CHECK(!result_sets.empty());
   auto result_rs = result_sets.front();
-  CHECK(result_rs->storage_);
-  auto& first_result = *result_rs->storage_;
+  CHECK(result_rs->getStorage());
+  auto& first_result = *result_rs->getStorage();
   auto result = &first_result;
-  const auto row_set_mem_owner = result_rs->row_set_mem_owner_;
+  const auto row_set_mem_owner = result_rs->getRowSetMemOwner();
   for (const auto result_set : result_sets) {
-    CHECK_EQ(row_set_mem_owner, result_set->row_set_mem_owner_);
+    CHECK_EQ(row_set_mem_owner, result_set->getRowSetMemOwner());
   }
   if (first_result.query_mem_desc_.getQueryDescriptionType() ==
       QueryDescriptionType::GroupByBaselineHash) {
@@ -919,7 +919,7 @@ ResultSet* ResultSetManager::reduce(std::vector<ResultSet*>& result_sets,
                         result_sets.end(),
                         size_t(0),
                         [](const size_t init, const ResultSet* rs) {
-                          return init + rs->query_mem_desc_.getEntryCount();
+                          return init + rs->getQueryMemDesc().getEntryCount();
                         });
     CHECK(total_entry_count);
     auto query_mem_desc = first_result.query_mem_desc_;
@@ -928,7 +928,7 @@ ResultSet* ResultSetManager::reduce(std::vector<ResultSet*>& result_sets,
                             ExecutorDeviceType::CPU,
                             query_mem_desc,
                             row_set_mem_owner,
-                            result_rs->data_mgr_,
+                            result_rs->getDataManager(),
                             0,
                             0));
     auto result_storage = rs_->allocateStorage(first_result.target_init_vals_);
@@ -951,19 +951,18 @@ ResultSet* ResultSetManager::reduce(std::vector<ResultSet*>& result_sets,
       default:
         CHECK(false);
     }
-    result = rs_->storage_.get();
+    result = rs_->getStorage();
     result_rs = rs_.get();
   }
 
-  auto& serialized_varlen_buffer = result_sets.front()->serialized_varlen_buffer_;
+  auto serialized_varlen_buffer = result_sets.front()->getSerializedVarlenBuffer();
   if (!serialized_varlen_buffer.empty()) {
     result->rewriteAggregateBufferOffsets(serialized_varlen_buffer.front());
     for (auto result_it = result_sets.begin() + 1; result_it != result_sets.end();
          ++result_it) {
-      auto& result_serialized_varlen_buffer = (*result_it)->serialized_varlen_buffer_;
+      auto& result_serialized_varlen_buffer = (*result_it)->getSerializedVarlenBuffer();
       CHECK_EQ(result_serialized_varlen_buffer.size(), size_t(1));
-      serialized_varlen_buffer.emplace_back(
-          std::move(result_serialized_varlen_buffer.front()));
+      serialized_varlen_buffer.emplace_back(result_serialized_varlen_buffer.front());
     }
   }
 
@@ -978,14 +977,14 @@ ResultSet* ResultSetManager::reduce(std::vector<ResultSet*>& result_sets,
        ++result_it) {
     if (!serialized_varlen_buffer.empty()) {
       ResultSetReduction::reduce(*result,
-                                 *((*result_it)->storage_),
+                                 *((*result_it)->getStorage()),
                                  serialized_varlen_buffer[ctr++],
                                  reduction_code,
                                  config,
                                  executor);
     } else {
       ResultSetReduction::reduce(
-          *result, *((*result_it)->storage_), {}, reduction_code, config, executor);
+          *result, *((*result_it)->getStorage()), {}, reduction_code, config, executor);
     }
   }
   return result_rs;
@@ -996,9 +995,9 @@ std::shared_ptr<ResultSet> ResultSetManager::getOwnResultSet() {
 }
 
 void ResultSetManager::rewriteVarlenAggregates(ResultSet* result_rs) {
-  auto& result_storage = result_rs->storage_;
+  auto result_storage = result_rs->getStorage();
   result_storage->rewriteAggregateBufferOffsets(
-      result_rs->serialized_varlen_buffer_.front());
+      result_rs->getSerializedVarlenBuffer().front());
 }
 
 #define AGGREGATE_ONE_VALUE(                                                      \

--- a/omniscidb/QueryEngine/ResultSetReduction.h
+++ b/omniscidb/QueryEngine/ResultSetReduction.h
@@ -106,3 +106,15 @@ class ResultSetReduction {
                                          const int8_t* that_ptr1,
                                          const size_t target_logical_idx);
 };
+
+class ResultSetManager {
+ public:
+  ResultSet* reduce(std::vector<ResultSet*>&, const Config& config, Executor* executor);
+
+  std::shared_ptr<ResultSet> getOwnResultSet();
+
+  void rewriteVarlenAggregates(ResultSet*);
+
+ private:
+  std::shared_ptr<ResultSet> rs_;
+};

--- a/omniscidb/Tests/ProfileTest.cpp
+++ b/omniscidb/Tests/ProfileTest.cpp
@@ -33,6 +33,7 @@
 #include "DataMgr/Allocators/ArenaAllocator.h"
 #include "QueryEngine/Descriptors/RowSetMemoryOwner.h"
 #include "QueryEngine/ResultSet.h"
+#include "QueryEngine/ResultSetReduction.h"
 #include "Shared/measure.h"
 #include "Shared/thread_count.h"
 #include "Tests/TestHelpers.h"


### PR DESCRIPTION
Move `ResultSetManager` declaration and remove it from `ResultSet` friends.