### PR TITLE
Introduce --null-mod-by-zero config flag.

### DIFF
--- a/omniscidb/ConfigBuilder/ConfigBuilder.cpp
+++ b/omniscidb/ConfigBuilder/ConfigBuilder.cpp
@@ -285,6 +285,12 @@ bool ConfigBuilder::parseCommandLineArgs(int argc,
           ->default_value(config_->exec.codegen.inf_div_by_zero)
           ->implicit_value(true),
       "Return INF on fp division by zero instead of throwing an exception.");
+  opt_desc.add_options()(
+      "null-mod-by-zero",
+      po::value<bool>(&config_->exec.codegen.null_mod_by_zero)
+          ->default_value(config_->exec.codegen.null_mod_by_zero)
+          ->implicit_value(true),
+      "Return NULL on modulo by zero instead of throwing an exception.");
   opt_desc.add_options()("enable-hoist-literals",
                          po::value<bool>(&config_->exec.codegen.hoist_literals)
                              ->default_value(config_->exec.codegen.hoist_literals)

--- a/omniscidb/Shared/Config.h
+++ b/omniscidb/Shared/Config.h
@@ -78,6 +78,7 @@ struct InterruptConfig {
 struct CodegenConfig {
   bool inf_div_by_zero = false;
   bool null_div_by_zero = false;
+  bool null_mod_by_zero = false;
   bool hoist_literals = true;
   bool enable_filter_function = true;
 };

--- a/omniscidb/Tests/ArrowBasedExecuteTest.cpp
+++ b/omniscidb/Tests/ArrowBasedExecuteTest.cpp
@@ -7278,6 +7278,23 @@ TEST_F(Select, ReturnNullFromDivByZero) {
   }
 }
 
+TEST_F(Select, ReturnNullFromModByZero) {
+  auto old_null_mod_by_zero = config().exec.codegen.null_mod_by_zero;
+  config().exec.codegen.null_mod_by_zero = true;
+  ScopeGuard sg = [old_null_mod_by_zero] {
+    config().exec.codegen.null_mod_by_zero = old_null_mod_by_zero;
+  };
+  for (auto dt : {ExecutorDeviceType::CPU, ExecutorDeviceType::GPU}) {
+    SKIP_NO_GPU();
+    c("SELECT x % 0 FROM test;", dt);
+    c("SELECT w % 0 FROM test;", dt);
+    c("SELECT y % 0 FROM test;", dt);
+    c("SELECT z % 0 FROM test;", dt);
+    c("SELECT t % 0 FROM test;", dt);
+    c("SELECT 1 % 0 FROM test;", dt);
+  }
+}
+
 TEST_F(Select, ReturnInfFromDivByZero) {
   config().exec.codegen.inf_div_by_zero = true;
   for (auto dt : {ExecutorDeviceType::CPU, ExecutorDeviceType::GPU}) {


### PR DESCRIPTION
This flag is to be used by Modin to match Pandas' behavior for modulo by zero.