### PR TITLE
hdk_cas fixes for CUDA and Windows

### DIFF
--- a/omniscidb/QueryEngine/JoinHashTable/Runtime/HashJoinRuntime.cpp
+++ b/omniscidb/QueryEngine/JoinHashTable/Runtime/HashJoinRuntime.cpp
@@ -217,17 +217,16 @@ void SUFFIX(init_hash_join_buff_tbb)(int32_t* groups_buffer,
 #ifdef __CUDACC__
 #define hdk_cas(address, compare, val) (atomicCAS(address, compare, val) == compare)
 #elif defined(_MSC_VER)
-#define hdk_cas(ptr, expected, desired) template <typename T>
 template <typename T>
-bool hdk_cas(T* ptr, T* expected, T desired) {
+bool hdk_cas(T* ptr, T expected, T desired) {
   if constexpr (sizeof(T) == 4) {
     return InterlockedCompareExchange(reinterpret_cast<volatile long*>(ptr),
                                       static_cast<long>(desired),
-                                      static_cast<long>(*expected)) ==
-           static_cast<long>(*expected);
+                                      static_cast<long>(expected)) ==
+           static_cast<long>(expected);
   } else if constexpr (sizeof(T) == 8) {
     return InterlockedCompareExchange64(
-               reinterpret_cast<volatile int64_t*>(ptr), desired, *expected) == *expected;
+               reinterpret_cast<volatile int64_t*>(ptr), desired, expected) == expected;
   } else {
     LOG(FATAL) << "Unsupported atomic operation";
   }

--- a/omniscidb/QueryEngine/JoinHashTable/Runtime/HashJoinRuntime.cpp
+++ b/omniscidb/QueryEngine/JoinHashTable/Runtime/HashJoinRuntime.cpp
@@ -215,7 +215,7 @@ void SUFFIX(init_hash_join_buff_tbb)(int32_t* groups_buffer,
 #endif  // #ifndef __CUDACC__
 
 #ifdef __CUDACC__
-#define hdk_cas(address, compare, val) atomicCAS(address, compare, val)
+#define hdk_cas(address, compare, val) (atomicCAS(address, compare, val) == compare)
 #elif defined(_MSC_VER)
 #define hdk_cas(ptr, expected, desired) template <typename T>
 template <typename T>


### PR DESCRIPTION
Currently, CUDA version of `hdk_cas` misses the comparison of the result and therefore always succeeds when the target memory holds a non-zero value.

For Windows, `hdk_cas` has a different signature (takes a pointer instead of a value as the second arg) which I also fixed but didn't test it anyhow.
