### PR TITLE
Disable optimizing out function bodies on windows

### DIFF
--- a/omniscidb/QueryEngine/RuntimeFunctions.cpp
+++ b/omniscidb/QueryEngine/RuntimeFunctions.cpp
@@ -1652,7 +1652,7 @@ extern "C" RUNTIME_EXPORT NOREMOVE NEVER_INLINE void query_stub_hoisted_literals
     GENERIC_ADDR_SPACE const int64_t* join_hash_tables,
     GENERIC_ADDR_SPACE int32_t* error_code,
     GENERIC_ADDR_SPACE int32_t* total_matched) {
-#if !defined(_WIN32) && !defined(L0_RUNTIME_ENABLED)
+#if !defined(L0_RUNTIME_ENABLED)
   assert(col_buffers || literals || num_rows || frag_row_offsets || max_matched ||
          init_agg_value || out || frag_idx || error_code || join_hash_tables ||
          total_matched);
@@ -1708,7 +1708,7 @@ extern "C" RUNTIME_EXPORT NOREMOVE NEVER_INLINE void query_stub(
     GENERIC_ADDR_SPACE const int64_t* join_hash_tables,
     GENERIC_ADDR_SPACE int32_t* error_code,
     GENERIC_ADDR_SPACE int32_t* total_matched) {
-#if !defined(_WIN32) && !defined(L0_RUNTIME_ENABLED)
+#if !defined(L0_RUNTIME_ENABLED)
   assert(col_buffers || num_rows || frag_row_offsets || max_matched || init_agg_value ||
          out || frag_idx || error_code || join_hash_tables || total_matched);
 #endif


### PR DESCRIPTION
Without assert in the function body it becomes empty and calling functions are optimizing out too.