### PR TITLE
Add ResultSetRegistry storage [2/N]

### DIFF
--- a/omniscidb/ArrowStorage/ArrowStorage.h
+++ b/omniscidb/ArrowStorage/ArrowStorage.h
@@ -167,9 +167,8 @@ class ArrowStorage : public SimpleSchemaProvider, public AbstractDataProvider {
                            const TableOptions& options) const;
   void compareSchemas(std::shared_ptr<arrow::Schema> lhs,
                       std::shared_ptr<arrow::Schema> rhs);
-  void computeStats(std::shared_ptr<arrow::ChunkedArray> arr,
-                    const hdk::ir::Type* type,
-                    ChunkStats& stats);
+  ChunkStats computeStats(std::shared_ptr<arrow::ChunkedArray> arr,
+                          const hdk::ir::Type* type);
   std::shared_ptr<arrow::Table> parseCsvFile(const std::string& file_name,
                                              const CsvParseOptions parse_options,
                                              const ColumnInfoList& col_infos = {});

--- a/omniscidb/DataMgr/ArrayNoneEncoder.h
+++ b/omniscidb/DataMgr/ArrayNoneEncoder.h
@@ -66,9 +66,10 @@ class ArrayNoneEncoder : public Encoder {
     return n - start_idx;
   }
 
-  void getMetadata(const std::shared_ptr<ChunkMetadata>& chunkMetadata) override {
-    Encoder::getMetadata(chunkMetadata);  // call on parent class
-    chunkMetadata->fillChunkStats(elem_min, elem_max, has_nulls);
+  std::shared_ptr<ChunkMetadata> getMetadata() override {
+    auto res = Encoder::getMetadata();
+    res->fillChunkStats(elem_min, elem_max, has_nulls);
+    return res;
   }
 
   // Only called from the executor for synthesized meta-information.

--- a/omniscidb/DataMgr/Chunk/Chunk.cpp
+++ b/omniscidb/DataMgr/Chunk/Chunk.cpp
@@ -205,7 +205,7 @@ ChunkIter Chunk::begin_iterator(const std::shared_ptr<ChunkMetadata>& chunk_meta
     it.end_pos = buffer_->getMemoryPtr() + buffer_->size();
     it.second_buf = nullptr;
   }
-  it.num_elems = chunk_metadata->numElements;
+  it.num_elems = chunk_metadata->numElements();
   return it;
 }
 }  // namespace Chunk_NS

--- a/omniscidb/DataMgr/DateDaysEncoder.h
+++ b/omniscidb/DataMgr/DateDaysEncoder.h
@@ -37,9 +37,10 @@ class DateDaysEncoder : public Encoder {
     resetChunkStats();
   }
 
