### PR TITLE
Throw an exception for unknown tables in RelAlg JSON.

### DIFF
--- a/omniscidb/Calcite/java/calcite/src/main/java/org/apache/calcite/rel/externalize/MapDRelJsonReader.java
+++ b/omniscidb/Calcite/java/calcite/src/main/java/org/apache/calcite/rel/externalize/MapDRelJsonReader.java
@@ -269,8 +269,9 @@ public class MapDRelJsonReader {
         Objects.requireNonNull(relOptSchema);
         Objects.requireNonNull(jsonRel);
         Objects.requireNonNull(jsonRel.get("table"));
-        Objects.requireNonNull(
-                relOptSchema.getTableForMember((List<String>) jsonRel.get("table")));
+        if (relOptSchema.getTableForMember((List<String>) jsonRel.get("table")) == null) {
+          throw new RuntimeException("unknown table: " + jsonRel.get("table"));
+        }
         rel = EnumerableTableScan.create(cluster,
                 relOptSchema.getTableForMember((List<String>) jsonRel.get("table")));
       }


### PR DESCRIPTION
Currently, we don't provide nice diagnostics when JSON passed to the Calcite is wrong. We assume that JSON API is not for wide usage and is used only by our code where we know how to build correct JSON requests. But when simple error like wrong table name occurs, we see a very confusing error:
```
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x00007fd0593eb770, pid=569141, tid=569141
#
# JRE version: OpenJDK Runtime Environment (17.0.3) (build 17.0.3-internal+0-adhoc..src)
# Java VM: OpenJDK 64-Bit Server VM (17.0.3-internal+0-adhoc..src, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, linux-amd64)
# Problematic frame:
# V  [libjvm.so+0x27c770]  AccessInternal::PostRuntimeDispatch<G1BarrierSet::AccessBarrier<548964ul, G1BarrierSet>, (AccessInternal::BarrierType)2, 548964ul>::oop_access_barrier(void*)+0x0
```
In a log file, we can see more useful information:
```
2023-03-13 19:15:00 ERROR CalciteServerHandler:process:179 - class java.lang.NullPointerException
2023-03-13 19:15:00 ERROR CalciteServerHandler:process:181 - null
java.lang.NullPointerException: null
        at java.util.Objects.requireNonNull(Objects.java:208) ~[?:?]
        at org.apache.calcite.rel.externalize.MapDRelJsonReader.readRel(MapDRelJsonReader.java:272) ~[calcite-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
        at org.apache.calcite.rel.externalize.MapDRelJsonReader.readRels(MapDRelJsonReader.java:92) ~[calcite-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
        at org.apache.calcite.rel.externalize.MapDRelJsonReader.read(MapDRelJsonReader.java:86) ~[calcite-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
        at org.apache.calcite.prepare.MapDPlanner.optimizeRaQuery(MapDPlanner.java:259) ~[calcite-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
        at com.mapd.calcite.parser.MapDParser.optimizeRAQuery(MapDParser.java:207) ~[calcite-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
        at com.mapd.parser.server.CalciteServerHandler.process(CalciteServerHandler.java:156) [calcite-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
```
This patch adds `RuntimeException` for unknown tables which gives a better error message. E. g. in Python we would see:
```
Traceback (most recent call last):
  File "/localdisk/ilyaenko/hdk/1.py", line 18, in <module>
    ra = calcite.process("execute calcite " + ra, db_name="hdk")
  File "_sql.pyx", line 41, in pyhdk._sql.Calcite.process
ValueError: unknown table: [hdk, table2]
```