### PR TITLE
Enable IN test, remove string-related queries.

### DIFF
--- a/omniscidb/QueryEngine/CgenState.cpp
+++ b/omniscidb/QueryEngine/CgenState.cpp
@@ -213,7 +213,7 @@ llvm::Value* CgenState::emitCall(const std::string& fname,
                                  const std::vector<llvm::Value*>& args) {
   // Get the function reference from the query module.
   auto func = module_->getFunction(fname);
-  CHECK(func);
+  CHECK(func) << "Unable to find function \"" << fname << "\" in the module.";
   // If the function called isn't external, clone the implementation from the runtime
   // module.
   maybeCloneFunctionRecursive(func, is_l0_module(module_));

--- a/omniscidb/Tests/IntelGPUEnablingTest.cpp
+++ b/omniscidb/Tests/IntelGPUEnablingTest.cpp
@@ -787,19 +787,22 @@ TEST_F(BasicTest, TimeExtract) {
 }
 
 TEST_F(BasicTest, In) {
-  GTEST_SKIP();
   c("SELECT COUNT(*) FROM test WHERE x IN (7, 8);", g_dt);
   c("SELECT COUNT(*) FROM test WHERE x IN (9, 10);", g_dt);
   c("SELECT COUNT(*) FROM test WHERE z IN (101, 102);", g_dt);
   c("SELECT COUNT(*) FROM test WHERE z IN (201, 202);", g_dt);
+  c("SELECT COUNT(*) FROM test WHERE x IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, "
+    "14, 15, 16, 17, 18, 19, 20);",
+    g_dt);
+}
+
+TEST_F(BasicTest, InWithStrings) {
+  GTEST_SKIP();
   c("SELECT COUNT(*) FROM test WHERE real_str IN ('real_foo', 'real_bar');", g_dt);
   c("SELECT COUNT(*) FROM test WHERE real_str IN ('real_foo', 'real_bar', 'real_baz', "
     "'foo');",
     g_dt);
   c("SELECT COUNT(*) FROM test WHERE str IN ('foo', 'bar', 'real_foo');", g_dt);
-  c("SELECT COUNT(*) FROM test WHERE x IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, "
-    "14, 15, 16, 17, 18, 19, 20);",
-    g_dt);
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
Creating the PR mostly because the CgenState check fails often. This one adds the missing info.