-  void getMetadata(const std::shared_ptr<ChunkMetadata>& chunkMetadata) override {
-    Encoder::getMetadata(chunkMetadata);
-    chunkMetadata->fillChunkStats(dataMin, dataMax, has_nulls);
+  std::shared_ptr<ChunkMetadata> getMetadata() override {
+    auto res = Encoder::getMetadata();
+    res->fillChunkStats(dataMin, dataMax, has_nulls);
+    return res;
   }
 
   // Only called from the executor for synthesized meta-information.

--- a/omniscidb/DataMgr/Encoder.cpp
+++ b/omniscidb/DataMgr/Encoder.cpp
@@ -120,8 +120,6 @@ Encoder::Encoder(Data_Namespace::AbstractBuffer* buffer)
     , decimal_overflow_validator_(buffer ? buffer->type() : nullptr)
     , date_days_overflow_validator_(buffer ? buffer->type() : nullptr){};
 
-void Encoder::getMetadata(const std::shared_ptr<ChunkMetadata>& chunkMetadata) {
-  chunkMetadata->type = buffer_->type();
-  chunkMetadata->numBytes = buffer_->size();
-  chunkMetadata->numElements = num_elems_;
+std::shared_ptr<ChunkMetadata> Encoder::getMetadata() {
+  return std::make_shared<ChunkMetadata>(buffer_->type(), buffer_->size(), num_elems_);
 }

--- a/omniscidb/DataMgr/Encoder.h
+++ b/omniscidb/DataMgr/Encoder.h
@@ -168,7 +168,7 @@ class Encoder {
   Encoder(Data_Namespace::AbstractBuffer* buffer);
   virtual ~Encoder() {}
 
-  virtual void getMetadata(const std::shared_ptr<ChunkMetadata>& chunkMetadata);
+  virtual std::shared_ptr<ChunkMetadata> getMetadata();
   // Only called from the executor for synthesized meta-information.
   virtual std::shared_ptr<ChunkMetadata> getMetadata(const hdk::ir::Type* type) = 0;
   virtual void updateStats(const int64_t val, const bool is_null) = 0;

--- a/omniscidb/DataMgr/FixedLengthArrayNoneEncoder.h
+++ b/omniscidb/DataMgr/FixedLengthArrayNoneEncoder.h
@@ -55,9 +55,10 @@ class FixedLengthArrayNoneEncoder : public Encoder {
     return dataSize / array_size;
   }
 
-  void getMetadata(const std::shared_ptr<ChunkMetadata>& chunkMetadata) override {
-    Encoder::getMetadata(chunkMetadata);  // call on parent class
-    chunkMetadata->fillChunkStats(elem_min, elem_max, has_nulls);
+  std::shared_ptr<ChunkMetadata> getMetadata() override {
+    auto res = Encoder::getMetadata();
+    res->fillChunkStats(elem_min, elem_max, has_nulls);
+    return res;
   }
 
   // Only called from the executor for synthesized meta-information.

--- a/omniscidb/DataMgr/FixedLengthEncoder.h
+++ b/omniscidb/DataMgr/FixedLengthEncoder.h
@@ -36,9 +36,10 @@ class FixedLengthEncoder : public Encoder {
     resetChunkStats();
   }
 
-  void getMetadata(const std::shared_ptr<ChunkMetadata>& chunkMetadata) override {
-    Encoder::getMetadata(chunkMetadata);  // call on parent class
-    chunkMetadata->fillChunkStats(dataMin, dataMax, has_nulls);
+  std::shared_ptr<ChunkMetadata> getMetadata() override {
+    auto res = Encoder::getMetadata();
+    res->fillChunkStats(dataMin, dataMax, has_nulls);
+    return res;
   }
 
   // Only called from the executor for synthesized meta-information.

--- a/omniscidb/DataMgr/NoneEncoder.h
+++ b/omniscidb/DataMgr/NoneEncoder.h
@@ -39,9 +39,10 @@ class NoneEncoder : public Encoder {
     resetChunkStats();
   }
 
-  void getMetadata(const std::shared_ptr<ChunkMetadata>& chunkMetadata) override {
-    Encoder::getMetadata(chunkMetadata);  // call on parent class
-    chunkMetadata->fillChunkStats(dataMin, dataMax, has_nulls);
+  std::shared_ptr<ChunkMetadata> getMetadata() override {
+    auto res = Encoder::getMetadata();
+    res->fillChunkStats(dataMin, dataMax, has_nulls);
+    return res;
   }
 
   // Only called from the executor for synthesized meta-information.

--- a/omniscidb/DataMgr/StringNoneEncoder.h
+++ b/omniscidb/DataMgr/StringNoneEncoder.h
@@ -45,11 +45,10 @@ class StringNoneEncoder : public Encoder {
                                        const size_t byteLimit,
                                        const bool replicating = false);
 
-  void getMetadata(const std::shared_ptr<ChunkMetadata>& chunkMetadata) override {
-    Encoder::getMetadata(chunkMetadata);  // call on parent class
-    chunkMetadata->chunkStats.min.stringval = nullptr;
-    chunkMetadata->chunkStats.max.stringval = nullptr;
-    chunkMetadata->chunkStats.has_nulls = has_nulls;
+  std::shared_ptr<ChunkMetadata> getMetadata() override {
+    auto res = Encoder::getMetadata();
+    res->fillStringChunkStats(has_nulls);
+    return res;
   }
 
   // Only called from the executor for synthesized meta-information.

--- a/omniscidb/DataProvider/TableFragmentsInfo.h
+++ b/omniscidb/DataProvider/TableFragmentsInfo.h
@@ -42,8 +42,7 @@ class FragmentInfo {
       , physicalTableId(-1)
       , resultSet(nullptr)
       , numTuples(0)
-      , synthesizedNumTuplesIsValid(false)
-      , synthesizedMetadataIsValid(false) {}
+      , synthesizedNumTuplesIsValid(false) {}
 
   void setChunkMetadataMap(const ChunkMetadataMap& chunk_metadata_map) {
     this->chunkMetadataMap = chunk_metadata_map;
@@ -67,7 +66,6 @@ class FragmentInfo {
 
   void setPhysicalNumTuples(const size_t physNumTuples) { numTuples = physNumTuples; }
 
-  void invalidateChunkMetadataMap() const { synthesizedMetadataIsValid = false; };
   void invalidateNumTuples() const { synthesizedNumTuplesIsValid = false; }
 
   int fragmentId;
@@ -82,7 +80,6 @@ class FragmentInfo {
   mutable size_t numTuples;
   mutable ChunkMetadataMap chunkMetadataMap;
   mutable bool synthesizedNumTuplesIsValid;
-  mutable bool synthesizedMetadataIsValid;
 };
 
 class TableFragmentsInfo {

--- a/omniscidb/QueryEngine/ColumnFetcher.cpp
+++ b/omniscidb/QueryEngine/ColumnFetcher.cpp
@@ -109,8 +109,8 @@ std::pair<const int8_t*, size_t> ColumnFetcher::getOneColumnFragment(
         chunk_key,
         effective_mem_lvl,
         effective_mem_lvl == Data_Namespace::CPU_LEVEL ? 0 : device_id,
-        chunk_meta_it->second->numBytes,
-        chunk_meta_it->second->numElements);
+        chunk_meta_it->second->numBytes(),
+        chunk_meta_it->second->numElements());
     chunks_owner.push_back(chunk);
     CHECK(chunk);
     auto ab = chunk->getBuffer();
@@ -255,8 +255,8 @@ const int8_t* ColumnFetcher::getOneTableColumnFragment(
         chunk_key,
         memory_level,
         memory_level == Data_Namespace::CPU_LEVEL ? 0 : device_id,
-        chunk_meta_it->second->numBytes,
-        chunk_meta_it->second->numElements);
+        chunk_meta_it->second->numBytes(),
+        chunk_meta_it->second->numElements());
     std::lock_guard<std::mutex> chunk_list_lock(chunk_list_mutex_);
     chunk_holder.push_back(chunk);
   }
@@ -334,7 +334,7 @@ const int8_t* ColumnFetcher::getAllTableColumnFragments(
             std::make_unique<ColumnarResults>(executor_->row_set_mem_owner_,
                                               col_buffer,
                                               fragment.getNumTuples(),
-                                              chunk_meta_it->second->type,
+                                              chunk_meta_it->second->type(),
                                               thread_idx));
       }
       auto merged_results =
@@ -445,8 +445,8 @@ const int8_t* ColumnFetcher::linearizeColumnFragments(
                                         chunk_key,
                                         Data_Namespace::CPU_LEVEL,
                                         0,
-                                        chunk_meta_it->second->numBytes,
-                                        chunk_meta_it->second->numElements);
+                                        chunk_meta_it->second->numBytes(),
+                                        chunk_meta_it->second->numElements());
       local_chunk_holder.push_back(chunk);
       auto chunk_iter = chunk->begin_iterator(chunk_meta_it->second);
       local_chunk_iter_holder.push_back(chunk_iter);

--- a/omniscidb/QueryEngine/Execute.cpp
+++ b/omniscidb/QueryEngine/Execute.cpp
@@ -3686,8 +3686,8 @@ FragmentSkipStatus Executor::canSkipFragmentForFpQual(
   double chunk_min{0.};
   double chunk_max{0.};
   const auto& chunk_type = lhs_col->type();
-  chunk_min = extract_min_stat_fp_type(chunk_meta_it->second->chunkStats, chunk_type);
-  chunk_max = extract_max_stat_fp_type(chunk_meta_it->second->chunkStats, chunk_type);
+  chunk_min = extract_min_stat_fp_type(chunk_meta_it->second->chunkStats(), chunk_type);
+  chunk_max = extract_max_stat_fp_type(chunk_meta_it->second->chunkStats(), chunk_type);
   if (chunk_min > chunk_max) {
     return FragmentSkipStatus::INVALID;
   }
@@ -3809,9 +3809,9 @@ std::pair<bool, int64_t> Executor::skipFragment(
     } else {
       const auto& chunk_type = lhs_col->type();
       chunk_min =
-          extract_min_stat_int_type(chunk_meta_it->second->chunkStats, chunk_type);
+          extract_min_stat_int_type(chunk_meta_it->second->chunkStats(), chunk_type);
       chunk_max =
-          extract_max_stat_int_type(chunk_meta_it->second->chunkStats, chunk_type);
+          extract_max_stat_int_type(chunk_meta_it->second->chunkStats(), chunk_type);
     }
     if (chunk_min > chunk_max) {
       // invalid metadata range, do not skip fragment

--- a/omniscidb/QueryEngine/InputMetadata.cpp
+++ b/omniscidb/QueryEngine/InputMetadata.cpp
@@ -17,8 +17,6 @@
 #include "InputMetadata.h"
 #include "Execute.h"
 
-#include <future>
-
 InputTableInfoCache::InputTableInfoCache(Executor* executor) : executor_(executor) {}
 
 namespace {
@@ -54,23 +52,31 @@ void InputTableInfoCache::clear() {
 
 namespace {
 
-bool uses_int_meta(const hdk::ir::Type* col_type) {
-  return col_type->isInteger() || col_type->isDecimal() || col_type->isDateTime() ||
-         col_type->isBoolean() || col_type->isExtDictionary();
-}
-
 TableFragmentsInfo synthesize_table_info(hdk::ResultSetTableTokenPtr token) {
   std::vector<FragmentInfo> result;
   bool non_empty = false;
-  for (int frag_id = 0; frag_id < token->resultSetCount(); ++frag_id) {
+  for (int frag_id = 0; frag_id < static_cast<int>(token->resultSetCount()); ++frag_id) {
     result.emplace_back();
     auto& fragment = result.back();
     fragment.fragmentId = frag_id;
     fragment.deviceIds.resize(3);
     fragment.resultSet = token->resultSet(frag_id).get();
     fragment.resultSetMutex.reset(new std::mutex());
-    fragment.setPhysicalNumTuples(fragment.resultSet ? fragment.resultSet->entryCount()
-                                                     : 0);
+    fragment.setPhysicalNumTuples(fragment.resultSet->entryCount());
+
+    for (size_t col_idx = 0;
+         col_idx < static_cast<size_t>(fragment.resultSet->colCount());
+         ++col_idx) {
+      auto meta = std::make_shared<ChunkMetadata>(
+          fragment.resultSet->colType(col_idx),
+          0,
+          0,
+          [frag_id, col_idx, token](ChunkStats& stats) {
+            stats = token->getChunkStats(frag_id, col_idx);
+          });
+      fragment.setChunkMetadata(static_cast<int>(col_idx), meta);
+    }
+
     non_empty |= (fragment.resultSet != nullptr);
   }
   TableFragmentsInfo table_info;
@@ -112,127 +118,6 @@ void collect_table_infos(std::vector<InputTableInfo>& table_infos,
 
 }  // namespace
 
-ChunkMetadataMap synthesize_metadata(const ResultSet* rows) {
-  auto timer = DEBUG_TIMER(__func__);
-
-  ChunkMetadataMap metadata_map;
-
-  if (rows->definitelyHasNoRows()) {
-    // resultset has no valid storage, so we fill dummy metadata and return early
-    std::vector<std::unique_ptr<Encoder>> decoders;
-    for (size_t i = 0; i < rows->colCount(); ++i) {
-      decoders.emplace_back(Encoder::Create(nullptr, rows->colType(i)));
-      const auto it_ok =
-          metadata_map.emplace(i, decoders.back()->getMetadata(rows->colType(i)));
-      CHECK(it_ok.second);
-    }
-    return metadata_map;
-  }
-
-  std::vector<std::vector<std::unique_ptr<Encoder>>> dummy_encoders;
-  const size_t worker_count =
-      result_set::use_parallel_algorithms(*rows) ? cpu_threads() : 1;
-  for (size_t worker_idx = 0; worker_idx < worker_count; ++worker_idx) {
-    dummy_encoders.emplace_back();
-    for (size_t i = 0; i < rows->colCount(); ++i) {
-      const auto& col_type = rows->colType(i);
-      dummy_encoders.back().emplace_back(Encoder::Create(nullptr, col_type));
-    }
-  }
-
-  rows->moveToBegin();
-  const auto do_work = [rows](const std::vector<TargetValue>& crt_row,
-                              std::vector<std::unique_ptr<Encoder>>& dummy_encoders) {
-    for (size_t i = 0; i < rows->colCount(); ++i) {
-      auto col_type = rows->colType(i);
-      const auto& col_val = crt_row[i];
-      const auto scalar_col_val = boost::get<ScalarTargetValue>(&col_val);
-      CHECK(scalar_col_val);
-      if (uses_int_meta(col_type)) {
-        const auto i64_p = boost::get<int64_t>(scalar_col_val);
-        CHECK(i64_p);
-        dummy_encoders[i]->updateStats(*i64_p, *i64_p == inline_int_null_value(col_type));
-      } else if (col_type->isFloatingPoint()) {
-        switch (col_type->as<hdk::ir::FloatingPointType>()->precision()) {
-          case hdk::ir::FloatingPointType::kFloat: {
-            const auto float_p = boost::get<float>(scalar_col_val);
-            CHECK(float_p);
-            dummy_encoders[i]->updateStats(*float_p,
-                                           *float_p == inline_fp_null_value(col_type));
-            break;
-          }
-          case hdk::ir::FloatingPointType::kDouble: {
-            const auto double_p = boost::get<double>(scalar_col_val);
-            CHECK(double_p);
-            dummy_encoders[i]->updateStats(*double_p,
-                                           *double_p == inline_fp_null_value(col_type));
-            break;
-          }
-          default:
-            CHECK(false);
-        }
-      } else {
-        throw std::runtime_error(col_type->toString() +
-                                 " is not supported in temporary table.");
-      }
-    }
-  };
-  if (result_set::use_parallel_algorithms(*rows)) {
-    const size_t worker_count = cpu_threads();
-    std::vector<std::future<void>> compute_stats_threads;
-    const auto entry_count = rows->entryCount();
-    for (size_t i = 0,
-                start_entry = 0,
-                stride = (entry_count + worker_count - 1) / worker_count;
-         i < worker_count && start_entry < entry_count;
-         ++i, start_entry += stride) {
-      const auto end_entry = std::min(start_entry + stride, entry_count);
-      compute_stats_threads.push_back(std::async(
-          std::launch::async,
-          [rows, &do_work, &dummy_encoders](
-              const size_t start, const size_t end, const size_t worker_idx) {
-            for (size_t i = start; i < end; ++i) {
-              const auto crt_row = rows->getRowAtNoTranslations(i);
-              if (!crt_row.empty()) {
-                do_work(crt_row, dummy_encoders[worker_idx]);
-              }
-            }
-          },
-          start_entry,
-          end_entry,
-          i));
-    }
-    for (auto& child : compute_stats_threads) {
-      child.wait();
-    }
-    for (auto& child : compute_stats_threads) {
-      child.get();
-    }
-  } else {
-    while (true) {
-      auto crt_row = rows->getNextRow(false, false);
-      if (crt_row.empty()) {
-        break;
-      }
-      do_work(crt_row, dummy_encoders[0]);
-    }
-  }
-  rows->moveToBegin();
-  for (size_t worker_idx = 1; worker_idx < worker_count; ++worker_idx) {
-    CHECK_LT(worker_idx, dummy_encoders.size());
-    const auto& worker_encoders = dummy_encoders[worker_idx];
-    for (size_t i = 0; i < rows->colCount(); ++i) {
-      dummy_encoders[0][i]->reduceStats(*worker_encoders[i]);
-    }
-  }
-  for (size_t i = 0; i < rows->colCount(); ++i) {
-    const auto it_ok =
-        metadata_map.emplace(i, dummy_encoders[0][i]->getMetadata(rows->colType(i)));
-    CHECK(it_ok.second);
-  }
-  return metadata_map;
-}
-
 size_t get_frag_count_of_table(const int db_id, const int table_id, Executor* executor) {
   const auto temporary_tables = executor->getTemporaryTables();
   CHECK(temporary_tables);
@@ -263,10 +148,6 @@ std::vector<InputTableInfo> get_table_infos(const RelAlgExecutionUnit& ra_exe_un
 }
 
 const ChunkMetadataMap& FragmentInfo::getChunkMetadataMap() const {
-  if (resultSet && !synthesizedMetadataIsValid) {
-    chunkMetadataMap = synthesize_metadata(resultSet);
-    synthesizedMetadataIsValid = true;
-  }
   return chunkMetadataMap;
 }
 

--- a/omniscidb/QueryEngine/InputMetadata.h
+++ b/omniscidb/QueryEngine/InputMetadata.h
@@ -48,8 +48,6 @@ class InputTableInfoCache {
   Executor* executor_;
 };
 
-ChunkMetadataMap synthesize_metadata(const ResultSet* rows);
-
 size_t get_frag_count_of_table(const int db_id, const int table_id, Executor* executor);
 
 std::vector<InputTableInfo> get_table_infos(

--- a/omniscidb/ResultSetRegistry/CMakeLists.txt
+++ b/omniscidb/ResultSetRegistry/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(result_set_registry_source_files
     ColumnarResults.cpp
+    ResultSetMetadata.cpp
     ResultSetRegistry.cpp
     ResultSetTableToken.cpp
 )

--- a/omniscidb/ResultSetRegistry/ResultSetMetadata.cpp
+++ b/omniscidb/ResultSetRegistry/ResultSetMetadata.cpp
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2023 Intel Corporation
+ * Copyright 2017 MapD Technologies, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "ResultSetMetadata.h"
+
+#include "Shared/thread_count.h"
+
+#include <future>
+
+namespace hdk {
+
+namespace {
+
+bool usesIntMeta(const hdk::ir::Type* col_type) {
+  return col_type->isInteger() || col_type->isDecimal() || col_type->isDateTime() ||
+         col_type->isBoolean() || col_type->isExtDictionary();
+}
+
+}  // namespace
+
+ChunkMetadataMap synthesizeMetadata(const ResultSet* rows) {
+  auto timer = DEBUG_TIMER(__func__);
+
+  ChunkMetadataMap metadata_map;
+
+  if (rows->definitelyHasNoRows()) {
+    // resultset has no valid storage, so we fill dummy metadata and return early
+    std::vector<std::unique_ptr<Encoder>> decoders;
+    for (size_t i = 0; i < rows->colCount(); ++i) {
+      decoders.emplace_back(Encoder::Create(nullptr, rows->colType(i)));
+      const auto it_ok =
+          metadata_map.emplace(i, decoders.back()->getMetadata(rows->colType(i)));
+      CHECK(it_ok.second);
+    }
+    return metadata_map;
+  }
+
+  std::vector<std::vector<std::unique_ptr<Encoder>>> dummy_encoders;
+  const size_t worker_count =
+      result_set::use_parallel_algorithms(*rows) ? cpu_threads() : 1;
+  for (size_t worker_idx = 0; worker_idx < worker_count; ++worker_idx) {
+    dummy_encoders.emplace_back();
+    for (size_t i = 0; i < rows->colCount(); ++i) {
+      const auto& col_type = rows->colType(i);
+      dummy_encoders.back().emplace_back(Encoder::Create(nullptr, col_type));
+    }
+  }
+
+  rows->moveToBegin();
+  const auto do_work = [rows](const std::vector<TargetValue>& crt_row,
+                              std::vector<std::unique_ptr<Encoder>>& dummy_encoders) {
+    for (size_t i = 0; i < rows->colCount(); ++i) {
+      auto col_type = rows->colType(i);
+      const auto& col_val = crt_row[i];
+      const auto scalar_col_val = boost::get<ScalarTargetValue>(&col_val);
+      CHECK(scalar_col_val);
+      if (usesIntMeta(col_type)) {
+        const auto i64_p = boost::get<int64_t>(scalar_col_val);
+        CHECK(i64_p);
+        dummy_encoders[i]->updateStats(*i64_p, *i64_p == inline_int_null_value(col_type));
+      } else if (col_type->isFloatingPoint()) {
+        switch (col_type->as<hdk::ir::FloatingPointType>()->precision()) {
+          case hdk::ir::FloatingPointType::kFloat: {
+            const auto float_p = boost::get<float>(scalar_col_val);
+            CHECK(float_p);
+            dummy_encoders[i]->updateStats(*float_p,
+                                           *float_p == inline_fp_null_value(col_type));
+            break;
+          }
+          case hdk::ir::FloatingPointType::kDouble: {
+            const auto double_p = boost::get<double>(scalar_col_val);
+            CHECK(double_p);
+            dummy_encoders[i]->updateStats(*double_p,
+                                           *double_p == inline_fp_null_value(col_type));
+            break;
+          }
+          default:
+            CHECK(false);
+        }
+      } else {
+        throw std::runtime_error(col_type->toString() +
+                                 " is not supported in temporary table.");
+      }
+    }
+  };
+  if (result_set::use_parallel_algorithms(*rows)) {
+    const size_t worker_count = cpu_threads();
+    std::vector<std::future<void>> compute_stats_threads;
+    const auto entry_count = rows->entryCount();
+    for (size_t i = 0,
+                start_entry = 0,
+                stride = (entry_count + worker_count - 1) / worker_count;
+         i < worker_count && start_entry < entry_count;
+         ++i, start_entry += stride) {
+      const auto end_entry = std::min(start_entry + stride, entry_count);
+      compute_stats_threads.push_back(std::async(
+          std::launch::async,
+          [rows, &do_work, &dummy_encoders](
+              const size_t start, const size_t end, const size_t worker_idx) {
+            for (size_t i = start; i < end; ++i) {
+              const auto crt_row = rows->getRowAtNoTranslations(i);
+              if (!crt_row.empty()) {
+                do_work(crt_row, dummy_encoders[worker_idx]);
+              }
+            }
+          },
+          start_entry,
+          end_entry,
+          i));
+    }
+    for (auto& child : compute_stats_threads) {
+      child.wait();
+    }
+    for (auto& child : compute_stats_threads) {
+      child.get();
+    }
+  } else {
+    while (true) {
+      auto crt_row = rows->getNextRow(false, false);
+      if (crt_row.empty()) {
+        break;
+      }
+      do_work(crt_row, dummy_encoders[0]);
+    }
+  }
+  rows->moveToBegin();
+  for (size_t worker_idx = 1; worker_idx < worker_count; ++worker_idx) {
+    CHECK_LT(worker_idx, dummy_encoders.size());
+    const auto& worker_encoders = dummy_encoders[worker_idx];
+    for (size_t i = 0; i < rows->colCount(); ++i) {
+      dummy_encoders[0][i]->reduceStats(*worker_encoders[i]);
+    }
+  }
+  for (size_t i = 0; i < rows->colCount(); ++i) {
+    const auto it_ok =
+        metadata_map.emplace(i, dummy_encoders[0][i]->getMetadata(rows->colType(i)));
+    CHECK(it_ok.second);
+  }
+  return metadata_map;
+}
+
+}  // namespace hdk

--- a/omniscidb/ResultSetRegistry/ResultSetMetadata.h
+++ b/omniscidb/ResultSetRegistry/ResultSetMetadata.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2023 Intel Corporation
+ * Copyright 2017 MapD Technologies, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "DataMgr/ChunkMetadata.h"
+#include "ResultSet/ResultSet.h"
+
+namespace hdk {
+
+ChunkMetadataMap synthesizeMetadata(const ResultSet* rows);
+
+}

--- a/omniscidb/ResultSetRegistry/ResultSetRegistry.h
+++ b/omniscidb/ResultSetRegistry/ResultSetRegistry.h
@@ -40,6 +40,10 @@ class ResultSetRegistry : public SimpleSchemaProvider,
   ResultSetPtr get(const ResultSetTableToken& token, size_t frag_id) const;
   void drop(const ResultSetTableToken& token);
 
+  ChunkStats getChunkStats(const ResultSetTableToken& token,
+                           size_t frag_idx,
+                           size_t col_idx) const;
+
   void fetchBuffer(const ChunkKey& key,
                    Data_Namespace::AbstractBuffer* dest,
                    const size_t num_bytes = 0) override;
@@ -60,7 +64,8 @@ class ResultSetRegistry : public SimpleSchemaProvider,
     size_t row_count = 0;
     ResultSetPtr rs;
     std::unique_ptr<ColumnarResults> columnar_res;
-    std::unique_ptr<std::mutex> mutex;
+    std::unique_ptr<mapd_shared_mutex> mutex;
+    ChunkMetadataMap meta;
   };
 
   struct TableData {

--- a/omniscidb/ResultSetRegistry/ResultSetTableToken.cpp
+++ b/omniscidb/ResultSetRegistry/ResultSetTableToken.cpp
@@ -35,4 +35,9 @@ void ResultSetTableToken::reset() {
   }
 }
 
+ChunkStats ResultSetTableToken::getChunkStats(size_t rs_idx, size_t col_idx) const {
+  CHECK(!empty());
+  return registry_->getChunkStats(*this, rs_idx, col_idx);
+}
+
 }  // namespace hdk

--- a/omniscidb/ResultSetRegistry/ResultSetTableToken.h
+++ b/omniscidb/ResultSetRegistry/ResultSetTableToken.h
@@ -8,6 +8,7 @@
 
 #include "ResultSetTable.h"
 
+#include "DataMgr/ChunkMetadata.h"
 #include "SchemaMgr/TableInfo.h"
 
 namespace hdk {
@@ -40,6 +41,8 @@ class ResultSetTableToken {
 
   size_t resultSetCount() const { return tinfo_->fragments; }
   ResultSetPtr resultSet(size_t idx) const;
+
+  ChunkStats getChunkStats(size_t rs_idx, size_t col_idx) const;
 
   static std::string tableName(int table_id) {
     return std::string("__result_set_") + std::to_string(table_id);

--- a/omniscidb/Tests/ArrowStorageTest.cpp
+++ b/omniscidb/Tests/ArrowStorageTest.cpp
@@ -215,10 +215,10 @@ void checkChunkMeta(std::shared_ptr<ChunkMetadata> meta,
                     size_t num_rows,
                     size_t num_bytes,
                     bool has_nulls) {
-  CHECK(meta->type->equal(type));
-  CHECK_EQ(meta->numElements, num_rows);
-  CHECK_EQ(meta->numBytes, num_bytes);
-  CHECK_EQ(meta->chunkStats.has_nulls, has_nulls);
+  CHECK(meta->type()->equal(type));
+  CHECK_EQ(meta->numElements(), num_rows);
+  CHECK_EQ(meta->numBytes(), num_bytes);
+  CHECK_EQ(meta->chunkStats().has_nulls, has_nulls);
 }
 
 template <typename T>
@@ -230,8 +230,8 @@ void checkChunkMeta(std::shared_ptr<ChunkMetadata> meta,
                     T min,
                     T max) {
   checkChunkMeta(meta, type, num_rows, num_bytes, has_nulls);
-  checkDatum(meta->chunkStats.min, min, type);
-  checkDatum(meta->chunkStats.max, max, type);
+  checkDatum(meta->chunkStats().min, min, type);
+  checkDatum(meta->chunkStats().max, max, type);
 }
 
 template <typename T>

--- a/omniscidb/Tests/EncoderTest.cpp
+++ b/omniscidb/Tests/EncoderTest.cpp
@@ -153,9 +153,8 @@ class EncoderUpdateStatsTest : public EncoderTest {
   template <typename T>
   void assertExpectedStats(const T& min, const T& max, const bool has_nulls) {
     auto encoder = buffer_->getEncoder();
-    auto chunk_metadata = std::make_shared<ChunkMetadata>();
-    encoder->getMetadata(chunk_metadata);
-    const auto& chunkStats = chunk_metadata->chunkStats;
+    auto chunk_metadata = encoder->getMetadata();
+    const auto& chunkStats = chunk_metadata->chunkStats();
     auto stats_min = DatumFetcher::getDatumVal<T>(chunkStats.min);
     auto stats_max = DatumFetcher::getDatumVal<T>(chunkStats.max);
     ASSERT_EQ(stats_min, min);
@@ -165,9 +164,8 @@ class EncoderUpdateStatsTest : public EncoderTest {
 
   void assertHasNulls(bool has_nulls) {
     auto encoder = buffer_->getEncoder();
-    auto chunk_metadata = std::make_shared<ChunkMetadata>();
-    encoder->getMetadata(chunk_metadata);
-    const auto& chunkStats = chunk_metadata->chunkStats;
+    auto chunk_metadata = encoder->getMetadata();
+    const auto& chunkStats = chunk_metadata->chunkStats();
     ASSERT_EQ(chunkStats.has_nulls, has_nulls);
   }
 

--- a/omniscidb/Tests/TestDataProvider.h
+++ b/omniscidb/Tests/TestDataProvider.h
@@ -75,15 +75,14 @@ class TestTableData {
       info_.setPhysicalNumTuples(info_.getPhysicalNumTuples() + vals.size());
     }
 
-    auto chunk_meta = std::make_shared<ChunkMetadata>();
-    chunk_meta->type = col_types_.at(col_id);
-    chunk_meta->numBytes = frag_data.size();
-    chunk_meta->numElements = vals.size();
-
     // No computed meta.
-    chunk_meta->chunkStats.has_nulls = true;
-    set_datum(chunk_meta->chunkStats.min, *std::min_element(vals.begin(), vals.end()));
-    set_datum(chunk_meta->chunkStats.max, *std::max_element(vals.begin(), vals.end()));
+    ChunkStats stats;
+    stats.has_nulls = true;
+    set_datum(stats.min, *std::min_element(vals.begin(), vals.end()));
+    set_datum(stats.max, *std::max_element(vals.begin(), vals.end()));
+
+    auto chunk_meta = std::make_shared<ChunkMetadata>(
+        col_types_.at(col_id), frag_data.size(), vals.size(), stats);
 
     auto& frag_info = info_.fragments[data_[col_id - 1].size() - 1];
     frag_info.setChunkMetadata(col_id, chunk_meta);


### PR DESCRIPTION
This PR adds lazy chunk stats to ChunkMetadata.

Currently, we may have lazily computed `ChunkMetadataMap` in `FragmentInfo` when it holds a `ResultSet`. Here I move laziness into `ChunkMetadata` to allow more granular stats computation (i.e. compute stats for some columns only) and use `std::function` instead of `ResultSet` to potentially utilize it later for `ArrowStorage`. Also, only stats are computed lazily now, not the whole `ChunkMetadata`. I'm not sure if we need laziness for `numElements` and `numBytes`. Computing the number of rows for ResultSet can take some time, but it is inevitable anyway so we can do it on import.