### PR TITLE
Quickfix for intrinsics declaration on cuda

### DIFF
--- a/omniscidb/QueryEngine/Compiler/Backend.cpp
+++ b/omniscidb/QueryEngine/Compiler/Backend.cpp
@@ -781,9 +781,9 @@ std::shared_ptr<CudaCompilationContext> CUDABackend::generateNativeGPUCode(
   }
   insert_emtpy_abort_replacement(llvm_module);
 
-  if (requires_libdevice) {
-    add_intrinsics_to_module(llvm_module);
-  }
+  // LLVM intrinsics can be generated due to optimizations (e.g., peephole) and thus need a declaration alongside __nv_ calls.
+  // TODO: Currently CUDA seems to accept llvm intrinsics, it would be good to compare the benefit of using __nv_ calls from libdevice.
+  add_intrinsics_to_module(llvm_module);
 
   // LLVM 14 emits
   //    warning: ignoring debug info with an invalid version (0) in


### PR DESCRIPTION
 LLVM intrinsics can be generated in the GPU codegen path due to llvm optimizations (e.g., peephole) and thus need a declaration alongside `__nv_` calls to not fallback to CPU.
The existence of `libdevice` with semantically equivalent intrinsics suggests a more optimized implementation, this claim needs further investigation on the benefit of implementing intrinsics conversion from llvm to nvvm for our workloads.