### PR TITLE
Move RowSetMemoryOwner code from QueryEngine.

### DIFF
--- a/omniscidb/QueryEngine/Execute.cpp
+++ b/omniscidb/QueryEngine/Execute.cpp
@@ -88,8 +88,6 @@ size_t g_approx_quantile_centroids{300};
 
 size_t g_max_log_length{500};
 
-extern bool g_cache_string_hash;
-
 int const Executor::max_gpu_count;
 
 const int32_t Executor::ERR_SINGLE_VALUE_FOUND_MULTIPLE_VALUES;
@@ -438,28 +436,6 @@ StringDictionaryProxy* Executor::getStringDictionaryProxy(
   const int64_t generation =
       with_generation ? string_dictionary_generations_.getGeneration(dict_id_in) : -1;
   return row_set_mem_owner->getOrAddStringDictProxy(dict_id_in, generation);
-}
-
-StringDictionaryProxy* RowSetMemoryOwner::getOrAddStringDictProxy(
-    const int dict_id_in,
-    const int64_t generation) {
-  const int dict_id{dict_id_in < 0 ? REGULAR_DICT(dict_id_in) : dict_id_in};
-  CHECK(data_provider_);
-  const auto dd = data_provider_->getDictMetadata(dict_id);
-  if (dd) {
-    CHECK(dd->stringDict);
-    CHECK_LE(dd->dictNBits, 32);
-    return addStringDict(dd->stringDict, dict_id, generation);
-  }
-  CHECK_EQ(dict_id, DictRef::literalsDictId);
-  if (!lit_str_dict_proxy_) {
-    DictRef literal_dict_ref(DictRef::invalidDbId, DictRef::literalsDictId);
-    std::shared_ptr<StringDictionary> tsd = std::make_shared<StringDictionary>(
-        literal_dict_ref, "", false, true, g_cache_string_hash);
-    lit_str_dict_proxy_ =
-        std::make_shared<StringDictionaryProxy>(tsd, literal_dict_ref.dictId, 0);
-  }
-  return lit_str_dict_proxy_.get();
 }
 
 const StringDictionaryProxy::IdMap* Executor::getStringProxyTranslationMap(

--- a/omniscidb/ResultSet/CMakeLists.txt
+++ b/omniscidb/ResultSet/CMakeLists.txt
@@ -4,9 +4,10 @@ set(result_set_source_files
     ResultSet.cpp
     ResultSetIteration.cpp
     ResultSetStorage.cpp
+    RowSetMemoryOwner.cpp
     StreamingTopN.cpp
 )
 
 add_library(ResultSet ${result_set_source_files})
 
-target_link_libraries(ResultSet DataMgr IR Logger Utils ${Folly_LIBRARIES})
+target_link_libraries(ResultSet DataMgr IR Logger Utils StringDictionary ${Folly_LIBRARIES})

--- a/omniscidb/ResultSet/RowSetMemoryOwner.cpp
+++ b/omniscidb/ResultSet/RowSetMemoryOwner.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023 Intel Corporation
+ * Copyright 2021 OmniSci, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "RowSetMemoryOwner.h"
+
+extern bool g_cache_string_hash;
+
+StringDictionaryProxy* RowSetMemoryOwner::getOrAddStringDictProxy(
+    const int dict_id_in,
+    const int64_t generation) {
+  const int dict_id{dict_id_in < 0 ? REGULAR_DICT(dict_id_in) : dict_id_in};
+  CHECK(data_provider_);
+  const auto dd = data_provider_->getDictMetadata(dict_id);
+  if (dd) {
+    CHECK(dd->stringDict);
+    CHECK_LE(dd->dictNBits, 32);
+    return addStringDict(dd->stringDict, dict_id, generation);
+  }
+  CHECK_EQ(dict_id, DictRef::literalsDictId);
+  if (!lit_str_dict_proxy_) {
+    DictRef literal_dict_ref(DictRef::invalidDbId, DictRef::literalsDictId);
+    std::shared_ptr<StringDictionary> tsd = std::make_shared<StringDictionary>(
+        literal_dict_ref, "", false, true, g_cache_string_hash);
+    lit_str_dict_proxy_ =
+        std::make_shared<StringDictionaryProxy>(tsd, literal_dict_ref.dictId, 0);
+  }
+  return lit_str_dict_proxy_.get();
+}


### PR DESCRIPTION
This is required for the Windows build.
