### PR TITLE
Use __atomic_compare_exchange_n for CPU CAS atomics where intrinsics …

### DIFF
--- a/omniscidb/QueryEngine/JoinHashTable/Runtime/HashJoinRuntime.cpp
+++ b/omniscidb/QueryEngine/JoinHashTable/Runtime/HashJoinRuntime.cpp
@@ -524,8 +524,8 @@ DEVICE int write_baseline_hash_slot(const int32_t val,
   if (!with_val_slot) {
     return 0;
   }
-  int32_t invalid_slot_val_copy = invalid_slot_val;
-  if (!mapd_cas(matching_group, invalid_slot_val_copy, val)) {
+  T invalid_slot_val_copy = static_cast<T>(invalid_slot_val);
+  if (!mapd_cas(matching_group, invalid_slot_val_copy, static_cast<T>(val))) {
     return -1;
   }
   return 0;
@@ -561,8 +561,8 @@ DEVICE int write_baseline_hash_slot_for_semi_join(const int32_t val,
   if (!with_val_slot) {
     return 0;
   }
-  int32_t invalid_slot_val_copy = invalid_slot_val;
-  mapd_cas(matching_group, invalid_slot_val_copy, val);
+  T invalid_slot_val_copy = static_cast<T>(invalid_slot_val);
+  mapd_cas(matching_group, invalid_slot_val_copy, static_cast<T>(val));
   return 0;
 }
 

--- a/omniscidb/QueryEngine/JoinHashTable/Runtime/JoinHashImpl.h
+++ b/omniscidb/QueryEngine/JoinHashTable/Runtime/JoinHashImpl.h
@@ -49,8 +49,8 @@ extern "C" ALWAYS_INLINE DEVICE int SUFFIX(fill_one_to_one_hashtable)(
     const int32_t invalid_slot_val) {
   // the atomic takes the address of invalid_slot_val to write the value of entry_ptr if
   // not equal to invalid_slot_val. make a copy to avoid dereferencing a const value.
-  auto invalid_slot_val_copy = invalid_slot_val;
-  if (!insert_key_cas(entry_ptr, invalid_slot_val_copy, idx)) {
+  int32_t invalid_slot_val_copy = invalid_slot_val;
+  if (!insert_key_cas(entry_ptr, invalid_slot_val_copy, static_cast<int32_t>(idx))) {
     // slot is full
     return -1;
   }

--- a/omniscidb/QueryEngine/ResultSetReduction.cpp
+++ b/omniscidb/QueryEngine/ResultSetReduction.cpp
@@ -468,7 +468,7 @@ GroupValueInfo get_matching_group_value_columnar_reduction(int64_t* groups_buffe
                                                            const size_t entry_count) {
   auto off = h;
   auto empty_key = EMPTY_KEY_64;
-  if (mapd_cas(&groups_buffer[off], empty_key, *key)) {
+  if (!mapd_cas(&groups_buffer[off], empty_key, *key)) {
     for (size_t i = 0; i < key_qw_count; ++i) {
       groups_buffer[off] = key[i];
       off += entry_count;

--- a/omniscidb/QueryEngine/ResultSetReduction.cpp
+++ b/omniscidb/QueryEngine/ResultSetReduction.cpp
@@ -451,10 +451,10 @@ void ResultSetReduction::reduceEntriesNoCollisionsColWise(
 namespace {
 
 #ifdef _MSC_VER
-#define mapd_cas(address, compare, val)                                 \
-  InterlockedCompareExchange(reinterpret_cast<volatile long*>(address), \
-                             static_cast<long>(val),                    \
-                             static_cast<long>(compare))
+#define mapd_cas(address, compare, val)                                      \
+  InterlockedCompareExchange64(reinterpret_cast<volatile int64_t*>(address), \
+                               static_cast<int64_t>(val),                    \
+                               static_cast<int64_t>(compare))
 #else
 #define mapd_cas(ptr, expected, desired) \
   __atomic_compare_exchange_n(           \
@@ -512,15 +512,42 @@ GroupValueInfo get_group_value_columnar_reduction(
 }
 
 #ifdef _MSC_VER
-#define cas_cst(ptr, expected, desired)                                      \
-  (InterlockedCompareExchangePointer(reinterpret_cast<void* volatile*>(ptr), \
-                                     reinterpret_cast<void*>(&desired),      \
-                                     expected) == expected)
-#define store_cst(ptr, val)                                          \
-  InterlockedExchangePointer(reinterpret_cast<void* volatile*>(ptr), \
-                             reinterpret_cast<void*>(val))
-#define load_cst(ptr) \
-  InterlockedCompareExchange(reinterpret_cast<volatile long*>(ptr), 0, 0)
+template <typename T>
+bool cas_cst(T* ptr, T* expected, T desired) {
+  if constexpr (sizeof(T) == 4) {
+    return InterlockedCompareExchange(reinterpret_cast<volatile long*>(ptr),
+                                      static_cast<long>(desired),
+                                      static_cast<long>(*expected)) ==
+           static_cast<long>(*expected);
+  } else if constexpr (sizeof(T) == 8) {
+    return InterlockedCompareExchange64(
+               reinterpret_cast<volatile int64_t*>(ptr), desired, *expected) == *expected;
+  } else {
+    LOG(FATAL) << "Unsupported atomic operation";
+  }
+}
+
+template <typename T>
+void store_cst(T* ptr, T val) {
+  if constexpr (sizeof(T) == 4) {
+    InterlockedExchange(reinterpret_cast<volatile long*>(ptr), static_cast<long>(val));
+  } else if constexpr (sizeof(T) == 8) {
+    InterlockedExchange64(reinterpret_cast<volatile int64_t*>(ptr), val);
+  } else {
+    LOG(FATAL) << "Unsupported atomic operation";
+  }
+}
+
+template <typename T>
+T load_cst(T* ptr) {
+  if constexpr (sizeof(T) == 4) {
+    return InterlockedCompareExchange(reinterpret_cast<volatile long*>(ptr), 0, 0);
+  } else if constexpr (sizeof(T) == 8) {
+    return InterlockedCompareExchange64(reinterpret_cast<volatile int64_t*>(ptr), 0, 0);
+  } else {
+    LOG(FATAL) << "Unsupported atomic operation";
+  }
+}
 #else
 #define cas_cst(ptr, expected, desired) \
   __atomic_compare_exchange_n(          \
@@ -571,9 +598,11 @@ GroupValueInfo get_matching_group_value_reduction(
   return {groups_buffer + off + slot_off_quad, false};
 }
 
+#ifndef _MSC_VER
 #undef load_cst
 #undef store_cst
 #undef cas_cst
+#endif
 
 inline GroupValueInfo get_matching_group_value_reduction(
     int64_t* groups_buffer,

--- a/omniscidb/QueryEngine/ResultSetReduction.cpp
+++ b/omniscidb/QueryEngine/ResultSetReduction.cpp
@@ -468,7 +468,7 @@ GroupValueInfo get_matching_group_value_columnar_reduction(int64_t* groups_buffe
                                                            const size_t entry_count) {
   auto off = h;
   auto empty_key = EMPTY_KEY_64;
-  if (!mapd_cas(&groups_buffer[off], empty_key, *key)) {
+  if (mapd_cas(&groups_buffer[off], empty_key, *key)) {
     for (size_t i = 0; i < key_qw_count; ++i) {
       groups_buffer[off] = key[i];
       off += entry_count;


### PR DESCRIPTION
…are used.

It turns out that the x86 assembly for the two intrinsics is the same:

```
int mapd_cas_test(int64_t* matching_group) {
  int64_t invalid_slot_val = std::numeric_limits<int64_t>::max();
int64_t write_pending = invalid_slot_val - 1;
 auto res = mapd_cas(matching_group, invalid_slot_val, write_pending);
 if (res != write_pending) {
    return -1;
  }
  return 0;
}
int64_t* cas_cst_test(int64_t* row_ptr, int64_t* key ) {
    int64_t empty_key = std::numeric_limits<int64_t>::max();
    int64_t write_pending = empty_key - 1;
  const bool success = cas_cst(row_ptr, &empty_key, write_pending);
  if (success) {
    store_cst(row_ptr, *key);
    return reinterpret_cast<int64_t*>(row_ptr + 1);
  }
}
```

(where `mapd_cas` calls `__sync_val` and `cas_cst` calls `__atomic`)

``` 
mapd_cas_test(long*):                    # @mapd_cas_test(long*)
        movabs  rax, 9223372036854775807
        movabs  rdx, 9223372036854775806
        lock            cmpxchg qword ptr [rdi], rdx
        xor     ecx, ecx
        cmp     rax, rdx
        setne   cl
        neg     ecx
        mov     eax, ecx
        ret
cas_cst_test(long*, long*):                   # @cas_cst_test(long*, long*)
        movabs  rax, 9223372036854775807
        movabs  rcx, 9223372036854775806
        lock            cmpxchg qword ptr [rdi], rcx
        jne     .LBB1_2
        mov     rax, qword ptr [rsi]
        xchg    qword ptr [rdi], rax
        add     rdi, 8
        mov     rax, rdi
        ret
```

The `cmpxchg` instructions sets the appropriate flags depending on what the compare result was, but in the `__sync_val` case those flags are never read. Uniformly using `__atomic` results in fewer instructions, and `__sync_val` is deprecated anyway.

@gshimansky I left all atomic names the same to reduce conflicts w/ Windows. We can make Windows work, then do the renaming, or do the renaming as part of the Windows work, as we no longer need `mapd_cas` and `cas_crt`. 