### PR TITLE
Introduce pyhdk Version API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ ThirdParty/gdal-data
 # Cython generated files
 python/pyhdk/*.cpp
 
+# Python version file, generated via cmake config
+version.py
+
 # Pytest generated files / directories
 __pycache__
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -11,6 +11,7 @@ file(GLOB_RECURSE PXD_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} pyhdk/*.pyx)
 
 set(pydeps
     ${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in
+    ${CMAKE_CURRENT_SOURCE_DIR}/pyhdk/version.py.in
     ${PY_SOURCES}
     ${PYX_SOURCES}
     ${PXD_SOURCES}

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SETUP_PY "${CMAKE_CURRENT_BINARY_DIR}/setup.py")
 
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in" "${SETUP_PY}")
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/pyhdk/version.py.in" "${CMAKE_CURRENT_SOURCE_DIR}/pyhdk/version.py")
 
 find_package(Python3 COMPONENTS Interpreter REQUIRED)
 

--- a/python/pyhdk/__init__.py
+++ b/python/pyhdk/__init__.py
@@ -20,6 +20,7 @@ import pyhdk.sql as sql
 import pyhdk.storage as storage
 from pyhdk.hdk import init
 from pyhdk._builder import QueryBuilder
+from pyhdk.version import Version 
 
 if sys.platform == "linux":
     sys.setdlopenflags(prev)

--- a/python/pyhdk/__init__.py
+++ b/python/pyhdk/__init__.py
@@ -24,3 +24,5 @@ from pyhdk.version import Version
 
 if sys.platform == "linux":
     sys.setdlopenflags(prev)
+
+__version__ = Version.str()

--- a/python/pyhdk/version.py.in
+++ b/python/pyhdk/version.py.in
@@ -8,7 +8,7 @@ class Version:
 
     @staticmethod
     def str():
-        return "@HDK_VERSION_RAW_NUMERIC@"
+        return "@HDK_VERSION_RAW@"
 
     @staticmethod
     def major():

--- a/python/pyhdk/version.py.in
+++ b/python/pyhdk/version.py.in
@@ -1,0 +1,41 @@
+from datetime import datetime
+
+class Version:
+
+    @staticmethod
+    def full():
+        return "@HDK_VERSION_RAW@-@HDK_BUILD_DATE@-@HDK_GIT_HASH@"        
+
+    @staticmethod
+    def str():
+        return "@HDK_VERSION_RAW_NUMERIC@"
+
+    @staticmethod
+    def major():
+        return @HDK_VERSION_MAJOR@
+
+    @staticmethod
+    def minor():
+        return @HDK_VERSION_MINOR@
+
+    @staticmethod
+    def patch():
+        return @HDK_VERSION_PATCH@
+
+    @staticmethod
+    def extra():
+        return "@HDK_VERSION_EXTRA@"
+
+    @staticmethod
+    def date():
+        return datetime.strptime("@HDK_BUILD_DATE@", "%Y%m%d")
+        
+    @staticmethod
+    def hash():
+        return "@HDK_GIT_HASH@"
+
+    def __str__(self):
+        return Version.str()
+    
+    def __repr__(self):
+        return Version.str()


### PR DESCRIPTION
Proved a little more challenging to do with C++ then I had hoped, so I gave up and just went ahead in pure python. Same variables as the C++ version so it shouldn't make a difference. I opted for a pretty verbose API, we can probably tweak it as necessary. 