### PR TITLE
Fix python version to 3.9

### DIFF
--- a/.github/workflows/modin.yml
+++ b/.github/workflows/modin.yml
@@ -29,7 +29,6 @@ jobs:
         run: |
           conda update conda
           conda env update -f omniscidb/scripts/mapd-deps-conda-dev-env.yml
-          conda install -n ${{ env.CONDA_ENV }} -c conda-forge python=3.8
 
       - name: Restore Maven cache
         uses: actions/cache@v3

--- a/omniscidb/scripts/mapd-deps-conda-dev-env.yml
+++ b/omniscidb/scripts/mapd-deps-conda-dev-env.yml
@@ -50,4 +50,5 @@ dependencies:
   - llvm-spirv 14.0.*
   - folly 2022.11.07.00
   - sqlite 3.40.0
+  - python 3.9.*
 


### PR DESCRIPTION
This is a workaround for https://github.com/intel-ai/hdk/issues/332 (it fixes development env; runtime env is still needed)