### PR TITLE
Prevent zero-sized copies to/from GPU

### DIFF
--- a/omniscidb/L0Mgr/L0Mgr.cpp
+++ b/omniscidb/L0Mgr/L0Mgr.cpp
@@ -305,6 +305,8 @@ void L0Manager::copyHostToDevice(int8_t* device_ptr,
                                  const int8_t* host_ptr,
                                  const size_t num_bytes,
                                  const int device_num) {
+  if (!num_bytes)
+    return;
   CHECK(host_ptr);
   CHECK(device_ptr);
   CHECK_GT(num_bytes, 0);
@@ -323,6 +325,8 @@ void L0Manager::copyDeviceToHost(int8_t* host_ptr,
                                  const int8_t* device_ptr,
                                  const size_t num_bytes,
                                  const int device_num) {
+  if (!num_bytes)
+    return;
   CHECK(host_ptr);
   CHECK(device_ptr);
   CHECK_GT(num_bytes, 0);
@@ -363,6 +367,8 @@ void L0Manager::freeDeviceMem(int8_t* device_ptr) {
 void L0Manager::zeroDeviceMem(int8_t* device_ptr,
                               const size_t num_bytes,
                               const int device_num) {
+  if (!num_bytes)
+    return;
   CHECK(device_ptr);
   CHECK_GE(device_num, 0);
   CHECK_LT(device_num, drivers_[0]->devices().size());
@@ -373,6 +379,8 @@ void L0Manager::setDeviceMem(int8_t* device_ptr,
                              const unsigned char uc,
                              const size_t num_bytes,
                              const int device_num) {
+  if (!num_bytes)
+    return;
   CHECK(device_ptr);
   CHECK_GE(device_num, 0);
   CHECK_LT(device_num, drivers_[0]->devices().size());

--- a/omniscidb/L0Mgr/L0Mgr.cpp
+++ b/omniscidb/L0Mgr/L0Mgr.cpp
@@ -305,6 +305,12 @@ void L0Manager::copyHostToDevice(int8_t* device_ptr,
                                  const int8_t* host_ptr,
                                  const size_t num_bytes,
                                  const int device_num) {
+  CHECK(host_ptr);
+  CHECK(device_ptr);
+  CHECK_GT(num_bytes, 0);
+  CHECK_GE(device_num, 0);
+  CHECK_LT(device_num, drivers_[0]->devices().size());
+
   auto& device = drivers()[0]->devices()[device_num];
   auto cl = device->create_command_list();
   auto queue = device->command_queue();
@@ -317,6 +323,12 @@ void L0Manager::copyDeviceToHost(int8_t* host_ptr,
                                  const int8_t* device_ptr,
                                  const size_t num_bytes,
                                  const int device_num) {
+  CHECK(host_ptr);
+  CHECK(device_ptr);
+  CHECK_GT(num_bytes, 0);
+  CHECK_GE(device_num, 0);
+  CHECK_LT(device_num, drivers_[0]->devices().size());
+
   auto& device = drivers_[0]->devices()[device_num];
   auto cl = device->create_command_list();
   auto queue = device->command_queue();
@@ -343,6 +355,7 @@ void L0Manager::freePinnedHostMem(int8_t* host_ptr) {
 }
 
 void L0Manager::freeDeviceMem(int8_t* device_ptr) {
+  CHECK(device_ptr);
   auto ctx = drivers_[0]->ctx();
   L0_SAFE_CALL(zeMemFree(ctx, device_ptr));
 }
@@ -350,12 +363,20 @@ void L0Manager::freeDeviceMem(int8_t* device_ptr) {
 void L0Manager::zeroDeviceMem(int8_t* device_ptr,
                               const size_t num_bytes,
                               const int device_num) {
+  CHECK(device_ptr);
+  CHECK_GE(device_num, 0);
+  CHECK_LT(device_num, drivers_[0]->devices().size());
+  CHECK_GE(num_bytes, 0);
   setDeviceMem(device_ptr, 0, num_bytes, device_num);
 }
 void L0Manager::setDeviceMem(int8_t* device_ptr,
                              const unsigned char uc,
                              const size_t num_bytes,
                              const int device_num) {
+  CHECK(device_ptr);
+  CHECK_GE(device_num, 0);
+  CHECK_LT(device_num, drivers_[0]->devices().size());
+  CHECK_GE(num_bytes, 0);
   auto& device = drivers_[0]->devices()[device_num];
   auto cl = device->create_command_list();
   L0_SAFE_CALL(zeCommandListAppendMemoryFill(
@@ -371,7 +392,8 @@ void L0Manager::synchronizeDevices() const {
 }
 
 size_t L0Manager::getMaxAllocationSize(const int device_num) const {
-  CHECK_LE(device_num, drivers_[0]->devices().size());
+  CHECK_GE(device_num, 0);
+  CHECK_LT(device_num, drivers_[0]->devices().size());
   ze_device_properties_t device_properties;
   L0_SAFE_CALL(zeDeviceGetProperties(drivers_[0]->devices()[device_num]->device(),
                                      &device_properties));
@@ -382,6 +404,7 @@ size_t L0Manager::getMaxAllocationSize(const int device_num) const {
 }
 
 uint32_t L0Manager::getMaxBlockSize() const {
+  CHECK_GT(drivers_[0]->devices().size(), size_t(0));
   unsigned sz = drivers_[0]->devices()[0]->maxGroupSize();
   for (auto d : drivers_[0]->devices()) {
     sz = d->maxGroupSize() < sz ? d->maxGroupSize() : sz;
@@ -395,6 +418,7 @@ int8_t L0Manager::getSubGroupSize() const {
 }
 
 uint32_t L0Manager::getGridSize() const {
+  CHECK_GT(drivers_[0]->devices().size(), size_t(0));
   auto cnt = drivers_[0]->devices()[0]->maxGroupCount();
   for (auto d : drivers_[0]->devices()) {
     cnt = d->maxGroupCount() < cnt ? d->maxGroupCount() : cnt;

--- a/omniscidb/QueryEngine/Dispatchers/DefaultExecutionPolicy.h
+++ b/omniscidb/QueryEngine/Dispatchers/DefaultExecutionPolicy.h
@@ -23,6 +23,7 @@ class FragmentIDAssignmentExecutionPolicy : public ExecutionPolicy {
                                               size_t frag_id,
                                               size_t frag_num) const override;
   std::vector<ExecutorDeviceType> devices() const override;
+  std::string name() const override { return "ExecutionPolicy::FragmentIDAssignment"; };
 
  private:
   const ExecutorDeviceType dt_;

--- a/omniscidb/QueryEngine/Dispatchers/ExecutionPolicy.h
+++ b/omniscidb/QueryEngine/Dispatchers/ExecutionPolicy.h
@@ -16,6 +16,8 @@
 #include "DataProvider/TableFragmentsInfo.h"
 #include "QueryEngine/CompilationOptions.h"
 
+#include <ostream>
+
 namespace policy {
 using TableFragments = std::vector<FragmentInfo>;
 
@@ -32,8 +34,13 @@ class ExecutionPolicy {
   virtual std::vector<ExecutorDeviceType> devices() const {
     return {ExecutorDeviceType::CPU, ExecutorDeviceType::GPU};
   }
+  virtual std::string name() const = 0;
 
   virtual ~ExecutionPolicy() = default;
 };
+
+inline std::ostream& operator<<(std::ostream& os, const ExecutionPolicy& policy) {
+  return os << policy.name();
+}
 
 }  // namespace policy

--- a/omniscidb/QueryEngine/Dispatchers/ProportionBasedExecutionPolicy.h
+++ b/omniscidb/QueryEngine/Dispatchers/ProportionBasedExecutionPolicy.h
@@ -29,6 +29,8 @@ class ProportionBasedExecutionPolicy : public ExecutionPolicy {
                                               size_t frag_id,
                                               size_t frag_num) const override;
 
+  std::string name() const override { return "ExecutionPolicy::ProportionBased"; };
+
  private:
   std::map<ExecutorDeviceType, unsigned> proportion_;
   unsigned total_parts_;

--- a/omniscidb/QueryEngine/Dispatchers/RRExecutionPolicy.h
+++ b/omniscidb/QueryEngine/Dispatchers/RRExecutionPolicy.h
@@ -21,5 +21,7 @@ class RoundRobinExecutionPolicy : public ExecutionPolicy {
   SchedulingAssignment scheduleSingleFragment(const FragmentInfo&,
                                               size_t frag_id,
                                               size_t frag_num) const override;
+
+  std::string name() const override { return "ExecutionPolicy::RoundRobin"; };
 };
 }  // namespace policy

--- a/omniscidb/ResultSet/ResultType.h
+++ b/omniscidb/ResultSet/ResultType.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include <ostream>
+
 enum class QueryDescriptionType {
   GroupByPerfectHash,
   GroupByBaselineHash,
@@ -30,3 +32,20 @@ enum class QueryDescriptionType {
   NonGroupedAggregate,
   Estimator
 };
+
+inline std::ostream& operator<<(std::ostream& os, const QueryDescriptionType& t) {
+  switch (t) {
+    case QueryDescriptionType::GroupByPerfectHash:
+      return os << "QueryDescriptionType::GroupByPerfectHash";
+    case QueryDescriptionType::GroupByBaselineHash:
+      return os << "QueryDescriptionType::GroupByBaselineHash";
+    case QueryDescriptionType::Projection:
+      return os << "QueryDescriptionType::Projection";
+    case QueryDescriptionType::NonGroupedAggregate:
+      return os << "QueryDescriptionType::NonGroupedAggregate";
+    case QueryDescriptionType::Estimator:
+      return os << "QueryDescriptionType::Estimator";
+    default:
+      return os << "Invalid Query Description Type";
+  };
+}


### PR DESCRIPTION
Fixes #378. These now pass:

- Select.NullGroupBy
- Select.LimitAndOffset
- Select.CountWithLimitAndOffset
- Select.CastDecimalToDecimal
- Select.LogicalValues
- Select.BigintGroupByColCompactionTest
- Select.Empty
- Select.ArrowOutput
- Select.QuotedColumnIdentifier
- Select.OffsetInFragment