### PR TITLE
Unified build flow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
           conda env update -f omniscidb/scripts/mapd-deps-conda-dev-env.yml
 
       - name: Install cuda
-        if: inputs.name == 'cuda'
+        if: inputs.name == 'cuda' || inputs.name == 'all-gpus'
         run: |
           wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb
           sudo dpkg -i cuda-keyring_1.0-1_all.deb
@@ -68,7 +68,7 @@ jobs:
           conda install -n omnisci-dev -c conda-forge arrow-cpp-proc=4.0.0=cuda
 
       - name: Install Intel GPU drivers
-        if: inputs.name == 'l0'
+        if: inputs.name == 'l0' || inputs.name == 'all-gpus'
         run: |
           wget https://github.com/oneapi-src/level-zero/releases/download/v1.9.4/level-zero-devel_1.9.4+u18.04_amd64.deb
           wget https://github.com/oneapi-src/level-zero/releases/download/v1.9.4/level-zero_1.9.4+u18.04_amd64.deb

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,12 @@ jobs:
       name: l0
       options: -DENABLE_L0=on
 
+  build-both-l0-cuda:
+  uses: ./.github/workflows/build.yml
+  with:
+    name: 'all-gpus'
+    options: -DENABLE_L0=on -DENABLE_CUDA=on
+
   style:
     needs: build
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       name: 'all-gpus'
+      cuda_compiler_version: 12-0
       options: -DENABLE_L0=on -DENABLE_CUDA=on
 
   style:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,10 +33,10 @@ jobs:
       options: -DENABLE_L0=on
 
   build-both-l0-cuda:
-  uses: ./.github/workflows/build.yml
-  with:
-    name: 'all-gpus'
-    options: -DENABLE_L0=on -DENABLE_CUDA=on
+    uses: ./.github/workflows/build.yml
+    with:
+      name: 'all-gpus'
+      options: -DENABLE_L0=on -DENABLE_CUDA=on
 
   style:
     needs: build


### PR DESCRIPTION
A unified build requires both cuda and l0 dependencies installation. For that, a convenient way would be to list all the required platform dependencies as a job parameter. Unfortunately, the language doesn't support lists. Here's a simple workaround.