### PR TITLE
[CI] Rename jobs

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   build:
+    name: env=Docker build_type=${{ inputs.name }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -58,10 +59,25 @@ jobs:
             rm -rf /tmp/.buildx-cache
             mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
+      - name: Restore Maven cache
+        id: maven-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2
+          key: maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: maven-
+
       - name: Start the container
         run:  |
           mkdir -p build
           docker run -id --name build.${{ inputs.name }} --network host -v $(pwd):/_work build.${{ inputs.name }}:latest
+
+      - name: Copy maven cache inside container
+        if: steps.maven-cache.cache-hit == 'true'
+        run: |
+          docker cp ~/.m2 build.${{ inputs.name }}:/home/ghrunner/.m2
+          docker exec -u ghrunner -i build.${{ inputs.name }} chown -R ghrunner:ghrunner /home/ghrunner
 
       - name: Configure and build the project
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ on:
 
 jobs:
   build:
+    name: env=Conda build_type=${{ inputs.name }}
     runs-on: ubuntu-latest
 
     outputs:
@@ -84,10 +85,10 @@ jobs:
         with:
           path: |
             ~/.m2
-          key: ${{ env.RUN_STAMP }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ env.RUN_STAMP }}-maven-
+          key: maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: maven-
 
-      - name: Build
+      - name: env=Conda build_type=${{ inputs.name }}
         run: |
           set -vx
           conda info

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Build
+name: CI
 on:
   workflow_dispatch:
     inputs:
@@ -13,13 +13,12 @@ on:
     - cron: '51 2 * * *'
 
 jobs:
-  modin:
-    uses: ./.github/workflows/modin.yml
-
   build:
+    name: Build
     uses: ./.github/workflows/build.yml
 
   build-cuda:
+    name: Build
     uses: ./.github/workflows/build.yml
     with:
       name: cuda
@@ -27,12 +26,14 @@ jobs:
       options: -DENABLE_CUDA=on
 
   build-l0:
+    name: Build
     uses: ./.github/workflows/build.yml
     with:
       name: l0
       options: -DENABLE_L0=on
 
   build-both-l0-cuda:
+    name: Build
     uses: ./.github/workflows/build.yml
     with:
       name: 'all-gpus'
@@ -40,6 +41,7 @@ jobs:
       options: -DENABLE_L0=on -DENABLE_CUDA=on
 
   style:
+    name: Style-check
     needs: build
     uses: ./.github/workflows/test.yml
     with:
@@ -47,6 +49,7 @@ jobs:
       test: style
 
   sanity:
+    name: Sanity test (Gtests)
     needs: build
     uses: ./.github/workflows/test.yml
     with:
@@ -54,6 +57,7 @@ jobs:
       test: sanity
 
   asan:
+    name: Asan test (Gtests)
     needs: build
     uses: ./.github/workflows/test.yml
     with:
@@ -69,12 +73,14 @@ jobs:
 
 
   build-cuda-docker:
+    name: Build
     uses: ./.github/workflows/build-docker.yml
     with:
       name: cuda
       options: -DENABLE_PYTHON=off 
 
   test-cuda-docker:
+    name: Sanity test (Gtests)
     needs: build-cuda-docker
     uses: ./.github/workflows/test-docker.yml
     with:
@@ -83,17 +89,24 @@ jobs:
       reset-cache: ${{ !!inputs.reset-cache }}
 
   build-l0-docker:
+    name: Build 
     uses: ./.github/workflows/build-docker.yml
     with:
       name: l0
       options: -DENABLE_L0=on -DENABLE_CUDA=off -DENABLE_PYTHON=off 
 
   test-l0-docker:
+    name: Sanity test (Gtests) 
     needs: build-l0-docker
     uses: ./.github/workflows/test-l0-docker.yml
     with:
       name: l0
       reset-cache: ${{ !!inputs.reset-cache }}
 
+  modin:
+    name: Integration HDK with Modin (Pytest)
+    uses: ./.github/workflows/modin.yml
+
   pytest:
+    name: PyHDK (Pytest)
     uses: ./.github/workflows/pytest.yml

--- a/.github/workflows/modin.yml
+++ b/.github/workflows/modin.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    name: Build and Test (env=Conda build_type=cpu)
     runs-on: ubuntu-latest
 
     env:
@@ -35,8 +36,8 @@ jobs:
         with:
           path: |
             ~/.m2
-          key: ${{ env.RUN_STAMP }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ env.RUN_STAMP }}-maven
+          key: maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: maven-
 
       - name: Build
         env:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,6 +4,7 @@ on:
 
 jobs:
   build:
+    name: Build and Test (env=Conda build_type=cpu)
     runs-on: ubuntu-latest
 
     env:
@@ -39,8 +40,8 @@ jobs:
         with:
           path: |
             ~/.m2
-          key: ${{ env.RUN_STAMP }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ env.RUN_STAMP }}-maven
+          key: maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: maven-
 
       - name: Build
         env:

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   build:
+    name: Test (env=Docker build_type=${{ inputs.name }})
     runs-on: [self-hosted, linux, docker]
     steps:
       - name: Clean
@@ -50,7 +51,7 @@ jobs:
           docker exec hdk-build.${{ inputs.name }} chown -R ghrunner:ghrunner /_work/
           docker exec -u ghrunner hdk-build.${{ inputs.name }} tar -zxf /_work/build.tgz -C /_work/
 
-      - name: sanity test
+      - name: Sanity test
         if: inputs.name == 'cuda'
         run: |
           docker exec -u ghrunner hdk-build.${{ inputs.name }} dpkg -l

--- a/.github/workflows/test-l0-docker.yml
+++ b/.github/workflows/test-l0-docker.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   build:
+    name: Test (env=Docker build_type=${{ inputs.name }})
     runs-on: [self-hosted, linux, intel-ai.hdk.l0]
     steps:
       - name: Clean
@@ -52,7 +53,7 @@ jobs:
           docker exec hdk-build.${{ inputs.name }} chown -R ghrunner:ghrunner /_work/
           docker exec -u ghrunner hdk-build.${{ inputs.name }} tar -zxf /_work/build.tgz -C /_work/
 
-      - name: sanity test
+      - name: Sanity test
         if: inputs.name == 'l0'
         run: |
           docker exec -u ghrunner hdk-build.${{ inputs.name }} dpkg -l

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   test:
+    name: Test (env=Conda build_type=${{ inputs.name }})
     runs-on: ubuntu-latest
 
     steps:
@@ -63,7 +64,6 @@ jobs:
 
       - name: Run ASAN test
         if: inputs.test == 'asan'
-
         run: |
           sudo sh -c 'echo 2 >/proc/sys/vm/overcommit_memory'
 


### PR DESCRIPTION
This pr adds names to jobs to make CI more clear.
Also maven packages are configuration agnostic (cpu/gpu conda/docker)
so maven caching will also use one key for all these cases.

Signed-off-by: Dmitrii Makarenko <dmitrii.makarenko@intel.com>