### PR TITLE
Prevent inline because it requires cross-DLL access to static variable

### DIFF
--- a/omniscidb/QueryEngine/Compiler/Backend.cpp
+++ b/omniscidb/QueryEngine/Compiler/Backend.cpp
@@ -56,6 +56,16 @@ const std::unordered_map<llvm::CallingConv::ID, CallingConvDesc>
         {llvm::CallingConv::SPIR_FUNC, CallingConvDesc::SPIR_FUNC},
     };
 
+CodegenTraitsDescriptor CodegenTraits::getDescriptor(unsigned local_addr_space,
+                                                     unsigned global_addr_space,
+                                                     llvm::CallingConv::ID calling_conv,
+                                                     const std::string triple) {
+  return CodegenTraitsDescriptor(local_addr_space,
+                                 global_addr_space,
+                                 llvmCallingConvToDesc.at(calling_conv),
+                                 triple);
+}
+
 std::shared_ptr<CompilationContext> CPUBackend::generateNativeCode(
     llvm::Function* func,
     llvm::Function* wrapper_func,

--- a/omniscidb/QueryEngine/Compiler/Backend.h
+++ b/omniscidb/QueryEngine/Compiler/Backend.h
@@ -69,12 +69,7 @@ class CodegenTraits {
   static CodegenTraitsDescriptor getDescriptor(unsigned local_addr_space,
                                                unsigned global_addr_space,
                                                llvm::CallingConv::ID calling_conv,
-                                               const std::string triple = "") {
-    return CodegenTraitsDescriptor(local_addr_space,
-                                   global_addr_space,
-                                   llvmCallingConvToDesc.at(calling_conv),
-                                   triple);
-  }
+                                               const std::string triple = "");
 
   CodegenTraitsDescriptor getDescriptor() {
     return CodegenTraitsDescriptor(local_addr_space_,


### PR DESCRIPTION
The change prevents inlining cross-DLL access to a static variable, it is not allowed on windows.