### PR TITLE
[NaN handling] Support NaN proper processing.

### DIFF
--- a/omniscidb/QueryEngine/ExpressionRewrite.cpp
+++ b/omniscidb/QueryEngine/ExpressionRewrite.cpp
@@ -240,6 +240,7 @@ class ConstantFoldingVisitor : public hdk::ir::ExprRewriter {
     return false;
   }
 
+  // Arithmetic operates with immediate values only
   template <typename T>
   T foldArithmetic(hdk::ir::OpType optype, T t1, T t2) const {
     bool t2_is_zero = (t2 == (t2 - t2));
@@ -612,7 +613,8 @@ class ConstantFoldingVisitor : public hdk::ir::ExprRewriter {
         return rhs;
       }
     }
-    if (*lhs == *rhs) {
+    // If any value is null (N/A) result value of any op is also null (N/A)
+    if (*lhs == *rhs && !lhs->type()->nullable()) {
       // Tautologies: v=v; v<=v; v>=v
       if (optype == hdk::ir::OpType::kEq || optype == hdk::ir::OpType::kLe ||
           optype == hdk::ir::OpType::kGe) {


### PR DESCRIPTION
This commit adds test to check types and values produced during math ops to compare hdk+modin behaviour with pandas default behaviour.

Resolves: #272

Signed-off-by: Dmitrii Makarenko <dmitrii.makarenko@intel.com>
