### PR TITLE
Force deps resolving on link.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,9 @@ if (WIN32)
   add_compile_options(/Zc:__cplusplus)
 else()
   set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
+  # Do not allow undefined symbols when linking shared libraries because such symbols break
+  # Windows build.
+  add_link_options("LINKER:-z,defs,-ldl")
 endif()
 
 # set default build type to "Release w/ Debug Info" 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ else()
   set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
   # Do not allow undefined symbols when linking shared libraries because such symbols break
   # Windows build.
-  add_link_options("LINKER:-z,defs,-ldl")
+  add_link_options("LINKER:-z,defs")
 endif()
 
 # set default build type to "Release w/ Debug Info" 

--- a/omniscidb/Analyzer/Analyzer.cpp
+++ b/omniscidb/Analyzer/Analyzer.cpp
@@ -27,7 +27,6 @@
 #include "IR/ExprCollector.h"
 #include "IR/TypeUtils.h"
 #include "QueryEngine/DateTimeUtils.h"
-#include "QueryEngine/Execute.h"  // TODO: remove
 #include "Shared/DateConverters.h"
 #include "Shared/misc.h"
 #include "Shared/sqltypes.h"

--- a/omniscidb/Calcite/CMakeLists.txt
+++ b/omniscidb/Calcite/CMakeLists.txt
@@ -62,6 +62,6 @@ add_library(Calcite CalciteAdapter.cpp CalciteJNI.cpp SchemaJson.cpp)
 
 add_dependencies(Calcite calcite_java_lib)
 
-target_link_libraries(Calcite OSDependent Shared ${JAVA_JVM_LIBRARY})
+target_link_libraries(Calcite PRIVATE IR OSDependent Shared ${JAVA_JVM_LIBRARY})
 
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/java/calcite/target/calcite-1.0-SNAPSHOT-jar-with-dependencies.jar DESTINATION bin COMPONENT "jar")

--- a/omniscidb/CudaMgr/CMakeLists.txt
+++ b/omniscidb/CudaMgr/CMakeLists.txt
@@ -4,4 +4,4 @@ else()
     add_library(CudaMgr CudaMgrNoCuda.cpp)
 endif()
 
-target_link_libraries(CudaMgr Logger ${CUDA_LIBRARIES})
+target_link_libraries(CudaMgr Logger Shared ${CUDA_LIBRARIES})

--- a/omniscidb/CudaMgr/CudaMgr.cpp
+++ b/omniscidb/CudaMgr/CudaMgr.cpp
@@ -63,12 +63,6 @@ CudaMgr::CudaMgr(const int num_gpus, const int start_gpu)
   initDeviceGroup();
   createDeviceContexts();
   printDeviceProperties();
-
-  // warm up the GPU JIT
-  LOG(INFO) << "Warming up the GPU JIT Compiler... (this may take several seconds)";
-  setContext(0);
-  nvidia_jit_warmup();
-  LOG(INFO) << "GPU JIT Compiler initialized.";
 }
 
 void CudaMgr::initDeviceGroup() {

--- a/omniscidb/DataMgr/CMakeLists.txt
+++ b/omniscidb/DataMgr/CMakeLists.txt
@@ -43,7 +43,7 @@ endif()
 
 add_library(DataMgr ${datamgr_source_files})
 
-set(DataMgrLibs CudaMgr L0Mgr Shared SchemaMgr IR ${Boost_THREAD_LIBRARY} TBB::tbb ${CMAKE_DL_LIBS})
+set(DataMgrLibs CudaMgr L0Mgr Shared SchemaMgr IR ${Boost_THREAD_LIBRARY} TBB::tbb ${CMAKE_DL_LIBS} ${CUDA_LIBRARIES})
 if(ENABLE_FOLLY)
   list(APPEND DataMgrLibs ${Folly_LIBRARIES})
 endif()

--- a/omniscidb/OSDependent/Unix/CMakeLists.txt
+++ b/omniscidb/OSDependent/Unix/CMakeLists.txt
@@ -5,4 +5,4 @@ endif()
 add_library(OSDependent ${OSDEPENDENT_SOURCE_FILES})
 set_target_properties(OSDependent PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/..)
 
-target_link_libraries(OSDependent Logger)
+target_link_libraries(OSDependent Logger ${CMAKE_DL_LIBS})

--- a/omniscidb/Shared/CMakeLists.txt
+++ b/omniscidb/Shared/CMakeLists.txt
@@ -23,7 +23,7 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/funcannotations.h
 
 add_library(Shared ${shared_source_files} "cleanup_global_namespace.h"
                    "boost_stacktrace.hpp")
-target_link_libraries(Shared OSDependent Logger ${Boost_LIBRARIES} TBB::tbb)
+target_link_libraries(Shared OSDependent Logger ${Boost_LIBRARIES} TBB::tbb ${Folly_LIBRARIES})
 if("${MAPD_EDITION_LOWER}" STREQUAL "ee")
   target_link_libraries(Shared ${OPENSSL_LIBRARIES})
 endif()

--- a/omniscidb/ThirdParty/googletest/CMakeLists.txt
+++ b/omniscidb/ThirdParty/googletest/CMakeLists.txt
@@ -1,2 +1,5 @@
 include_directories(.)
 add_library(gtest gmock-gtest-all.cc)
+
+find_package(Threads REQUIRED)
+target_link_libraries(gtest PRIVATE Threads::Threads)

--- a/omniscidb/UdfCompiler/CMakeLists.txt
+++ b/omniscidb/UdfCompiler/CMakeLists.txt
@@ -16,5 +16,4 @@ find_package(Clang REQUIRED)
 include_directories(${CLANG_INCLUDE_DIRS})
 add_definitions(${CLANG_DEFINITIONS})
 
-target_link_libraries(UdfCompiler OSDependent ${clang_libs})
-
+target_link_libraries(UdfCompiler PRIVATE OSDependent Logger CudaMgr ${clang_libs} ${llvm_libs})


### PR DESCRIPTION
This change should help us stop breaking Windows build by introducing new circular and implicit dependencies.

We have one circular dependency right now for `nvidia_jit_warmup`. Moving this code to the `CudaMgr` doesn't seem right and this warmup doesn't seem so important. When we use HDK as a library, it shouldn't matter when exactly the first module compilation happens. And for perf measurements, we do some warmup queries anyway. I leave the warmup method in place just in case we want to call it somewhere on PyHDK init later. I'm open to other options here.
