### PR TITLE
Add ResultSetRegistry storage [3/N] 

### DIFF
--- a/omniscidb/ArrowStorage/ArrowStorage.cpp
+++ b/omniscidb/ArrowStorage/ArrowStorage.cpp
@@ -305,7 +305,6 @@ TableFragmentsInfo ArrowStorage::getEmptyTableMetadata(int table_id) const {
   // Executor requires dummy empty fragment for empty tables
   FragmentInfo& empty_frag = res.fragments.emplace_back();
   empty_frag.fragmentId = 0;
-  empty_frag.shadowNumTuples = 0;
   empty_frag.setPhysicalNumTuples(0);
   empty_frag.deviceIds.push_back(0);  // Data_Namespace::DISK_LEVEL
   empty_frag.deviceIds.push_back(0);  // Data_Namespace::CPU_LEVEL

--- a/omniscidb/DataMgr/AbstractBuffer.h
+++ b/omniscidb/DataMgr/AbstractBuffer.h
@@ -21,6 +21,7 @@
  */
 #pragma once
 
+#include <atomic>
 #include <memory>
 
 #ifdef BUFFER_MUTEX
@@ -98,6 +99,7 @@ class AbstractBuffer {
   virtual inline int pin() { return 0; }
   virtual inline int unPin() { return 0; }
   virtual inline int getPinCount() { return 0; }
+  virtual inline void deleteWhenUnpinned() {}
 
   // These getters should not vary when inherited and therefore don't need to be virtual.
   inline size_t size() const { return size_; }

--- a/omniscidb/DataMgr/BufferMgr/Buffer.cpp
+++ b/omniscidb/DataMgr/BufferMgr/Buffer.cpp
@@ -35,7 +35,8 @@ Buffer::Buffer(BufferMgr* bm,
     , seg_it_(seg_it)
     , page_size_(page_size)
     , num_pages_(0)
-    , pin_count_(0) {
+    , pin_count_(0)
+    , delete_on_unpin_(false) {
   pin();
   // so that the pointer value of this Buffer is stored
   seg_it_->buffer = this;
@@ -56,6 +57,7 @@ Buffer::Buffer(BufferMgr* bm,
     , page_size_(page_size)
     , num_pages_(0)
     , pin_count_(0)
+    , delete_on_unpin_(false)
     , token_(std::move(token)) {
   pin();
   seg_it_->buffer = this;

--- a/omniscidb/DataMgr/BufferMgr/Buffer.h
+++ b/omniscidb/DataMgr/BufferMgr/Buffer.h
@@ -70,7 +70,6 @@ class Buffer : public AbstractBuffer {
 
   // Create zero-copy read-only buffer referencing external memory.
   Buffer(BufferMgr* bm,
-         BufferList::iterator seg_it,
          int device_id,
          size_t page_size,
          std::unique_ptr<AbstractDataToken> token);

--- a/omniscidb/DataMgr/BufferMgr/BufferMgr.cpp
+++ b/omniscidb/DataMgr/BufferMgr/BufferMgr.cpp
@@ -162,18 +162,7 @@ AbstractBuffer* BufferMgr::createBuffer(const ChunkKey& chunk_key,
 AbstractBuffer* BufferMgr::createZeroCopyBuffer(
     const ChunkKey& chunk_key,
     std::unique_ptr<AbstractDataToken> token) {
-  BufferList::iterator seg_it;
-  {
-    std::lock_guard<std::mutex> lock(chunk_index_mutex_);
-    CHECK(chunk_index_.find(chunk_key) == chunk_index_.end());
-    BufferSeg buffer_seg(BufferSeg(-1, 0, USED));
-    buffer_seg.chunk_key = chunk_key;
-    std::lock_guard<std::mutex> unsizedSegsLock(unsized_segs_mutex_);
-    unsized_segs_.push_back(buffer_seg);
-    seg_it = std::prev(unsized_segs_.end(), 1);
-    chunk_index_[chunk_key] = seg_it;
-  }
-  return allocateZeroCopyBuffer(seg_it, page_size_, std::move(token));
+  return allocateZeroCopyBuffer(page_size_, std::move(token));
 }
 
 BufferList::iterator BufferMgr::evict(BufferList::iterator& evict_start,

--- a/omniscidb/DataMgr/BufferMgr/BufferMgr.h
+++ b/omniscidb/DataMgr/BufferMgr/BufferMgr.h
@@ -222,7 +222,6 @@ class BufferMgr : public AbstractBufferMgr {  // implements
                               const size_t page_size,
                               const size_t num_bytes) = 0;
   virtual AbstractBuffer* allocateZeroCopyBuffer(
-      BufferList::iterator seg_it,
       const size_t page_size,
       std::unique_ptr<AbstractDataToken> token) {
     UNREACHABLE();

--- a/omniscidb/DataMgr/BufferMgr/CpuBufferMgr/CpuBuffer.cpp
+++ b/omniscidb/DataMgr/BufferMgr/CpuBufferMgr/CpuBuffer.cpp
@@ -33,13 +33,11 @@ CpuBuffer::CpuBuffer(BufferMgr* bm,
     : Buffer(bm, segment_iter, device_id, page_size, num_bytes), gpu_mgr_(gpu_mgr) {}
 
 CpuBuffer::CpuBuffer(BufferMgr* bm,
-                     BufferList::iterator segment_iter,
                      int device_id,
                      const size_t page_size,
                      std::unique_ptr<AbstractDataToken> token,
                      GpuMgr* gpu_mgr)
-    : Buffer(bm, segment_iter, device_id, page_size, std::move(token))
-    , gpu_mgr_(gpu_mgr) {}
+    : Buffer(bm, device_id, page_size, std::move(token)), gpu_mgr_(gpu_mgr) {}
 
 void CpuBuffer::readData(int8_t* const dst,
                          const size_t num_bytes,

--- a/omniscidb/DataMgr/BufferMgr/CpuBufferMgr/CpuBuffer.h
+++ b/omniscidb/DataMgr/BufferMgr/CpuBufferMgr/CpuBuffer.h
@@ -30,7 +30,6 @@ class CpuBuffer : public Buffer {
             const size_t num_bytes = 0);
 
   CpuBuffer(BufferMgr* bm,
-            BufferList::iterator segment_iter,
             int device_id,
             const size_t page_size,
             std::unique_ptr<AbstractDataToken> token,

--- a/omniscidb/DataMgr/BufferMgr/CpuBufferMgr/CpuBufferMgr.cpp
+++ b/omniscidb/DataMgr/BufferMgr/CpuBufferMgr/CpuBufferMgr.cpp
@@ -55,10 +55,9 @@ void CpuBufferMgr::allocateBuffer(BufferList::iterator seg_it,
 }
 
 AbstractBuffer* CpuBufferMgr::allocateZeroCopyBuffer(
-    BufferList::iterator seg_it,
     const size_t page_size,
     std::unique_ptr<AbstractDataToken> token) {
-  return new CpuBuffer(this, seg_it, device_id_, page_size, std::move(token), gpu_mgr_);
+  return new CpuBuffer(this, device_id_, page_size, std::move(token), gpu_mgr_);
 }
 
 void CpuBufferMgr::initializeMem() {

--- a/omniscidb/DataMgr/BufferMgr/CpuBufferMgr/CpuBufferMgr.h
+++ b/omniscidb/DataMgr/BufferMgr/CpuBufferMgr/CpuBufferMgr.h
@@ -49,7 +49,6 @@ class CpuBufferMgr : public BufferMgr {
   inline std::string getStringMgrType() override { return ToString(CPU_MGR); }
 
   AbstractBuffer* allocateZeroCopyBuffer(
-      BufferList::iterator seg_it,
       const size_t page_size,
       std::unique_ptr<AbstractDataToken> token) override;
 

--- a/omniscidb/DataMgr/Encoder.cpp
+++ b/omniscidb/DataMgr/Encoder.cpp
@@ -107,6 +107,7 @@ Encoder* Encoder::Create(Data_Namespace::AbstractBuffer* buffer,
       }
     case hdk::ir::Type::kTime:
     case hdk::ir::Type::kTimestamp:
+    case hdk::ir::Type::kInterval:
       return createFixedLengthEncoderBySize(buffer, type->size());
     default:
       CHECK(false);

--- a/omniscidb/DataProvider/TableFragmentsInfo.h
+++ b/omniscidb/DataProvider/TableFragmentsInfo.h
@@ -25,8 +25,6 @@
 #include <map>
 #include <mutex>
 
-class ResultSet;
-
 /**
  * @class FragmentInfo
  * @brief Used by Fragmenter classes to store info about each
@@ -36,13 +34,7 @@ class ResultSet;
 
 class FragmentInfo {
  public:
-  FragmentInfo()
-      : fragmentId(-1)
-      , shadowNumTuples(0)
-      , physicalTableId(-1)
-      , resultSet(nullptr)
-      , numTuples(0)
-      , synthesizedNumTuplesIsValid(false) {}
+  FragmentInfo() : fragmentId(-1), physicalTableId(-1), numTuples(0) {}
 
   void setChunkMetadataMap(const ChunkMetadataMap& chunk_metadata_map) {
     this->chunkMetadataMap = chunk_metadata_map;
@@ -66,20 +58,13 @@ class FragmentInfo {
 
   void setPhysicalNumTuples(const size_t physNumTuples) { numTuples = physNumTuples; }
 
-  void invalidateNumTuples() const { synthesizedNumTuplesIsValid = false; }
-
   int fragmentId;
-  size_t shadowNumTuples;
   std::vector<int> deviceIds;
   int physicalTableId;
-  ChunkMetadataMap shadowChunkMetadataMap;
-  mutable ResultSet* resultSet;
-  mutable std::shared_ptr<std::mutex> resultSetMutex;
 
  private:
   mutable size_t numTuples;
   mutable ChunkMetadataMap chunkMetadataMap;
-  mutable bool synthesizedNumTuplesIsValid;
 };
 
 class TableFragmentsInfo {

--- a/omniscidb/IR/Expr.cpp
+++ b/omniscidb/IR/Expr.cpp
@@ -1298,7 +1298,8 @@ bool ArrayExpr::operator==(Expr const& rhs) const {
 }
 
 std::string ColumnVar::toString() const {
-  return "(ColumnVar table: " + std::to_string(tableId()) +
+  return "(ColumnVar db: " + std::to_string(dbId()) +
+         " table: " + std::to_string(tableId()) +
          " column: " + std::to_string(columnId()) + " rte: " + std::to_string(rte_idx_) +
          " " + type()->toString() + ") ";
 }

--- a/omniscidb/IR/Expr.h
+++ b/omniscidb/IR/Expr.h
@@ -132,14 +132,19 @@ class ColumnVar : public Expr {
       , rte_idx_(-1)
       , col_info_(std::make_shared<ColumnInfo>(-1, 0, 0, "", type_, false)) {}
   ColumnVar(const hdk::ir::Type* type,
+            int db_id,
             int table_id,
             int col_id,
             int nest_level,
             bool is_virtual = false)
       : Expr(type)
       , rte_idx_(nest_level)
-      , col_info_(
-            std::make_shared<ColumnInfo>(-1, table_id, col_id, "", type_, is_virtual)) {}
+      , col_info_(std::make_shared<ColumnInfo>(db_id,
+                                               table_id,
+                                               col_id,
+                                               "",
+                                               type_,
+                                               is_virtual)) {}
   int dbId() const { return col_info_->db_id; }
   int tableId() const { return col_info_->table_id; }
   int columnId() const { return col_info_->column_id; }

--- a/omniscidb/QueryEngine/ColumnFetcher.h
+++ b/omniscidb/QueryEngine/ColumnFetcher.h
@@ -68,7 +68,7 @@ class ColumnFetcher {
   const int8_t* getOneTableColumnFragment(
       ColumnInfoPtr col_info,
       const int frag_id,
-      const std::map<int, const TableFragments*>& all_tables_fragments,
+      const std::map<TableRef, const TableFragments*>& all_tables_fragments,
       std::list<std::shared_ptr<Chunk_NS::Chunk>>& chunk_holder,
       std::list<ChunkIter>& chunk_iter_holder,
       const Data_Namespace::MemoryLevel memory_level,
@@ -77,23 +77,15 @@ class ColumnFetcher {
 
   const int8_t* getAllTableColumnFragments(
       ColumnInfoPtr col_info,
-      const std::map<int, const TableFragments*>& all_tables_fragments,
+      const std::map<TableRef, const TableFragments*>& all_tables_fragments,
       const Data_Namespace::MemoryLevel memory_level,
       const int device_id,
       DeviceAllocator* device_allocator,
       const size_t thread_idx) const;
 
-  const int8_t* getResultSetColumn(const int table_id,
-                                   const int col_id,
-                                   const int frag_id,
-                                   const Data_Namespace::MemoryLevel memory_level,
-                                   const int device_id,
-                                   DeviceAllocator* device_allocator,
-                                   const size_t thread_idx) const;
-
   const int8_t* linearizeColumnFragments(
       ColumnInfoPtr col_info,
-      const std::map<int, const TableFragments*>& all_tables_fragments,
+      const std::map<TableRef, const TableFragments*>& all_tables_fragments,
       std::list<std::shared_ptr<Chunk_NS::Chunk>>& chunk_holder,
       std::list<ChunkIter>& chunk_iter_holder,
       const Data_Namespace::MemoryLevel memory_level,
@@ -158,15 +150,6 @@ class ColumnFetcher {
                              ChunkIter& chunk_iter,
                              bool is_true_varlen_type,
                              const size_t total_num_tuples) const;
-
-  const int8_t* getResultSetColumn(const ResultSetPtr& buffer,
-                                   const int table_id,
-                                   const int frag_id,
-                                   const int col_id,
-                                   const Data_Namespace::MemoryLevel memory_level,
-                                   const int device_id,
-                                   DeviceAllocator* device_allocator,
-                                   const size_t thread_idx) const;
 
   Executor* executor_;
   DataProvider* data_provider_;

--- a/omniscidb/QueryEngine/Descriptors/InputDescriptors.h
+++ b/omniscidb/QueryEngine/Descriptors/InputDescriptors.h
@@ -19,11 +19,10 @@
 
 #include "Logger/Logger.h"
 #include "SchemaMgr/ColumnInfo.h"
+#include "SchemaMgr/TableInfo.h"
 #include "Shared/toString.h"
 
 #include <memory>
-
-enum class InputSourceType { TABLE, RESULT };
 
 class InputDescriptor {
  public:
@@ -41,9 +40,7 @@ class InputDescriptor {
 
   int getNestLevel() const { return nest_level_; }
 
-  InputSourceType getSourceType() const {
-    return table_id_ > 0 ? InputSourceType::TABLE : InputSourceType::RESULT;
-  }
+  TableRef getTableRef() const { return {db_id_, table_id_}; }
 
   std::string toString() const {
     return ::typeName(this) + "(table_id=" + std::to_string(table_id_) +
@@ -86,14 +83,12 @@ class InputColDescriptor {
 
   int getDatabaseId() const { return col_info_->db_id; }
 
+  TableRef getTableRef() const { return {getDatabaseId(), getTableId()}; }
+
   int getNestLevel() const { return nest_level_; }
 
   InputDescriptor getScanDesc() const {
     return {col_info_->db_id, col_info_->table_id, nest_level_};
-  }
-
-  InputSourceType getSourceType() const {
-    return col_info_->table_id > 0 ? InputSourceType::TABLE : InputSourceType::RESULT;
   }
 
   const hdk::ir::Type* type() const { return col_info_->type; }

--- a/omniscidb/QueryEngine/Descriptors/QueryFragmentDescriptor.h
+++ b/omniscidb/QueryEngine/Descriptors/QueryFragmentDescriptor.h
@@ -71,7 +71,7 @@ class QueryFragmentDescriptor {
                           const std::vector<size_t> allowed_outer_fragment_indices);
 
   static void computeAllTablesFragments(
-      std::map<int, const TableFragments*>& all_tables_fragments,
+      std::map<TableRef, const TableFragments*>& all_tables_fragments,
       const RelAlgExecutionUnit& ra_exe_unit,
       const std::vector<InputTableInfo>& query_infos);
 
@@ -155,7 +155,7 @@ class QueryFragmentDescriptor {
   size_t outer_fragments_size_ = 0;
   int64_t rowid_lookup_key_ = -1;
 
-  std::map<int, const TableFragments*> selected_tables_fragments_;
+  std::map<TableRef, const TableFragments*> selected_tables_fragments_;
 
   std::map<ExecutorDeviceType, std::map<int, std::vector<ExecutionKernelDescriptor>>>
       execution_kernels_per_device_;

--- a/omniscidb/QueryEngine/Execute.h
+++ b/omniscidb/QueryEngine/Execute.h
@@ -153,20 +153,6 @@ inline hdk::ResultSetTableTokenPtr get_temporary_table(
   return it->second;
 }
 
-inline const hdk::ir::Type* get_column_type(const int col_id,
-                                            const int table_id,
-                                            ColumnInfoPtr col_info,
-                                            const TemporaryTables* temporary_tables) {
-  CHECK(col_info || temporary_tables);
-  if (col_info) {
-    CHECK_EQ(col_id, col_info->column_id);
-    CHECK_EQ(table_id, col_info->table_id);
-    return col_info->type;
-  }
-  auto token = get_temporary_table(temporary_tables, table_id);
-  return token->resultSet(0)->colType(col_id);
-}
-
 // TODO(alex): Adjust interfaces downstream and make this not needed.
 inline std::vector<const hdk::ir::Expr*> get_exprs_not_owned(
     const std::vector<hdk::ir::ExprPtr>& exprs) {
@@ -564,7 +550,7 @@ class Executor : public StringDictionaryProxyProvider {
       const ExecutorDeviceType device_type,
       const size_t table_idx,
       const size_t outer_frag_idx,
-      std::map<int, const TableFragments*>& selected_tables_fragments,
+      std::map<TableRef, const TableFragments*>& selected_tables_fragments,
       const std::unordered_map<int, const hdk::ir::BinOper*>&
           inner_table_id_to_join_condition);
 
@@ -580,7 +566,7 @@ class Executor : public StringDictionaryProxyProvider {
                           const RelAlgExecutionUnit& ra_exe_unit,
                           const int device_id,
                           const Data_Namespace::MemoryLevel,
-                          const std::map<int, const TableFragments*>&,
+                          const std::map<TableRef, const TableFragments*>&,
                           const FragmentsList& selected_fragments,
                           std::list<ChunkIter>&,
                           std::list<std::shared_ptr<Chunk_NS::Chunk>>&,
@@ -592,7 +578,7 @@ class Executor : public StringDictionaryProxyProvider {
                                const RelAlgExecutionUnit& ra_exe_unit,
                                const int device_id,
                                const Data_Namespace::MemoryLevel,
-                               const std::map<int, const TableFragments*>&,
+                               const std::map<TableRef, const TableFragments*>&,
                                const FragmentsList& selected_fragments,
                                std::list<ChunkIter>&,
                                std::list<std::shared_ptr<Chunk_NS::Chunk>>&,
@@ -605,7 +591,7 @@ class Executor : public StringDictionaryProxyProvider {
       const RelAlgExecutionUnit& ra_exe_unit,
       const CartesianProduct<std::vector<std::vector<size_t>>>& frag_ids_crossjoin,
       const std::vector<InputDescriptor>& input_descs,
-      const std::map<int, const TableFragments*>& all_tables_fragments);
+      const std::map<TableRef, const TableFragments*>& all_tables_fragments);
 
   void buildSelectedFragsMapping(
       std::vector<std::vector<size_t>>& selected_fragments_crossjoin,

--- a/omniscidb/QueryEngine/ExecutionKernel.cpp
+++ b/omniscidb/QueryEngine/ExecutionKernel.cpp
@@ -183,7 +183,7 @@ void ExecutionKernel::runImpl(Executor* executor,
   }
   std::shared_ptr<FetchResult> fetch_result(new FetchResult);
   try {
-    std::map<int, const TableFragments*> all_tables_fragments;
+    std::map<TableRef, const TableFragments*> all_tables_fragments;
     TableFragments streaming_table_fragment;
     QueryFragmentDescriptor::computeAllTablesFragments(
         all_tables_fragments, ra_exe_unit_, shared_context.getQueryInfos());
@@ -195,7 +195,7 @@ void ExecutionKernel::runImpl(Executor* executor,
         CHECK(data_provider);
         auto table_meta = data_provider->getTableMetadata(qi.db_id, qi.table_id);
         streaming_table_fragment = table_meta.fragments;
-        all_tables_fragments[qi.table_id] = &streaming_table_fragment;
+        all_tables_fragments[{qi.db_id, qi.table_id}] = &streaming_table_fragment;
       }
     }
 

--- a/omniscidb/QueryEngine/ExternalExecutor.cpp
+++ b/omniscidb/QueryEngine/ExternalExecutor.cpp
@@ -364,14 +364,9 @@ std::vector<TargetMetaInfo> create_table_schema(const PlanState* plan_state) {
     const int table_id = kv.first.getTableId();
     const int column_id = kv.first.getColId();
     const hdk::ir::Type* column_type;
-    if (table_id < 0) {
-      auto token =
-          get_temporary_table(plan_state->executor_->getTemporaryTables(), table_id);
-      column_type = token->resultSet(0)->colType(column_id);
-    } else {
-      const auto col_info = schema_provider->getColumnInfo(db_id, table_id, column_id);
-      column_type = col_info->type;
-    }
+    const auto col_info = schema_provider->getColumnInfo(db_id, table_id, column_id);
+    CHECK(col_info);
+    column_type = col_info->type;
     if (!is_supported_type_for_extern_execution(column_type)) {
       throw std::runtime_error("Type not supported yet for extern execution: " +
                                column_type->toString());

--- a/omniscidb/QueryEngine/JoinHashTable/BaselineJoinHashTable.cpp
+++ b/omniscidb/QueryEngine/JoinHashTable/BaselineJoinHashTable.cpp
@@ -242,7 +242,8 @@ void BaselineJoinHashTable::reify(const HashType preferred_layout) {
 }
 
 void BaselineJoinHashTable::reifyWithLayout(const HashType layout) {
-  const auto& query_info = get_inner_query_info(getInnerTableId(), query_infos_).info;
+  const auto& query_info =
+      get_inner_query_info(getInnerDbId(), getInnerTableId(), query_infos_).info;
   if (query_info.fragments.empty()) {
     return;
   }
@@ -928,6 +929,12 @@ llvm::Value* BaselineJoinHashTable::hashPtr(const size_t index,
 #undef LL_INT
 #undef LL_BUILDER
 #undef LL_CONTEXT
+
+int BaselineJoinHashTable::getInnerDbId() const noexcept {
+  CHECK(!inner_outer_pairs_.empty());
+  const auto first_inner_col = inner_outer_pairs_.front().first;
+  return first_inner_col->dbId();
+}
 
 int BaselineJoinHashTable::getInnerTableId() const noexcept {
   try {

--- a/omniscidb/QueryEngine/JoinHashTable/BaselineJoinHashTable.h
+++ b/omniscidb/QueryEngine/JoinHashTable/BaselineJoinHashTable.h
@@ -74,6 +74,8 @@ class BaselineJoinHashTable : public HashJoin {
   HashJoinMatchingSet codegenMatchingSet(const CompilationOptions&,
                                          const size_t) override;
 
+  int getInnerDbId() const noexcept override;
+
   int getInnerTableId() const noexcept override;
 
   int getInnerTableRteIdx() const noexcept override;
@@ -95,14 +97,16 @@ class BaselineJoinHashTable : public HashJoin {
   std::string getHashJoinType() const final { return "Baseline"; }
 
   static auto getCacheInvalidator() -> std::function<void()> {
-    CHECK(hash_table_cache_);
-    CHECK(hash_table_layout_cache_);
     return []() -> void {
-      auto layout_cache_invalidator = hash_table_layout_cache_->getCacheInvalidator();
-      layout_cache_invalidator();
+      if (hash_table_layout_cache_) {
+        auto layout_cache_invalidator = hash_table_layout_cache_->getCacheInvalidator();
+        layout_cache_invalidator();
+      }
 
-      auto main_cache_invalidator = hash_table_cache_->getCacheInvalidator();
-      main_cache_invalidator();
+      if (hash_table_cache_) {
+        auto main_cache_invalidator = hash_table_cache_->getCacheInvalidator();
+        main_cache_invalidator();
+      }
     };
   }
 

--- a/omniscidb/QueryEngine/JoinHashTable/HashJoin.cpp
+++ b/omniscidb/QueryEngine/JoinHashTable/HashJoin.cpp
@@ -474,6 +474,7 @@ std::vector<InputTableInfo> getSyntheticInputTableInfo(
   std::vector<InputTableInfo> query_infos(phys_table_ids.size());
   size_t i = 0;
   for (auto [db_id, table_id] : phys_table_ids) {
+    query_infos[i].db_id = db_id;
     query_infos[i].table_id = table_id;
     query_infos[i].info = executor->getDataMgr()->getTableMetadata(db_id, table_id);
     ++i;
@@ -670,8 +671,8 @@ InnerOuter HashJoin::normalizeColumnPair(const hdk::ir::Expr* lhs,
   // We need to fetch the actual type information from the schema provider since
   // Analyzer always reports nullable as true for inner table columns in left joins.
   const auto inner_col_info = schema_provider->getColumnInfo(*inner_col->columnInfo());
-  const auto inner_col_real_type = get_column_type(
-      inner_col->columnId(), inner_col->tableId(), inner_col_info, temporary_tables);
+  CHECK(inner_col_info);
+  const auto inner_col_real_type = inner_col_info->type;
   auto outer_col_type = !(dynamic_cast<const hdk::ir::FunctionOper*>(lhs)) && outer_col
                             ? outer_col->type()
                             : outer_type;

--- a/omniscidb/QueryEngine/JoinHashTable/HashJoin.h
+++ b/omniscidb/QueryEngine/JoinHashTable/HashJoin.h
@@ -114,6 +114,8 @@ class HashJoin {
   virtual HashJoinMatchingSet codegenMatchingSet(const CompilationOptions&,
                                                  const size_t) = 0;
 
+  virtual int getInnerDbId() const noexcept = 0;
+
   virtual int getInnerTableId() const noexcept = 0;
 
   virtual int getInnerTableRteIdx() const noexcept = 0;

--- a/omniscidb/QueryEngine/JoinHashTable/Runtime/HashJoinRuntime.cpp
+++ b/omniscidb/QueryEngine/JoinHashTable/Runtime/HashJoinRuntime.cpp
@@ -215,7 +215,7 @@ void SUFFIX(init_hash_join_buff_tbb)(int32_t* groups_buffer,
 #endif  // #ifndef __CUDACC__
 
 #ifdef __CUDACC__
-#define hdk_cas(address, compare, val) atomicCAS(address, compare, val)
+#define hdk_cas(address, compare, val) (atomicCAS(address, compare, val) == compare)
 #elif defined(_MSC_VER)
 #define hdk_cas(ptr, expected, desired) template <typename T>
 template <typename T>

--- a/omniscidb/QueryEngine/NativeCodegen.cpp
+++ b/omniscidb/QueryEngine/NativeCodegen.cpp
@@ -981,16 +981,11 @@ void Executor::createErrorCheckControlFlow(
             if (!input_table_infos.empty()) {
               const auto& outer_table_info = *input_table_infos.begin();
               auto num_outer_table_tuples = outer_table_info.info.getNumTuples();
-              if (outer_table_info.table_id < 0) {
-                auto* rs = (*outer_table_info.info.fragments.begin()).resultSet;
-                CHECK(rs);
-                num_outer_table_tuples = rs->entryCount();
-              } else {
-                auto num_frags = outer_table_info.info.fragments.size();
-                if (num_frags > 0) {
-                  num_outer_table_tuples =
-                      outer_table_info.info.fragments.begin()->getNumTuples();
-                }
+              CHECK_GT(outer_table_info.table_id, 0);
+              auto num_frags = outer_table_info.info.fragments.size();
+              if (num_frags > 0) {
+                num_outer_table_tuples =
+                    outer_table_info.info.fragments.begin()->getNumTuples();
               }
               if (num_outer_table_tuples > 0) {
                 // gridSize * blockSize --> pos_step (idx of the next row per thread)

--- a/omniscidb/QueryEngine/PlanState.cpp
+++ b/omniscidb/QueryEngine/PlanState.cpp
@@ -25,15 +25,13 @@ bool PlanState::isLazyFetchColumn(const hdk::ir::Expr* target_expr) const {
   if (!do_not_fetch_column || dynamic_cast<const hdk::ir::Var*>(do_not_fetch_column)) {
     return false;
   }
-  if (do_not_fetch_column->tableId() > 0) {
-    auto col_info =
-        executor_->getSchemaProvider()->getColumnInfo(do_not_fetch_column->dbId(),
-                                                      do_not_fetch_column->tableId(),
-                                                      do_not_fetch_column->columnId());
-    CHECK(col_info);
-    if (col_info->is_rowid) {
-      return false;
-    }
+  auto col_info =
+      executor_->getSchemaProvider()->getColumnInfo(do_not_fetch_column->dbId(),
+                                                    do_not_fetch_column->tableId(),
+                                                    do_not_fetch_column->columnId());
+  CHECK(col_info);
+  if (col_info->is_rowid) {
+    return false;
   }
   InputColDescriptorSet intersect;
   std::set_intersection(columns_to_fetch_.begin(),

--- a/omniscidb/QueryEngine/QueryPhysicalInputsCollector.cpp
+++ b/omniscidb/QueryEngine/QueryPhysicalInputsCollector.cpp
@@ -273,5 +273,6 @@ TableInfoMap get_physical_table_infos(const hdk::ir::Node* ra) {
 }
 
 std::ostream& operator<<(std::ostream& os, PhysicalInput const& physical_input) {
-  return os << '(' << physical_input.col_id << ',' << physical_input.table_id << ')';
+  return os << '(' << physical_input.col_id << ',' << physical_input.table_id << ','
+            << physical_input.db_id << ')';
 }

--- a/omniscidb/QueryEngine/QueryPhysicalInputsCollector.h
+++ b/omniscidb/QueryEngine/QueryPhysicalInputsCollector.h
@@ -37,11 +37,16 @@ class Node;
 }
 
 struct PhysicalInput {
+  PhysicalInput(int col_id_, int table_id_, int db_id_)
+      : col_id(col_id_), table_id(table_id_), db_id(db_id_) {}
+  PhysicalInput(const PhysicalInput& other) = default;
+
   int col_id;
   int table_id;
+  int db_id;
 
   bool operator==(const PhysicalInput& that) const {
-    return col_id == that.col_id && table_id == that.table_id;
+    return col_id == that.col_id && table_id == that.table_id && db_id == that.db_id;
   }
 };
 

--- a/omniscidb/QueryEngine/RelAlgExecutor.h
+++ b/omniscidb/QueryEngine/RelAlgExecutor.h
@@ -53,6 +53,7 @@ class RelAlgExecutor {
   RelAlgExecutor(Executor* executor,
                  SchemaProviderPtr schema_provider,
                  std::unique_ptr<hdk::ir::QueryDag> query_dag);
+  ~RelAlgExecutor();
 
   ExecutionResult executeRelAlgQuery(const CompilationOptions& co,
                                      const ExecutionOptions& eo,
@@ -223,8 +224,6 @@ class RelAlgExecutor {
     const auto it_ok = temporary_tables_.emplace(table_id, token);
     CHECK(it_ok.second);
   }
-
-  void eraseFromTemporaryTables(const int table_id) { temporary_tables_.erase(table_id); }
 
   void handleNop(RaExecutionDesc& ed);
 

--- a/omniscidb/QueryEngine/RelAlgSchemaProvider.cpp
+++ b/omniscidb/QueryEngine/RelAlgSchemaProvider.cpp
@@ -30,8 +30,12 @@ RelAlgSchemaProvider::RelAlgSchemaProvider(const hdk::ir::Node& root) {
 }
 
 std::vector<int> RelAlgSchemaProvider::listDatabases() const {
-  UNREACHABLE();
-  return std::vector<int>{};
+  std::vector<int> res;
+  res.reserve(table_index_by_name_.size());
+  for (auto& pr : table_index_by_name_) {
+    res.push_back(pr.first);
+  }
+  return res;
 }
 
 TableInfoList RelAlgSchemaProvider::listTables(int db_id) const {

--- a/omniscidb/QueryEngine/RelAlgTranslator.cpp
+++ b/omniscidb/QueryEngine/RelAlgTranslator.cpp
@@ -232,8 +232,9 @@ class NormalizerVisitor : public hdk::ir::ExprRewriter {
       }
     }
 
+    auto token = executor_->getTemporaryTable(-source->getId());
     return std::make_shared<hdk::ir::ColumnVar>(
-        col_type, -source->getId(), col_idx, rte_idx);
+        col_type, token->dbId(), token->tableId(), col_idx + 1, rte_idx);
   }
 
   hdk::ir::ExprPtr visitBinOper(const hdk::ir::BinOper* bin_oper) override {

--- a/omniscidb/ResultSet/RowSetMemoryOwner.h
+++ b/omniscidb/ResultSet/RowSetMemoryOwner.h
@@ -99,6 +99,7 @@ class RowSetMemoryOwner final : public SimpleAllocator, boost::noncopyable {
   void addVarlenInputBuffer(Data_Namespace::AbstractBuffer* buffer) {
     std::lock_guard<std::mutex> lock(state_mutex_);
     CHECK_EQ(buffer->getType(), Data_Namespace::MemoryLevel::GPU_LEVEL);
+    buffer->pin();
     varlen_input_buffers_.push_back(buffer);
   }
 

--- a/omniscidb/ResultSetRegistry/ResultSetMetadata.cpp
+++ b/omniscidb/ResultSetRegistry/ResultSetMetadata.cpp
@@ -33,7 +33,7 @@ ChunkMetadataMap synthesizeMetadata(const ResultSet* rows) {
     for (size_t i = 0; i < rows->colCount(); ++i) {
       decoders.emplace_back(Encoder::Create(nullptr, rows->colType(i)));
       const auto it_ok =
-          metadata_map.emplace(i, decoders.back()->getMetadata(rows->colType(i)));
+          metadata_map.emplace(i + 1, decoders.back()->getMetadata(rows->colType(i)));
       CHECK(it_ok.second);
     }
     return metadata_map;
@@ -136,8 +136,12 @@ ChunkMetadataMap synthesizeMetadata(const ResultSet* rows) {
     }
   }
   for (size_t i = 0; i < rows->colCount(); ++i) {
-    const auto it_ok =
-        metadata_map.emplace(i, dummy_encoders[0][i]->getMetadata(rows->colType(i)));
+    auto meta = std::make_shared<ChunkMetadata>(
+        rows->colType(i),
+        rows->rowCount() * rows->colType(i)->size(),
+        rows->rowCount(),
+        dummy_encoders[0][i]->getMetadata(rows->colType(i))->chunkStats());
+    const auto it_ok = metadata_map.emplace(i + 1, meta);
     CHECK(it_ok.second);
   }
   return metadata_map;

--- a/omniscidb/ResultSetRegistry/ResultSetRegistry.h
+++ b/omniscidb/ResultSetRegistry/ResultSetRegistry.h
@@ -40,10 +40,6 @@ class ResultSetRegistry : public SimpleSchemaProvider,
   ResultSetPtr get(const ResultSetTableToken& token, size_t frag_id) const;
   void drop(const ResultSetTableToken& token);
 
-  ChunkStats getChunkStats(const ResultSetTableToken& token,
-                           size_t frag_idx,
-                           size_t col_idx) const;
-
   void fetchBuffer(const ChunkKey& key,
                    Data_Namespace::AbstractBuffer* dest,
                    const size_t num_bytes = 0) override;
@@ -58,6 +54,8 @@ class ResultSetRegistry : public SimpleSchemaProvider,
 
  private:
   bool useColumnarResults(const ResultSet& rs) const;
+
+  ChunkStats getChunkStats(int table_id, size_t frag_idx, size_t col_idx) const;
 
   struct DataFragment {
     size_t offset = 0;

--- a/omniscidb/ResultSetRegistry/ResultSetTableToken.cpp
+++ b/omniscidb/ResultSetRegistry/ResultSetTableToken.cpp
@@ -35,9 +35,4 @@ void ResultSetTableToken::reset() {
   }
 }
 
-ChunkStats ResultSetTableToken::getChunkStats(size_t rs_idx, size_t col_idx) const {
-  CHECK(!empty());
-  return registry_->getChunkStats(*this, rs_idx, col_idx);
-}
-
 }  // namespace hdk

--- a/omniscidb/ResultSetRegistry/ResultSetTableToken.h
+++ b/omniscidb/ResultSetRegistry/ResultSetTableToken.h
@@ -42,8 +42,6 @@ class ResultSetTableToken {
   size_t resultSetCount() const { return tinfo_->fragments; }
   ResultSetPtr resultSet(size_t idx) const;
 
-  ChunkStats getChunkStats(size_t rs_idx, size_t col_idx) const;
-
   static std::string tableName(int table_id) {
     return std::string("__result_set_") + std::to_string(table_id);
   }

--- a/omniscidb/SchemaMgr/TableInfo.h
+++ b/omniscidb/SchemaMgr/TableInfo.h
@@ -31,6 +31,10 @@ struct TableRef {
     return table_id == other.table_id && db_id == other.db_id;
   }
 
+  bool operator<(const TableRef& other) const {
+    return std::tie(db_id, table_id) < std::tie(other.db_id, other.table_id);
+  }
+
   std::string toString() const {
     return ::typeName(this) + "(db_id=" + std::to_string(db_id) +
            ", table_id=" + std::to_string(table_id) + ")";

--- a/omniscidb/Tests/ArrowBasedExecuteTest.cpp
+++ b/omniscidb/Tests/ArrowBasedExecuteTest.cpp
@@ -16927,10 +16927,10 @@ TEST_F(Select, FilterNodeCoalesce) {
     }
     const auto buffer_pool_stats = getBufferPoolStats();
     ASSERT_GE(buffer_pool_stats.num_buffers, static_cast<size_t>(2));
-    ASSERT_EQ(buffer_pool_stats.num_tables, static_cast<size_t>(1));
-    ASSERT_EQ(buffer_pool_stats.num_columns, static_cast<size_t>(2));
-    ASSERT_EQ(buffer_pool_stats.num_fragments, static_cast<size_t>(1));
-    ASSERT_EQ(buffer_pool_stats.num_chunks, static_cast<size_t>(2));
+    ASSERT_GE(buffer_pool_stats.num_tables, static_cast<size_t>(1));
+    ASSERT_GE(buffer_pool_stats.num_columns, static_cast<size_t>(2));
+    ASSERT_GE(buffer_pool_stats.num_fragments, static_cast<size_t>(1));
+    ASSERT_GE(buffer_pool_stats.num_chunks, static_cast<size_t>(2));
   }
 
   // Single-step window function
@@ -16947,10 +16947,10 @@ TEST_F(Select, FilterNodeCoalesce) {
 
     const auto buffer_pool_stats = getBufferPoolStats();
     ASSERT_GE(buffer_pool_stats.num_buffers, static_cast<size_t>(3));
-    ASSERT_EQ(buffer_pool_stats.num_tables, static_cast<size_t>(1));
-    ASSERT_EQ(buffer_pool_stats.num_columns, static_cast<size_t>(3));
-    ASSERT_EQ(buffer_pool_stats.num_fragments, static_cast<size_t>(1));
-    ASSERT_EQ(buffer_pool_stats.num_chunks, static_cast<size_t>(3));
+    ASSERT_GE(buffer_pool_stats.num_tables, static_cast<size_t>(1));
+    ASSERT_GE(buffer_pool_stats.num_columns, static_cast<size_t>(3));
+    ASSERT_GE(buffer_pool_stats.num_fragments, static_cast<size_t>(1));
+    ASSERT_GE(buffer_pool_stats.num_chunks, static_cast<size_t>(3));
   }
 
   // Multi-step window function to ensure project is inserted before each window step
@@ -16968,10 +16968,10 @@ TEST_F(Select, FilterNodeCoalesce) {
 
     const auto buffer_pool_stats = getBufferPoolStats();
     ASSERT_GE(buffer_pool_stats.num_buffers, static_cast<size_t>(3));
-    ASSERT_EQ(buffer_pool_stats.num_tables, static_cast<size_t>(1));
-    ASSERT_EQ(buffer_pool_stats.num_columns, static_cast<size_t>(3));
-    ASSERT_EQ(buffer_pool_stats.num_fragments, static_cast<size_t>(1));
-    ASSERT_EQ(buffer_pool_stats.num_chunks, static_cast<size_t>(3));
+    ASSERT_GE(buffer_pool_stats.num_tables, static_cast<size_t>(1));
+    ASSERT_GE(buffer_pool_stats.num_columns, static_cast<size_t>(3));
+    ASSERT_GE(buffer_pool_stats.num_fragments, static_cast<size_t>(1));
+    ASSERT_GE(buffer_pool_stats.num_chunks, static_cast<size_t>(3));
   }
 
   // Multi-fragment window function with filter should run due to preceding compound node
@@ -16988,10 +16988,10 @@ TEST_F(Select, FilterNodeCoalesce) {
 
     const auto buffer_pool_stats = getBufferPoolStats();
     ASSERT_GE(buffer_pool_stats.num_buffers, static_cast<size_t>(30));
-    ASSERT_EQ(buffer_pool_stats.num_tables, static_cast<size_t>(1));
-    ASSERT_EQ(buffer_pool_stats.num_columns, static_cast<size_t>(3));
-    ASSERT_EQ(buffer_pool_stats.num_fragments, static_cast<size_t>(10));
-    ASSERT_EQ(buffer_pool_stats.num_chunks, static_cast<size_t>(30));
+    ASSERT_GE(buffer_pool_stats.num_tables, static_cast<size_t>(1));
+    ASSERT_GE(buffer_pool_stats.num_columns, static_cast<size_t>(3));
+    ASSERT_GE(buffer_pool_stats.num_fragments, static_cast<size_t>(10));
+    ASSERT_GE(buffer_pool_stats.num_chunks, static_cast<size_t>(30));
   }
 
   {
@@ -17005,10 +17005,10 @@ TEST_F(Select, FilterNodeCoalesce) {
     }
     const auto buffer_pool_stats = getBufferPoolStats();
     ASSERT_GE(buffer_pool_stats.num_buffers, static_cast<size_t>(30));
-    ASSERT_EQ(buffer_pool_stats.num_tables, static_cast<size_t>(1));
-    ASSERT_EQ(buffer_pool_stats.num_columns, static_cast<size_t>(3));
-    ASSERT_EQ(buffer_pool_stats.num_fragments, static_cast<size_t>(10));
-    ASSERT_EQ(buffer_pool_stats.num_chunks, static_cast<size_t>(30));
+    ASSERT_GE(buffer_pool_stats.num_tables, static_cast<size_t>(1));
+    ASSERT_GE(buffer_pool_stats.num_columns, static_cast<size_t>(3));
+    ASSERT_GE(buffer_pool_stats.num_fragments, static_cast<size_t>(10));
+    ASSERT_GE(buffer_pool_stats.num_chunks, static_cast<size_t>(30));
   }
 }
 

--- a/omniscidb/Tests/ArrowSQLRunner/ArrowSQLRunner.cpp
+++ b/omniscidb/Tests/ArrowSQLRunner/ArrowSQLRunner.cpp
@@ -19,6 +19,8 @@
 #include "DataMgr/DataMgr.h"
 #include "DataMgr/DataMgrDataProvider.h"
 #include "QueryEngine/RelAlgExecutor.h"
+#include "ResultSetRegistry/ResultSetRegistry.h"
+#include "SchemaMgr/SchemaMgr.h"
 
 #include "SQLiteComparator.h"
 

--- a/omniscidb/Tests/CodeGeneratorTest.cpp
+++ b/omniscidb/Tests/CodeGeneratorTest.cpp
@@ -148,7 +148,7 @@ TEST(CodeGeneratorTest, IntegerColumn) {
   int column_id = 5;
   int rte_idx = 0;
 
-  auto col = hdk::ir::makeExpr<hdk::ir::ColumnVar>(type, table_id, column_id, rte_idx);
+  auto col = hdk::ir::makeExpr<hdk::ir::ColumnVar>(type, 0, table_id, column_id, rte_idx);
   const auto compiled_expr = code_generator.compile(col.get(), true, co, get_traits());
 
   compiler::verify_function_ir(compiled_expr.func);
@@ -178,7 +178,7 @@ TEST(CodeGeneratorTest, IntegerExpr) {
   int table_id = 1;
   int column_id = 5;
   int rte_idx = 0;
-  auto lhs = hdk::ir::makeExpr<hdk::ir::ColumnVar>(type, table_id, column_id, rte_idx);
+  auto lhs = hdk::ir::makeExpr<hdk::ir::ColumnVar>(type, 0, table_id, column_id, rte_idx);
   Datum d;
   d.intval = 42;
 
@@ -334,7 +334,7 @@ TEST(CodeGeneratorTest, IntegerColumnGPU) {
   int column_id = 5;
   int rte_idx = 0;
 
-  auto col = hdk::ir::makeExpr<hdk::ir::ColumnVar>(type, table_id, column_id, rte_idx);
+  auto col = hdk::ir::makeExpr<hdk::ir::ColumnVar>(type, 0, table_id, column_id, rte_idx);
   const auto compiled_expr = code_generator.compile(col.get(), true, co, get_traits());
 
   compiler::verify_function_ir(compiled_expr.func);
@@ -395,7 +395,7 @@ TEST(CodeGeneratorTest, IntegerExprGPU) {
   int table_id = 1;
   int column_id = 5;
   int rte_idx = 0;
-  auto lhs = hdk::ir::makeExpr<hdk::ir::ColumnVar>(type, table_id, column_id, rte_idx);
+  auto lhs = hdk::ir::makeExpr<hdk::ir::ColumnVar>(type, 0, table_id, column_id, rte_idx);
   Datum d;
   d.intval = 42;
 

--- a/omniscidb/Tests/FromTableReorderingTest.cpp
+++ b/omniscidb/Tests/FromTableReorderingTest.cpp
@@ -30,8 +30,8 @@ hdk::ir::Context& ctx = hdk::ir::Context::defaultCtx();
 TEST(Ordering, Basic) {
   // Basic test of inner join ordering. Equal table sizes.
   {
-    auto a1 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 0, 0, 0);
-    auto a2 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 1, 1);
+    auto a1 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 0, 0, 0);
+    auto a2 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 1, 1, 1);
     auto op = std::make_shared<hdk::ir::BinOper>(
         ctx.int32(), hdk::ir::OpType::kGt, hdk::ir::Qualifier::kOne, a1, a2);
 
@@ -49,8 +49,8 @@ TEST(Ordering, Basic) {
 
   // Basic test of inner join ordering. Descending table sizes.
   {
-    auto a1 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 0, 0, 0);
-    auto a2 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 1, 1);
+    auto a1 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 0, 0, 0);
+    auto a2 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 1, 1, 1);
     auto op = std::make_shared<hdk::ir::BinOper>(
         ctx.int32(), hdk::ir::OpType::kGt, hdk::ir::Qualifier::kOne, a1, a2);
 
@@ -70,8 +70,8 @@ TEST(Ordering, Basic) {
 
   // Basic test of inner join ordering. Ascending table sizes.
   {
-    auto a1 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 0, 0, 0);
-    auto a2 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 1, 1);
+    auto a1 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 0, 0, 0);
+    auto a2 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 1, 1, 1);
     auto op = std::make_shared<hdk::ir::BinOper>(
         ctx.int32(), hdk::ir::OpType::kGt, hdk::ir::Qualifier::kOne, a1, a2);
 
@@ -91,8 +91,8 @@ TEST(Ordering, Basic) {
 
   // Basic test of left join ordering. Equal table sizes.
   {
-    auto a1 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 0, 0, 0);
-    auto a2 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 1, 1);
+    auto a1 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 0, 0, 0);
+    auto a2 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 1, 1, 1);
     auto op = std::make_shared<hdk::ir::BinOper>(
         ctx.int32(), hdk::ir::OpType::kGt, hdk::ir::Qualifier::kOne, a1, a2);
 
@@ -110,8 +110,8 @@ TEST(Ordering, Basic) {
 
   // Basic test of left join ordering. Descending table sizes.
   {
-    auto a1 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 0, 0, 0);
-    auto a2 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 1, 1);
+    auto a1 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 0, 0, 0);
+    auto a2 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 1, 1, 1);
     auto op = std::make_shared<hdk::ir::BinOper>(
         ctx.int32(), hdk::ir::OpType::kGt, hdk::ir::Qualifier::kOne, a1, a2);
 
@@ -131,8 +131,8 @@ TEST(Ordering, Basic) {
 
   // Basic test of left join ordering. Ascending table sizes.
   {
-    auto a1 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 0, 0, 0);
-    auto a2 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 1, 1);
+    auto a1 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 0, 0, 0);
+    auto a2 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 1, 1, 1);
     auto op = std::make_shared<hdk::ir::BinOper>(
         ctx.int32(), hdk::ir::OpType::kGt, hdk::ir::Qualifier::kOne, a1, a2);
 
@@ -154,9 +154,9 @@ TEST(Ordering, Basic) {
 TEST(Ordering, Triple) {
   // Triple test of inner join ordering. Equal table sizes.
   {
-    auto a1 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 0, 0, 0);
-    auto a2 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 1, 1);
-    auto a3 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 2, 2, 2);
+    auto a1 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 0, 0, 0);
+    auto a2 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 1, 1, 1);
+    auto a3 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 2, 2, 2);
     auto op1 = std::make_shared<hdk::ir::BinOper>(
         ctx.int32(), hdk::ir::OpType::kEq, hdk::ir::Qualifier::kOne, a1, a2);
     auto op2 = std::make_shared<hdk::ir::BinOper>(
@@ -178,9 +178,9 @@ TEST(Ordering, Triple) {
 
   // Triple test of inner join ordering. Descending table sizes.
   {
-    auto a1 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 0, 0, 0);
-    auto a2 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 1, 1);
-    auto a3 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 2, 2, 2);
+    auto a1 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 0, 0, 0);
+    auto a2 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 1, 1, 1);
+    auto a3 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 2, 2, 2);
     auto op1 = std::make_shared<hdk::ir::BinOper>(
         ctx.int32(), hdk::ir::OpType::kEq, hdk::ir::Qualifier::kOne, a1, a2);
     auto op2 = std::make_shared<hdk::ir::BinOper>(
@@ -205,9 +205,9 @@ TEST(Ordering, Triple) {
 
   // Triple test of inner join ordering. Ascending table sizes.
   {
-    auto a1 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 0, 0, 0);
-    auto a2 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 1, 1);
-    auto a3 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 2, 2, 2);
+    auto a1 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 0, 0, 0);
+    auto a2 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 1, 1, 1);
+    auto a3 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 2, 2, 2);
     auto op1 = std::make_shared<hdk::ir::BinOper>(
         ctx.int32(), hdk::ir::OpType::kEq, hdk::ir::Qualifier::kOne, a1, a2);
     auto op2 = std::make_shared<hdk::ir::BinOper>(
@@ -232,9 +232,9 @@ TEST(Ordering, Triple) {
 
   // Triple test of left join ordering. Equal table sizes.
   {
-    auto a1 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 0, 0, 0);
-    auto a2 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 1, 1);
-    auto a3 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 2, 2, 2);
+    auto a1 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 0, 0, 0);
+    auto a2 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 1, 1, 1);
+    auto a3 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 2, 2, 2);
     auto op1 = std::make_shared<hdk::ir::BinOper>(
         ctx.int32(), hdk::ir::OpType::kEq, hdk::ir::Qualifier::kOne, a1, a2);
     auto op2 = std::make_shared<hdk::ir::BinOper>(
@@ -256,9 +256,9 @@ TEST(Ordering, Triple) {
 
   // Triple test of left join ordering. Descending table sizes.
   {
-    auto a1 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 0, 0, 0);
-    auto a2 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 1, 1);
-    auto a3 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 2, 2, 2);
+    auto a1 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 0, 0, 0);
+    auto a2 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 1, 1, 1);
+    auto a3 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 2, 2, 2);
     auto op1 = std::make_shared<hdk::ir::BinOper>(
         ctx.int32(), hdk::ir::OpType::kEq, hdk::ir::Qualifier::kOne, a1, a2);
     auto op2 = std::make_shared<hdk::ir::BinOper>(
@@ -283,9 +283,9 @@ TEST(Ordering, Triple) {
 
   // Triple test of left join ordering. Ascending table sizes.
   {
-    auto a1 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 0, 0, 0);
-    auto a2 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 1, 1);
-    auto a3 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 2, 2, 2);
+    auto a1 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 0, 0, 0);
+    auto a2 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 1, 1, 1);
+    auto a3 = std::make_shared<hdk::ir::ColumnVar>(ctx.int32(false), 1, 2, 2, 2);
     auto op1 = std::make_shared<hdk::ir::BinOper>(
         ctx.int32(), hdk::ir::OpType::kEq, hdk::ir::Qualifier::kOne, a1, a2);
     auto op2 = std::make_shared<hdk::ir::BinOper>(

--- a/omniscidb/Tests/GroupByTest.cpp
+++ b/omniscidb/Tests/GroupByTest.cpp
@@ -136,13 +136,18 @@ std::unordered_set<InputColDescriptor> setup_str_col_caching(
   std::unordered_set<std::pair<int, int>> phys_table_ids;
   phys_table_ids.insert({group_col_desc.getDatabaseId(), group_col_desc.getTableId()});
   executor->setupCaching(data_provider, col_descs, phys_table_ids);
-  auto filter_col_range =
-      executor->getColRange({filter_col_desc.getColId(), filter_col_desc.getTableId()});
+  auto filter_col_range = executor->getColRange({filter_col_desc.getColId(),
+                                                 filter_col_desc.getTableId(),
+                                                 filter_col_desc.getDatabaseId()});
   // reset the col range to trigger the optimization
   AggregatedColRange col_range_cache;
-  col_range_cache.setColRange({group_col_desc.getColId(), group_col_desc.getTableId()},
+  col_range_cache.setColRange({group_col_desc.getColId(),
+                               group_col_desc.getTableId(),
+                               group_col_desc.getDatabaseId()},
                               ExpressionRange::makeIntRange(min, max, 0, false));
-  col_range_cache.setColRange({filter_col_desc.getColId(), filter_col_desc.getTableId()},
+  col_range_cache.setColRange({filter_col_desc.getColId(),
+                               filter_col_desc.getTableId(),
+                               group_col_desc.getDatabaseId()},
                               filter_col_range);
   executor->setColRangeCache(col_range_cache);
   return col_descs;


### PR DESCRIPTION
With this patch, we finally start using ResultSetRegistry through DataProvider and SchemaProvider interfaces. So, we don't use negative table ids anymore and those code branches can be removed (I removed those I could find but some might remain).