### PR TITLE
Disable inline of CodegenTraits::get to prevent cross-DLL access to descCallingConvToLLVM

### DIFF
--- a/omniscidb/QueryEngine/Compiler/Backend.cpp
+++ b/omniscidb/QueryEngine/Compiler/Backend.cpp
@@ -57,6 +57,16 @@ const std::unordered_map<llvm::CallingConv::ID, CallingConvDesc>
         {llvm::CallingConv::SPIR_FUNC, CallingConvDesc::SPIR_FUNC},
     };
 
+CodegenTraits CodegenTraits::get(CodegenTraitsDescriptor codegen_traits_desc) {
+  CHECK(descCallingConvToLLVM.find(codegen_traits_desc.conv_) !=
+        descCallingConvToLLVM.end());
+  return CodegenTraits(codegen_traits_desc.local_addr_space_,
+                       codegen_traits_desc.smem_addr_space_,
+                       codegen_traits_desc.global_addr_space_,
+                       descCallingConvToLLVM.at(codegen_traits_desc.conv_),
+                       codegen_traits_desc.triple_);
+}
+
 CodegenTraitsDescriptor CodegenTraits::getDescriptor(unsigned local_addr_space,
                                                      unsigned shared_addr_space,
                                                      unsigned global_addr_space,

--- a/omniscidb/QueryEngine/Compiler/Backend.h
+++ b/omniscidb/QueryEngine/Compiler/Backend.h
@@ -62,16 +62,7 @@ class CodegenTraits {
         local_addr_space, smem_addr_space, global_addr_space, calling_conv, triple);
   }
 
-  static CodegenTraits get(CodegenTraitsDescriptor codegen_traits_desc) {
-    CHECK(descCallingConvToLLVM.find(codegen_traits_desc.conv_) !=
-          descCallingConvToLLVM.end());
-    return CodegenTraits(codegen_traits_desc.local_addr_space_,
-                         codegen_traits_desc.smem_addr_space_,
-                         codegen_traits_desc.global_addr_space_,
-                         descCallingConvToLLVM.at(codegen_traits_desc.conv_),
-                         codegen_traits_desc.triple_);
-  }
-
+  static CodegenTraits get(CodegenTraitsDescriptor codegen_traits_desc);
   static CodegenTraitsDescriptor getDescriptor(unsigned local_addr_space,
                                                unsigned shared_addr_space,
                                                unsigned global_addr_space,


### PR DESCRIPTION
When CodegenTraits::get is inlined in other DLLs or executables it makes it necessary to access descCallingConvToLLVM from another DLL/executable and it is not allowed for a static constant on windows.