### PR TITLE
Fixed generation of left shift on windows

### DIFF
--- a/omniscidb/QueryEngine/RowFuncBuilder.cpp
+++ b/omniscidb/QueryEngine/RowFuncBuilder.cpp
@@ -877,10 +877,11 @@ llvm::Value* RowFuncBuilder::codegenAggColumnPtr(
       CHECK(out_row_idx);
       uint32_t col_off = query_mem_desc.getColOffInBytes(agg_out_off);
       // multiplying by chosen_bytes, i.e., << log2(chosen_bytes)
-      auto out_per_col_byte_idx =
 #ifdef _WIN32
-          LL_BUILDER.CreateShl(out_row_idx, __lzcnt(chosen_bytes) - 1);
+      auto out_per_col_byte_idx =
+          LL_BUILDER.CreateShl(out_row_idx, 32 - __lzcnt(chosen_bytes) - 1);
 #else
+      auto out_per_col_byte_idx =
           LL_BUILDER.CreateShl(out_row_idx, __builtin_ffs(chosen_bytes) - 1);
 #endif
       auto byte_offset = LL_BUILDER.CreateAdd(out_per_col_byte_idx,


### PR DESCRIPTION
`__lzcnt` counts leading zeroes in a 32-bit value, different from what `__builtin_ffs` does on Linux.