### PR TITLE
Fixed inline functions declaration on windows

### DIFF
--- a/omniscidb/Shared/funcannotations.h
+++ b/omniscidb/Shared/funcannotations.h
@@ -50,7 +50,7 @@
     defined(WITH_JIT_DEBUG)
 #define ALWAYS_INLINE
 #elif defined(_WIN32)
-#define ALWAYS_INLINE __inline
+#define ALWAYS_INLINE
 #elif defined(ENABLE_SHARED_LIBS)
 // Protected visibility allows to inline non-private functions which can
 // be overwritten at dynamic link time with the default visibility.


### PR DESCRIPTION
If inline flag is present on windows then bodies of inline functions is not generated and then JIT fails to find these symbols.