### PR TITLE
Add dependency-reduced-pom to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ __pycache__
 # Logs
 hdk_log/*
 omniscidb/Calcite/java/calcite/hdk_log/*
+omniscidb/Calcite/java/calcite/dependency-reduced-pom.xml


### PR DESCRIPTION
This file was introduced with an update to one of the Calcite java packages. I do not think we need to commit it.