### PR TITLE
ResultSet refactoring and clean-up [17/N]

### DIFF
--- a/omniscidb/QueryEngine/Descriptors/QueryMemoryDescriptor.h
+++ b/omniscidb/QueryEngine/Descriptors/QueryMemoryDescriptor.h
@@ -53,7 +53,6 @@ class BufferProvider;
 class QueryExecutionContext;
 class RowSetMemoryOwner;
 struct InputTableInfo;
-struct RelAlgExecutionUnit;
 class TResultSetBufferDescriptor;
 struct ColRangeInfo;
 
@@ -77,8 +76,9 @@ class QueryMemoryDescriptor {
   // constructor for init call
   QueryMemoryDescriptor(Data_Namespace::DataMgr* data_mgr,
                         ConfigPtr config,
-                        const RelAlgExecutionUnit& ra_exe_unit,
                         const std::vector<InputTableInfo>& query_infos,
+                        const bool use_bump_allocator,
+                        const bool approx_quantile,
                         const bool allow_multifrag,
                         const bool keyless_hash,
                         const bool interleaved_bins_on_gpu,
@@ -108,23 +108,6 @@ class QueryMemoryDescriptor {
                         const std::vector<int8_t>& group_col_widths);
 
   bool operator==(const QueryMemoryDescriptor& other) const;
-
-  static std::unique_ptr<QueryMemoryDescriptor> init(
-      Data_Namespace::DataMgr* data_mgr,
-      ConfigPtr config,
-      const RelAlgExecutionUnit& ra_exe_unit,
-      const std::vector<InputTableInfo>& query_infos,
-      const ColRangeInfo& col_range_info,
-      const KeylessInfo& keyless_info,
-      const bool allow_multifrag,
-      const ExecutorDeviceType device_type,
-      const int8_t crt_min_byte_width,
-      const bool sort_on_gpu_hint,
-      const size_t max_groups_buffer_entry_count,
-      const CountDistinctDescriptors count_distinct_descriptors,
-      const bool must_use_baseline_sort,
-      const bool output_columnar_hint,
-      const bool streaming_top_n_hint);
 
   static bool many_entries(const int64_t max_val,
                            const int64_t min_val,
@@ -263,7 +246,7 @@ class QueryMemoryDescriptor {
   size_t getKeyCount() const { return keyless_hash_ ? 0 : getGroupbyColCount(); }
   size_t getBufferColSlotCount() const;
 
-  size_t getBufferSizeBytes(const RelAlgExecutionUnit& ra_exe_unit,
+  size_t getBufferSizeBytes(const size_t max_rows,
                             const unsigned thread_count,
                             const ExecutorDeviceType device_type) const;
   size_t getBufferSizeBytes(const ExecutorDeviceType device_type) const;

--- a/omniscidb/QueryEngine/QueryMemoryInitializer.cpp
+++ b/omniscidb/QueryEngine/QueryMemoryInitializer.cpp
@@ -297,8 +297,9 @@ QueryMemoryInitializer::QueryMemoryInitializer(
                           query_mem_desc.getRowSize();
     }
   } else {
+    size_t max_rows = ra_exe_unit.sort_info.offset + ra_exe_unit.sort_info.limit;
     group_buffer_size =
-        query_mem_desc.getBufferSizeBytes(ra_exe_unit, thread_count, device_type);
+        query_mem_desc.getBufferSizeBytes(max_rows, thread_count, device_type);
   }
   CHECK_GE(group_buffer_size, size_t(0));
 
@@ -1288,10 +1289,11 @@ void QueryMemoryInitializer::applyStreamingTopNOffsetCpu(
   const size_t buffer_start_idx = query_mem_desc.hasVarlenOutput() ? 1 : 0;
   CHECK_EQ(group_by_buffers_.size(), buffer_start_idx + 1);
 
+  size_t max_rows = ra_exe_unit.sort_info.offset + ra_exe_unit.sort_info.limit;
   const auto rows_copy = streaming_top_n::get_rows_copy_from_heaps(
       group_by_buffers_[buffer_start_idx],
-      query_mem_desc.getBufferSizeBytes(ra_exe_unit, 1, ExecutorDeviceType::CPU),
-      ra_exe_unit.sort_info.offset + ra_exe_unit.sort_info.limit,
+      query_mem_desc.getBufferSizeBytes(max_rows, 1, ExecutorDeviceType::CPU),
+      max_rows,
       1);
   CHECK_EQ(rows_copy.size(),
            query_mem_desc.getEntryCount() * query_mem_desc.getRowSize());

--- a/omniscidb/QueryEngine/StreamingTopN.cpp
+++ b/omniscidb/QueryEngine/StreamingTopN.cpp
@@ -82,8 +82,7 @@ std::vector<int8_t> pick_top_n_rows_from_dev_heaps(
   return pop_n_rows_from_merged_heaps_gpu(
       buffer_provider,
       dev_heaps_buffer,
-      query_mem_desc.getBufferSizeBytes(
-          ra_exe_unit, thread_count, ExecutorDeviceType::GPU),
+      query_mem_desc.getBufferSizeBytes(n, thread_count, ExecutorDeviceType::GPU),
       n,
       pod_oe,
       oe_layout,


### PR DESCRIPTION
Remove RelAlgExecutionUnit usage in QueryMemoryDescriptor.