### PR TITLE
Use the LLVM New Pass Manager

### DIFF
--- a/omniscidb/QueryEngine/ArithmeticIR.cpp
+++ b/omniscidb/QueryEngine/ArithmeticIR.cpp
@@ -415,10 +415,10 @@ llvm::Value* CodeGenerator::codegenMul(const hdk::ir::BinOper* bin_oper,
     cgen_state_->ir_builder_.SetInsertPoint(mul_check_1);
 
     // Check b==-1, no overflow
-    // ((b) < 0 && ((a) > 0 && (b) == -1)
+    // ((b) < 0 && ((a) >= 0 && (b) == -1)
     auto rhs_neg_and_lhs_pos = cgen_state_->ir_builder_.CreateAnd(
         cgen_state_->ir_builder_.CreateICmpSLT(rhs_lv, const_zero),
-        cgen_state_->ir_builder_.CreateICmpSGT(lhs_lv, const_zero));
+        cgen_state_->ir_builder_.CreateICmpSGE(lhs_lv, const_zero));
 
     auto rhs_minus_one = cgen_state_->ir_builder_.CreateICmpEQ(rhs_lv, const_minus_one);
 

--- a/omniscidb/QueryEngine/Compiler/Backend.cpp
+++ b/omniscidb/QueryEngine/Compiler/Backend.cpp
@@ -977,6 +977,7 @@ std::shared_ptr<L0CompilationContext> L0Backend::generateNativeGPUCode(
 
   DUMP_MODULE(module, "after.optimization.spirv.ll")
 
+  // Write IR with the LOG channel
   std::stringstream stringstream_L0;
   llvm::raw_os_ostream os(stringstream_L0);
   auto L0_llir = stringstream_L0.str();

--- a/omniscidb/QueryEngine/Compiler/Backend.cpp
+++ b/omniscidb/QueryEngine/Compiler/Backend.cpp
@@ -975,6 +975,13 @@ std::shared_ptr<L0CompilationContext> L0Backend::generateNativeGPUCode(
 
   compiler::optimize_ir(func, module, live_funcs, false /*smem_used*/, co);
 
+  DUMP_MODULE(module, "after.optimization.spirv.ll")
+
+  std::stringstream stringstream_L0;
+  llvm::raw_os_ostream os(stringstream_L0);
+  auto L0_llir = stringstream_L0.str();
+  LOG(IR) << "CodeGenerator L0::generateIR:\n" << L0_llir << "\nEnd of IR";
+
   // Remove the remaining freeze instruction after the optimization
   std::vector<llvm::Instruction*> to_erase;
   for (auto& Fn : *module) {

--- a/omniscidb/QueryEngine/Compiler/Backend.cpp
+++ b/omniscidb/QueryEngine/Compiler/Backend.cpp
@@ -84,9 +84,7 @@ std::shared_ptr<CpuCompilationContext> CPUBackend::generateNativeCPUCode(
   llvm::Module* llvm_module = func->getParent();
   // run optimizations
 #ifndef WITH_JIT_DEBUG
-  llvm::PassBuilder pass_builder;
-  compiler::optimize_ir(
-      func, llvm_module, pass_builder, live_funcs, /*is_gpu_smem_used=*/false, co);
+  compiler::optimize_ir(func, llvm_module, live_funcs, /*is_gpu_smem_used=*/false, co);
 #endif  // WITH_JIT_DEBUG
 
   auto init_err = llvm::InitializeNativeTarget();
@@ -695,8 +693,7 @@ std::shared_ptr<CudaCompilationContext> CUDABackend::generateNativeGPUCode(
   }
 
   // run optimizations
-  compiler::optimize_ir(
-      func, llvm_module, module_pass_manager, live_funcs, is_gpu_smem_used, co);
+  compiler::optimize_ir(func, llvm_module, live_funcs, is_gpu_smem_used, co);
   compiler::legalize_nvvm_ir(func);
 
   std::stringstream ss;
@@ -976,8 +973,7 @@ std::shared_ptr<L0CompilationContext> L0Backend::generateNativeGPUCode(
   llvm::NamedMDNode* spirv_src = module->getOrInsertNamedMetadata("spirv.Source");
   spirv_src->addOperand(llvm::MDNode::get(ctx, spirv_src_ops));
 
-  llvm::PassBuilder pass_builder;
-  compiler::optimize_ir(func, module, pass_builder, live_funcs, false /*smem_used*/, co);
+  compiler::optimize_ir(func, module, live_funcs, false /*smem_used*/, co);
 
   // Remove the remaining freeze instruction after the optimization
   std::vector<llvm::Instruction*> to_erase;

--- a/omniscidb/QueryEngine/Compiler/Backend.cpp
+++ b/omniscidb/QueryEngine/Compiler/Backend.cpp
@@ -84,9 +84,9 @@ std::shared_ptr<CpuCompilationContext> CPUBackend::generateNativeCPUCode(
   llvm::Module* llvm_module = func->getParent();
   // run optimizations
 #ifndef WITH_JIT_DEBUG
-  llvm::legacy::PassManager pass_manager;
+  llvm::PassBuilder pass_builder;
   compiler::optimize_ir(
-      func, llvm_module, pass_manager, live_funcs, /*is_gpu_smem_used=*/false, co);
+      func, llvm_module, pass_builder, live_funcs, /*is_gpu_smem_used=*/false, co);
 #endif  // WITH_JIT_DEBUG
 
   auto init_err = llvm::InitializeNativeTarget();
@@ -976,10 +976,8 @@ std::shared_ptr<L0CompilationContext> L0Backend::generateNativeGPUCode(
   llvm::NamedMDNode* spirv_src = module->getOrInsertNamedMetadata("spirv.Source");
   spirv_src->addOperand(llvm::MDNode::get(ctx, spirv_src_ops));
 
-  auto pass_manager_builder = llvm::PassManagerBuilder();
-  llvm::legacy::PassManager PM;
-  pass_manager_builder.populateModulePassManager(PM);
-  compiler::optimize_ir(func, module, PM, live_funcs, false /*smem_used*/, co);
+  llvm::PassBuilder pass_builder;
+  compiler::optimize_ir(func, module, pass_builder, live_funcs, false /*smem_used*/, co);
 
   // Remove the remaining freeze instruction after the optimization
   std::vector<llvm::Instruction*> to_erase;

--- a/omniscidb/QueryEngine/Compiler/HelperFunctions.cpp
+++ b/omniscidb/QueryEngine/Compiler/HelperFunctions.cpp
@@ -89,11 +89,12 @@ void eliminate_dead_self_recursive_funcs(
 
 void optimize_ir(llvm::Function* query_func,
                  llvm::Module* llvm_module,
-                 llvm::PassBuilder& PB,
                  const std::unordered_set<llvm::Function*>& live_funcs,
                  const bool is_gpu_smem_used,
                  const CompilationOptions& co) {
   auto timer = DEBUG_TIMER(__func__);
+
+  llvm::PassBuilder PB;
 
   llvm::LoopAnalysisManager LAM;
   llvm::FunctionAnalysisManager FAM;

--- a/omniscidb/QueryEngine/Compiler/HelperFunctions.cpp
+++ b/omniscidb/QueryEngine/Compiler/HelperFunctions.cpp
@@ -108,8 +108,7 @@ void optimize_ir(llvm::Function* query_func,
   PB.registerLoopAnalyses(LAM);
   PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
 
-  llvm::ModulePassManager MPM =
-      PB.buildPerModuleDefaultPipeline(llvm::OptimizationLevel::O3);
+  llvm::ModulePassManager MPM;
   llvm::FunctionPassManager FPM;
 
   // the always inliner legacy pass must always run first

--- a/omniscidb/QueryEngine/Compiler/HelperFunctions.h
+++ b/omniscidb/QueryEngine/Compiler/HelperFunctions.h
@@ -17,9 +17,25 @@
 #include <string>
 #include <unordered_set>
 
+#include <llvm/Analysis/MemorySSA.h>
 #include <llvm/IR/LegacyPassManager.h>
+#include <llvm/Passes/PassBuilder.h>
 #include <llvm/Support/SourceMgr.h>
 #include <llvm/Support/raw_os_ostream.h>
+#include <llvm/Transforms/IPO/AlwaysInliner.h>
+#include <llvm/Transforms/IPO/GlobalOpt.h>
+#include <llvm/Transforms/IPO/PassManagerBuilder.h>
+#include <llvm/Transforms/InstCombine/InstCombine.h>
+#include <llvm/Transforms/Scalar/DeadStoreElimination.h>
+#include <llvm/Transforms/Scalar/EarlyCSE.h>
+#include <llvm/Transforms/Scalar/GVN.h>
+#include <llvm/Transforms/Scalar/JumpThreading.h>
+#include <llvm/Transforms/Scalar/LICM.h>
+#include <llvm/Transforms/Scalar/MemCpyOptimizer.h>
+#include <llvm/Transforms/Scalar/SROA.h>
+#include <llvm/Transforms/Scalar/SimplifyCFG.h>
+#include <llvm/Transforms/Utils/Mem2Reg.h>
+#include "llvm/IR/PassManager.h"
 
 #include "QueryEngine/CompilationOptions.h"
 
@@ -50,7 +66,7 @@ void verify_function_ir(const llvm::Function* func);
 
 void optimize_ir(llvm::Function* query_func,
                  llvm::Module* llvm_module,
-                 llvm::legacy::PassManager& pass_manager,
+                 llvm::PassBuilder& PB,
                  const std::unordered_set<llvm::Function*>& live_funcs,
                  const bool is_gpu_smem_used,
                  const CompilationOptions& co);

--- a/omniscidb/QueryEngine/Compiler/HelperFunctions.h
+++ b/omniscidb/QueryEngine/Compiler/HelperFunctions.h
@@ -65,7 +65,6 @@ void verify_function_ir(const llvm::Function* func);
 
 void optimize_ir(llvm::Function* query_func,
                  llvm::Module* llvm_module,
-                 llvm::PassBuilder& PB,
                  const std::unordered_set<llvm::Function*>& live_funcs,
                  const bool is_gpu_smem_used,
                  const CompilationOptions& co);

--- a/omniscidb/QueryEngine/Compiler/HelperFunctions.h
+++ b/omniscidb/QueryEngine/Compiler/HelperFunctions.h
@@ -18,7 +18,6 @@
 #include <unordered_set>
 
 #include <llvm/Analysis/MemorySSA.h>
-#include <llvm/IR/LegacyPassManager.h>
 #include <llvm/Passes/PassBuilder.h>
 #include <llvm/Support/SourceMgr.h>
 #include <llvm/Support/raw_os_ostream.h>

--- a/omniscidb/QueryEngine/NativeCodegen.cpp
+++ b/omniscidb/QueryEngine/NativeCodegen.cpp
@@ -1743,10 +1743,8 @@ Executor::compileWorkUnit(const std::vector<InputTableInfo>& query_infos,
       // Note that we don't run the NVVM reflect pass here. Use LOG(IR) to get the
       // optimized IR after NVVM reflect
       // llvm::legacy::PassManager pass_manager;
-      llvm::PassBuilder pass_builder;
       compiler::optimize_ir(query_func,
                             cgen_state_->module_,
-                            pass_builder,
                             live_funcs,
                             gpu_smem_context.isSharedMemoryUsed(),
                             co_codegen_traits);

--- a/omniscidb/QueryEngine/NativeCodegen.cpp
+++ b/omniscidb/QueryEngine/NativeCodegen.cpp
@@ -1742,10 +1742,11 @@ Executor::compileWorkUnit(const std::vector<InputTableInfo>& query_infos,
 #else
       // Note that we don't run the NVVM reflect pass here. Use LOG(IR) to get the
       // optimized IR after NVVM reflect
-      llvm::legacy::PassManager pass_manager;
+      // llvm::legacy::PassManager pass_manager;
+      llvm::PassBuilder pass_builder;
       compiler::optimize_ir(query_func,
                             cgen_state_->module_,
-                            pass_manager,
+                            pass_builder,
                             live_funcs,
                             gpu_smem_context.isSharedMemoryUsed(),
                             co_codegen_traits);

--- a/omniscidb/QueryEngine/Optimization/AnnotateInternalFunctionsPass.h
+++ b/omniscidb/QueryEngine/Optimization/AnnotateInternalFunctionsPass.h
@@ -18,7 +18,7 @@
 
 #include <llvm/Analysis/CallGraph.h>
 #include <llvm/Analysis/CallGraphSCCPass.h>
-
+#include <llvm/IR/PassManager.h>
 #include <llvm/Pass.h>
 #include <llvm/Support/raw_ostream.h>
 
@@ -31,18 +31,30 @@
  * optimizer to more aggressively remove / reorder these functions and is particularly
  * important for dead code elimination.
  */
-class AnnotateInternalFunctionsPass : public llvm::CallGraphSCCPass {
+class AnnotateInternalFunctionsPass
+    : public llvm::PassInfoMixin<AnnotateInternalFunctionsPass> {
  public:
   static char ID;
-  AnnotateInternalFunctionsPass() : CallGraphSCCPass(ID) {}
 
-  bool runOnSCC(llvm::CallGraphSCC& SCC) override {
+  llvm::PreservedAnalyses run(llvm::LazyCallGraph::SCC& SCC,
+                              llvm::CGSCCAnalysisManager& AM,
+                              llvm::LazyCallGraph& CG,
+                              llvm::CGSCCUpdateResult& UR) {
     bool updated_function_defs = false;
 
+#if 0
+    for (llvm::LazyCallGraph::Node& N : InitialC) {
+      llvm::Function* Fn = &N.getFunction();
+      llvm::errs() << "llvm::PreservedAnalyse run(), Function=" << Fn->getName() << "\n";
+    }
+#endif
+
+    // --------------
     // iterate the call graph
     for (auto& node : SCC) {
-      CHECK(node);
-      auto fcn = node->getFunction();
+      CHECK(&node);
+
+      llvm::Function* fcn = &node.getFunction();
       if (!fcn) {
         continue;
       }
@@ -64,10 +76,8 @@ class AnnotateInternalFunctionsPass : public llvm::CallGraphSCCPass {
       }
     }
 
-    return updated_function_defs;
+    return llvm::PreservedAnalyses::all();
   }
-
-  llvm::StringRef getPassName() const override { return "AnnotateInternalFunctionsPass"; }
 
  private:
   static const std::set<std::string> extension_functions;
@@ -119,8 +129,8 @@ const std::set<std::string> AnnotateInternalFunctionsPass::extension_functions =
                           "is_point_in_merc_view",
                           "is_point_size_in_merc_view"};
 
-// TODO: consider either adding specializations here for the `__X` versions (for different
-// types), or just truncate the function name removing the underscores in
+// TODO: consider either adding specializations here for the `__X` versions (for
+// different types), or just truncate the function name removing the underscores in
 // `isInternalMathFunction`.
 const std::set<std::string> AnnotateInternalFunctionsPass::math_builtins =
     std::set<std::string>{"Acos",  "Asin",    "Atan", "Atan2",    "Ceil",    "Cos",

--- a/omniscidb/QueryEngine/Optimization/AnnotateInternalFunctionsPass.h
+++ b/omniscidb/QueryEngine/Optimization/AnnotateInternalFunctionsPass.h
@@ -15,9 +15,6 @@
  */
 
 #include <llvm/IR/Function.h>
-
-#include <llvm/Analysis/CallGraph.h>
-#include <llvm/Analysis/CallGraphSCCPass.h>
 #include <llvm/IR/PassManager.h>
 #include <llvm/Pass.h>
 #include <llvm/Support/raw_ostream.h>

--- a/omniscidb/Tests/IntelGPUEnablingTest.cpp
+++ b/omniscidb/Tests/IntelGPUEnablingTest.cpp
@@ -445,6 +445,26 @@ TEST_F(AggregationTest, NullHandling) {
   c("SELECT COUNT(*) FROM test WHERE ofq >= 0 OR ofq IS NULL;", g_dt);
 }
 
+class OverflowTest : public ExecuteTestBase, public ::testing::Test {};
+
+TEST_F(OverflowTest, OverflowAndUnderFlow) {
+  c("SELECT dd * ufd FROM test;", g_dt);
+  c("SELECT dd * -1 FROM test;", g_dt);
+  c("SELECT -1 * dd FROM test;", g_dt);
+  c("SELECT ofq * -1 FROM test;", g_dt);
+  c("SELECT 1 * ofq FROM test;", g_dt);
+  c("SELECT 566 * 244 FROM test;", g_dt);
+  EXPECT_THROW(c("SELECT ofd * ofd FROM test;", g_dt), std::runtime_error);
+  EXPECT_THROW(c("SELECT 9223372036854775807 * 2 FROM test;", g_dt), std::runtime_error);
+  EXPECT_THROW(c("SELECT -9223372036854775808 * 2 FROM test;", g_dt), std::runtime_error);
+  EXPECT_THROW(c("SELECT 2*9223372036854775807 FROM test;", g_dt), std::runtime_error);
+  EXPECT_THROW(c("SELECT -2*-9223372036854775808 FROM test;", g_dt), std::runtime_error);
+  EXPECT_THROW(c("SELECT ofq * 2 FROM test;", g_dt), std::runtime_error);
+  EXPECT_THROW(c("SELECT ofq * -2 FROM test;", g_dt), std::runtime_error);
+  EXPECT_THROW(c("SELECT 2* ofq FROM test;", g_dt), std::runtime_error);
+  EXPECT_THROW(c("SELECT -2* ofq FROM test;", g_dt), std::runtime_error);
+}
+
 class GroupByAggTest : public ExecuteTestBase, public ::testing::Test {};
 
 TEST_F(GroupByAggTest, GroupByCount) {

--- a/omniscidb/Tests/IntelGPUEnablingTest.cpp
+++ b/omniscidb/Tests/IntelGPUEnablingTest.cpp
@@ -809,14 +809,25 @@ int main(int argc, char* argv[]) {
   namespace po = boost::program_options;
   po::options_description desc("Options");
 
+  desc.add_options()("dump-ir",
+                     po::value<bool>()->default_value(false)->implicit_value(true),
+                     "Dump IR and PTX for all executed queries to file."
+                     " Currently only supports single node tests.");
+
   logger::LogOptions log_options(argv[0]);
-  log_options.severity_ = logger::Severity::INFO;
+  log_options.severity_ = logger::Severity::FATAL;
   log_options.set_options();
   desc.add(log_options.get_options());
 
   po::variables_map vm;
   po::store(po::command_line_parser(argc, argv).options(desc).run(), vm);
   po::notify(vm);
+
+  if (vm["dump-ir"].as<bool>()) {
+    // Only log IR, PTX channels to file with no rotation size.
+    log_options.channels_ = {logger::Channel::IR, logger::Channel::PTX};
+    log_options.rotation_size_ = std::numeric_limits<size_t>::max();
+  }
 
   logger::init(log_options);
 


### PR DESCRIPTION
(rebased from origin/main, #334 to delete)

[o] Need to add function test
[o] Solve Aggregation overflow issue
[x] Need to check performance of tests (was using -O3 opt by default)

Current performance:
```
[==========] Running 8 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 8 tests from CodeGeneratorTest
[ RUN      ] CodeGeneratorTest.IntegerConstant
[       OK ] CodeGeneratorTest.IntegerConstant (186 ms)
[ RUN      ] CodeGeneratorTest.IntegerAdd
[       OK ] CodeGeneratorTest.IntegerAdd (173 ms)
[ RUN      ] CodeGeneratorTest.IntegerColumn
[       OK ] CodeGeneratorTest.IntegerColumn (174 ms)
[ RUN      ] CodeGeneratorTest.IntegerExpr
[       OK ] CodeGeneratorTest.IntegerExpr (174 ms)
[ RUN      ] CodeGeneratorTest.IntegerConstantGPU
[       OK ] CodeGeneratorTest.IntegerConstantGPU (290 ms)
[ RUN      ] CodeGeneratorTest.IntegerAddGPU
[       OK ] CodeGeneratorTest.IntegerAddGPU (265 ms)
[ RUN      ] CodeGeneratorTest.IntegerColumnGPU
[       OK ] CodeGeneratorTest.IntegerColumnGPU (294 ms)
[ RUN      ] CodeGeneratorTest.IntegerExprGPU
[       OK ] CodeGeneratorTest.IntegerExprGPU (266 ms)
[----------] 8 tests from CodeGeneratorTest (1822 ms total)

[----------] Global test environment tear-down
[==========] 8 tests from 1 test suite ran. (1822 ms total)
[  PASSED  ] 8 tests.

```
