### PR TITLE
Temporary disable string queries for L0

### DIFF
--- a/omniscidb/QueryEngine/InValuesBitmap.cpp
+++ b/omniscidb/QueryEngine/InValuesBitmap.cpp
@@ -44,7 +44,7 @@ InValuesBitmap::InValuesBitmap(const std::vector<int64_t>& values,
     , memory_level_(memory_level)
     , device_count_(device_count)
     , buffer_provider_(buffer_provider) {
-#ifdef HAVE_CUDA
+#if defined(HAVE_CUDA) || defined(HAVE_L0)
   CHECK(memory_level_ == Data_Namespace::CPU_LEVEL ||
         memory_level == Data_Namespace::GPU_LEVEL);
 #else
@@ -87,7 +87,7 @@ InValuesBitmap::InValuesBitmap(const std::vector<int64_t>& values,
     }
     agg_count_distinct_bitmap(reinterpret_cast<int64_t*>(&cpu_bitset), value, min_val_);
   }
-#ifdef HAVE_CUDA
+#if defined(HAVE_CUDA) || defined(HAVE_L0)
   if (memory_level_ == Data_Namespace::GPU_LEVEL) {
     for (int device_id = 0; device_id < device_count_; ++device_id) {
       gpu_buffers_.emplace_back(GpuAllocator::allocGpuAbstractBuffer(

--- a/omniscidb/QueryEngine/WorkUnitBuilder.cpp
+++ b/omniscidb/QueryEngine/WorkUnitBuilder.cpp
@@ -502,12 +502,11 @@ void WorkUnitBuilder::processSort(const ir::Sort* sort) {
       throw std::runtime_error("Columns with array types cannot be used for sorting.");
     }
 #ifdef HAVE_L0
-    if (expr->type()->isString() ||
-        (expr->type()->isExtDictionary() &&
-         expr->type()->as<hdk::ir::ExtDictionaryType>()->elemType()->isString())) {
-      if (co_.device_type == ExecutorDeviceType::GPU) {
-        throw QueryMustRunOnCpu();
-      }
+    if ((expr->type()->isString() ||
+         (expr->type()->isExtDictionary() &&
+          expr->type()->as<hdk::ir::ExtDictionaryType>()->elemType()->isString())) &&
+        co_.device_type == ExecutorDeviceType::GPU) {
+      throw QueryMustRunOnCpu();
     }
 #endif
   }
@@ -772,15 +771,14 @@ void WorkUnitBuilder::computeInputColDescs() {
 #ifdef HAVE_L0
   ColumnVarSet non_targets_touch = collector.result();
   for (const auto& col_var : non_targets_touch) {
-    if (col_var.columnInfo()->type->isString() ||
-        (col_var.columnInfo()->type->isExtDictionary() &&
-         col_var.columnInfo()
-             ->type->as<hdk::ir::ExtDictionaryType>()
-             ->elemType()
-             ->isString())) {
-      if (co_.device_type == ExecutorDeviceType::GPU) {
-        throw QueryMustRunOnCpu();
-      }
+    if ((col_var.columnInfo()->type->isString() ||
+         (col_var.columnInfo()->type->isExtDictionary() &&
+          col_var.columnInfo()
+              ->type->as<hdk::ir::ExtDictionaryType>()
+              ->elemType()
+              ->isString())) &&
+        co_.device_type == ExecutorDeviceType::GPU) {
+      throw QueryMustRunOnCpu();
     }
   }
 #endif

--- a/omniscidb/QueryEngine/WorkUnitBuilder.cpp
+++ b/omniscidb/QueryEngine/WorkUnitBuilder.cpp
@@ -441,7 +441,7 @@ void WorkUnitBuilder::processFilter(const ir::Filter* filter) {
   auto rte_idx = all_nest_levels_.at(filter);
 
   if (co_.device_type == ExecutorDeviceType::GPU && executor_ &&
-      executor_->getDataMgr() && executor_->getDataMgr()->getGpuMgr() &&
+      executor_->getDataMgr()->getGpuMgr() &&
       executor_->getDataMgr()->getGpuMgr()->getPlatform() == GpuMgrPlatform::L0) {
     StringGuardForL0 strConstCollector;
     strConstCollector.visit(filter->getConditionExpr());
@@ -504,7 +504,7 @@ void WorkUnitBuilder::processSort(const ir::Sort* sort) {
       throw std::runtime_error("Columns with array types cannot be used for sorting.");
     }
     if ((co_.device_type == ExecutorDeviceType::GPU && executor_ &&
-         executor_->getDataMgr() && executor_->getDataMgr()->getGpuMgr() &&
+         executor_->getDataMgr()->getGpuMgr() &&
          executor_->getDataMgr()->getGpuMgr()->getPlatform() == GpuMgrPlatform::L0) &&
         (expr->type()->isString() ||
          (expr->type()->isExtDictionary() &&
@@ -772,7 +772,7 @@ void WorkUnitBuilder::computeInputColDescs() {
   }
 
   if (co_.device_type == ExecutorDeviceType::GPU && executor_ &&
-      executor_->getDataMgr() && executor_->getDataMgr()->getGpuMgr() &&
+      executor_->getDataMgr()->getGpuMgr() &&
       executor_->getDataMgr()->getGpuMgr()->getPlatform() == GpuMgrPlatform::L0) {
     ColumnVarSet non_targets_touch = collector.result();
     for (const auto& col_var : non_targets_touch) {

--- a/omniscidb/QueryEngine/WorkUnitBuilder.cpp
+++ b/omniscidb/QueryEngine/WorkUnitBuilder.cpp
@@ -440,7 +440,8 @@ void WorkUnitBuilder::processFilter(const ir::Filter* filter) {
       executor_, input_nest_levels_, join_types_, now_, eo_.just_explain);
   auto rte_idx = all_nest_levels_.at(filter);
 
-  if (co_.device_type == ExecutorDeviceType::GPU &&
+  if (co_.device_type == ExecutorDeviceType::GPU && executor_ &&
+      executor_->getDataMgr() && executor_->getDataMgr()->getGpuMgr() &&
       executor_->getDataMgr()->getGpuMgr()->getPlatform() == GpuMgrPlatform::L0) {
     StringGuardForL0 strConstCollector;
     strConstCollector.visit(filter->getConditionExpr());
@@ -502,7 +503,8 @@ void WorkUnitBuilder::processSort(const ir::Sort* sort) {
     if (expr->type()->isArray()) {
       throw std::runtime_error("Columns with array types cannot be used for sorting.");
     }
-    if ((co_.device_type == ExecutorDeviceType::GPU &&
+    if ((co_.device_type == ExecutorDeviceType::GPU && executor_ &&
+         executor_->getDataMgr() && executor_->getDataMgr()->getGpuMgr() &&
          executor_->getDataMgr()->getGpuMgr()->getPlatform() == GpuMgrPlatform::L0) &&
         (expr->type()->isString() ||
          (expr->type()->isExtDictionary() &&
@@ -769,7 +771,8 @@ void WorkUnitBuilder::computeInputColDescs() {
     }
   }
 
-  if (co_.device_type == ExecutorDeviceType::GPU &&
+  if (co_.device_type == ExecutorDeviceType::GPU && executor_ &&
+      executor_->getDataMgr() && executor_->getDataMgr()->getGpuMgr() &&
       executor_->getDataMgr()->getGpuMgr()->getPlatform() == GpuMgrPlatform::L0) {
     ColumnVarSet non_targets_touch = collector.result();
     for (const auto& col_var : non_targets_touch) {


### PR DESCRIPTION
Addresses #379.
Detect string related queries and fall back to CPU from L0, extend memory level handling for L0.

- Select.FilterShortCircuit - runs on L0
- Select.InValues - runs on L0
- Select.ComplexQueries - fallback to CPU (on string-related queries)
- Select.Case - fallback to CPU (on string-related queries) / `PerfectJoinHashTable` is not functional for L0
- Select.Strings - fallback to CPU
- Select.SharedDictionary - fallback to CPU
- Select.StringCompare - fallback to CPU
- Select.DictionaryStringEquality - explicitly disallows CPU retry