### PR TITLE
Add projections after joins.

### DIFF
--- a/omniscidb/QueryEngine/RelAlgDagBuilder.h
+++ b/omniscidb/QueryEngine/RelAlgDagBuilder.h
@@ -108,3 +108,5 @@ inline InputColDescriptor column_var_to_descriptor(const hdk::ir::ColumnVar* var
 hdk::ir::ExprPtrVector getInputExprsForAgg(const hdk::ir::Node* node);
 
 bool hasWindowFunctionExpr(const hdk::ir::Project* node);
+
+void insert_join_projections(std::vector<hdk::ir::NodePtr>& nodes);

--- a/omniscidb/Tests/TestRelAlgDagBuilder.h
+++ b/omniscidb/Tests/TestRelAlgDagBuilder.h
@@ -14,6 +14,7 @@
 
 #include "IR/LeftDeepInnerJoin.h"
 #include "QueryEngine/RelAlgDagBuilder.h"
+#include "QueryEngine/RelAlgOptimizer.h"
 
 class TestRelAlgDagBuilder : public hdk::ir::QueryDag {
  public:
@@ -108,6 +109,9 @@ class TestRelAlgDagBuilder : public hdk::ir::QueryDag {
   void finalize() {
     if (config_->exec.use_legacy_work_unit_builder) {
       hdk::ir::create_left_deep_join(nodes_);
+    } else {
+      insert_join_projections(nodes_);
+      eliminate_dead_columns(nodes_);
     }
     setRoot(nodes_.back());
   }


### PR DESCRIPTION
It looks like Calcite can remove projections after joins in the case of nested joins. In this case, join can become an execution point, which we don't handle well. Instead of supporting join as a valid execution point, I decided to add additional projections because it allows the exclusion of unused columns from the intermediate result set.

This resolves #253 