### PR TITLE
Create Calcite singleton using a dedicated worker thread

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -20,20 +20,28 @@ jobs:
           echo CONDA_ENV_PATH=$CONDA/envs/${{ env.CONDA_ENV }} >>$GITHUB_ENV
 
       - name: Restore Conda env cache
-        id: conda-cache
-        uses: actions/cache@v3
+        id: restore-conda-cache
+        uses: actions/cache/restore@v3
         with:
           path: |
             ${{ env.CONDA_ENV_PATH }}
-          key: ${{ env.RUN_STAMP }}-conda-${{ hashFiles('omniscidb/scripts/mapd-deps-conda-dev-env.yml') }}-${{ env.DATE }}
+          key: ${{ env.RUN_STAMP }}-conda-pytest-${{ hashFiles('omniscidb/scripts/mapd-deps-conda-dev-env.yml') }}-${{ env.DATE }}
           restore-keys: |
-            ${{ env.RUN_STAMP }}-conda-${{ hashFiles('omniscidb/scripts/mapd-deps-conda-dev-env.yml') }}-
+            ${{ env.RUN_STAMP }}-conda-pytest-${{ hashFiles('omniscidb/scripts/mapd-deps-conda-dev-env.yml') }}-
 
       - name: Update Conda env
         if: steps.conda-cache.cache-hit != 'true'
         run: |
           conda update conda
           conda env update -f omniscidb/scripts/mapd-deps-conda-dev-env.yml
+
+      - name: Save Conda env cache
+        id: save-conda-cache
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            ${{ env.CONDA_ENV_PATH }}
+          key: ${{ env.RUN_STAMP }}-conda-pytest-${{ hashFiles('omniscidb/scripts/mapd-deps-conda-dev-env.yml') }}-${{ env.DATE }}
 
       - name: Restore Maven cache
         uses: actions/cache@v3

--- a/omniscidb/Calcite/CalciteJNI.cpp
+++ b/omniscidb/Calcite/CalciteJNI.cpp
@@ -572,6 +572,14 @@ CalciteMgr::~CalciteMgr() {
   worker_.join();
 }
 
+CalciteMgr* CalciteMgr::get(const std::string& udf_filename, size_t calcite_max_mem_mb) {
+  std::call_once(instance_init_flag_, [=] {
+    instance_ =
+        std::unique_ptr<CalciteMgr>(new CalciteMgr(udf_filename, calcite_max_mem_mb));
+  });
+  return instance_.get();
+}
+
 std::string CalciteMgr::process(
     const std::string& db_name,
     const std::string& sql_string,

--- a/omniscidb/Calcite/CalciteJNI.cpp
+++ b/omniscidb/Calcite/CalciteJNI.cpp
@@ -201,8 +201,8 @@ class CalciteJNI {
 
   std::string process(const std::string& db_name,
                       const std::string& sql_string,
-                      SchemaProviderPtr schema_provider,
-                      ConfigPtr config,
+                      SchemaProvider* schema_provider,
+                      Config* config,
                       const std::vector<FilterPushDownInfo>& filter_push_down_info,
                       const bool legacy_syntax,
                       const bool is_explain,
@@ -575,8 +575,8 @@ CalciteMgr::~CalciteMgr() {
 std::string CalciteMgr::process(
     const std::string& db_name,
     const std::string& sql_string,
-    SchemaProviderPtr schema_provider,
-    ConfigPtr config,
+    SchemaProvider* schema_provider,
+    Config* config,
     const std::vector<FilterPushDownInfo>& filter_push_down_info,
     const bool legacy_syntax,
     const bool is_explain,

--- a/omniscidb/Calcite/CalciteJNI.h
+++ b/omniscidb/Calcite/CalciteJNI.h
@@ -43,13 +43,7 @@ class CalciteMgr {
   ~CalciteMgr();
 
   static CalciteMgr* get(const std::string& udf_filename = "",
-                         size_t calcite_max_mem_mb = 1024) {
-    std::call_once(instance_init_flag_, [=] {
-      instance_ =
-          std::unique_ptr<CalciteMgr>(new CalciteMgr(udf_filename, calcite_max_mem_mb));
-    });
-    return instance_.get();
-  }
+                         size_t calcite_max_mem_mb = 1024);
 
   std::string process(const std::string& db_name,
                       const std::string& sql_string,

--- a/omniscidb/Calcite/CalciteJNI.h
+++ b/omniscidb/Calcite/CalciteJNI.h
@@ -53,8 +53,8 @@ class CalciteMgr {
 
   std::string process(const std::string& db_name,
                       const std::string& sql_string,
-                      SchemaProviderPtr schema_provider,
-                      ConfigPtr config,
+                      SchemaProvider* schema_provider,
+                      Config* config,
                       const std::vector<FilterPushDownInfo>& filter_push_down_info = {},
                       const bool legacy_syntax = false,
                       const bool is_explain = false,

--- a/omniscidb/Calcite/SchemaJson.cpp
+++ b/omniscidb/Calcite/SchemaJson.cpp
@@ -183,7 +183,7 @@ int getCalciteScale(const hdk::ir::Type* type) {
 
 }  // namespace
 
-std::string schema_to_json(SchemaProviderPtr schema_provider) {
+std::string schema_to_json(SchemaProvider* schema_provider) {
   auto dbs = schema_provider->listDatabases();
   if (dbs.empty()) {
     return "{}";

--- a/omniscidb/Calcite/SchemaJson.h
+++ b/omniscidb/Calcite/SchemaJson.h
@@ -14,4 +14,4 @@
 
 #include "SchemaMgr/SchemaProvider.h"
 
-std::string schema_to_json(SchemaProviderPtr schema_provider);
+std::string schema_to_json(SchemaProvider* schema_provider);

--- a/omniscidb/Tests/ArrowSQLRunner/ArrowSQLRunner.cpp
+++ b/omniscidb/Tests/ArrowSQLRunner/ArrowSQLRunner.cpp
@@ -298,14 +298,13 @@ class ArrowSQLRunnerImpl {
 
   Executor* getExecutor() { return executor_.get(); }
 
-  std::shared_ptr<CalciteJNI> getCalcite() { return calcite_; }
+  CalciteMgr* getCalcite() { return calcite_; }
 
   ~ArrowSQLRunnerImpl() {
     executor_.reset();
     storage_.reset();
     rs_registry_.reset();
     schema_mgr_.reset();
-    calcite_.reset();
     rel_alg_cache_.reset();
 
     Executor::resetCodeCache();  // flush caches before tearing down buffer mgrs
@@ -334,7 +333,7 @@ class ArrowSQLRunnerImpl {
     executor_->setSchemaProvider(schema_mgr_);
 
     if (config_->debug.use_ra_cache.empty() || !config_->debug.build_ra_cache.empty()) {
-      calcite_ = std::make_shared<CalciteJNI>(schema_mgr_, config_, udf_filename, 1024);
+      calcite_ = CalciteMgr::get(udf_filename, 1024);
 
       if (config_->debug.use_ra_cache.empty()) {
         ExtensionFunctionsWhitelist::add(calcite_->getExtensionFunctionWhitelist());
@@ -356,7 +355,7 @@ class ArrowSQLRunnerImpl {
   std::shared_ptr<ArrowStorage> storage_;
   std::shared_ptr<hdk::ResultSetRegistry> rs_registry_;
   std::shared_ptr<SchemaMgr> schema_mgr_;
-  std::shared_ptr<CalciteJNI> calcite_;
+  CalciteMgr* calcite_;
   std::shared_ptr<RelAlgCache> rel_alg_cache_;
 
   SQLiteComparator sqlite_comparator_;
@@ -520,7 +519,7 @@ Executor* getExecutor() {
   return ArrowSQLRunnerImpl::get()->getExecutor();
 }
 
-std::shared_ptr<CalciteJNI> getCalcite() {
+CalciteMgr* getCalcite() {
   return ArrowSQLRunnerImpl::get()->getCalcite();
 }
 

--- a/omniscidb/Tests/ArrowSQLRunner/ArrowSQLRunner.h
+++ b/omniscidb/Tests/ArrowSQLRunner/ArrowSQLRunner.h
@@ -26,7 +26,7 @@
 
 #include "BufferPoolStats.h"
 
-class CalciteJNI;
+class CalciteMgr;
 class Executor;
 class RelAlgExecutor;
 
@@ -124,7 +124,7 @@ DataMgr* getDataMgr();
 
 Executor* getExecutor();
 
-std::shared_ptr<CalciteJNI> getCalcite();
+CalciteMgr* getCalcite();
 
 std::unique_ptr<RelAlgExecutor> makeRelAlgExecutor(const std::string& query_str);
 

--- a/omniscidb/Tests/ArrowSQLRunner/RelAlgCache.cpp
+++ b/omniscidb/Tests/ArrowSQLRunner/RelAlgCache.cpp
@@ -61,7 +61,7 @@ std::string RelAlgCache::process(
 
   std::string schema_json;
   if (!use_cache_.empty() || !build_cache_.empty()) {
-    schema_json = schema_to_json(schema_provider_);
+    schema_json = schema_to_json(schema_provider_.get());
   }
 
   if (!use_cache_.empty()) {
@@ -89,8 +89,8 @@ std::string RelAlgCache::process(
 
   auto ra = calcite_->process(db_name,
                               sql_string,
-                              schema_provider_,
-                              config_,
+                              schema_provider_.get(),
+                              config_.get(),
                               filter_push_down_info,
                               legacy_syntax,
                               is_explain,

--- a/omniscidb/Tests/ArrowSQLRunner/RelAlgCache.cpp
+++ b/omniscidb/Tests/ArrowSQLRunner/RelAlgCache.cpp
@@ -27,7 +27,7 @@
 
 #include <fstream>
 
-RelAlgCache::RelAlgCache(std::shared_ptr<CalciteJNI> calcite,
+RelAlgCache::RelAlgCache(CalciteMgr* calcite,
                          SchemaProviderPtr schema_provider,
                          ConfigPtr config)
     : calcite_(calcite), schema_provider_(schema_provider), config_(config) {
@@ -89,6 +89,8 @@ std::string RelAlgCache::process(
 
   auto ra = calcite_->process(db_name,
                               sql_string,
+                              schema_provider_,
+                              config_,
                               filter_push_down_info,
                               legacy_syntax,
                               is_explain,

--- a/omniscidb/Tests/ArrowSQLRunner/RelAlgCache.h
+++ b/omniscidb/Tests/ArrowSQLRunner/RelAlgCache.h
@@ -26,9 +26,7 @@
 
 class RelAlgCache {
  public:
-  RelAlgCache(std::shared_ptr<CalciteJNI> calcite,
-              SchemaProviderPtr schema_provider,
-              ConfigPtr config);
+  RelAlgCache(CalciteMgr* calcite, SchemaProviderPtr schema_provider, ConfigPtr config);
   ~RelAlgCache();
 
   std::string process(const std::string& db_name,
@@ -76,7 +74,7 @@ class RelAlgCache {
     }
   };
 
-  std::shared_ptr<CalciteJNI> calcite_;
+  CalciteMgr* calcite_;
   SchemaProviderPtr schema_provider_;
   ConfigPtr config_;
   std::string build_cache_;

--- a/python/pyhdk/_sql.pxd
+++ b/python/pyhdk/_sql.pxd
@@ -29,9 +29,11 @@ cdef extern from "omniscidb/Calcite/CalciteJNI.h":
     int input_start;
     int input_next;
 
-  cdef cppclass CalciteJNI:
-    CalciteJNI(CSchemaProviderPtr, shared_ptr[CConfig], const string&, size_t);
-    string process(const string&, const string&, const vector[FilterPushDownInfo]&, bool, bool, bool) except +
+  cdef cppclass CalciteMgr:    
+    @staticmethod
+    CalciteMgr* get(const string&, size_t);
+    
+    string process(const string&, const string&, CSchemaProviderPtr, shared_ptr[CConfig], const vector[FilterPushDownInfo]&, bool, bool, bool) except +
 
     string getExtensionFunctionWhitelist()
     string getUserDefinedFunctionWhitelist()

--- a/python/pyhdk/_sql.pxd
+++ b/python/pyhdk/_sql.pxd
@@ -9,7 +9,7 @@ from libcpp.string cimport string
 from libcpp.vector cimport vector
 
 from pyhdk._common cimport CConfig
-from pyhdk._storage cimport CSchemaProviderPtr, CDataProvider, CDataMgr, CBufferProvider
+from pyhdk._storage cimport CSchemaProvider, CSchemaProviderPtr, CDataProvider, CDataMgr, CBufferProvider
 from pyhdk._execute cimport CExecutor, CResultSetPtr, CCompilationOptions, CExecutionOptions, CTargetMetaInfo
 
 cdef extern from "omniscidb/QueryEngine/ExtensionFunctionsWhitelist.h":
@@ -33,7 +33,7 @@ cdef extern from "omniscidb/Calcite/CalciteJNI.h":
     @staticmethod
     CalciteMgr* get(const string&, size_t);
     
-    string process(const string&, const string&, CSchemaProviderPtr, shared_ptr[CConfig], const vector[FilterPushDownInfo]&, bool, bool, bool) except +
+    string process(const string&, const string&, CSchemaProvider*, CConfig*, const vector[FilterPushDownInfo]&, bool, bool, bool) except +
 
     string getExtensionFunctionWhitelist()
     string getUserDefinedFunctionWhitelist()

--- a/python/pyhdk/_sql.pyx
+++ b/python/pyhdk/_sql.pyx
@@ -40,7 +40,7 @@ cdef class Calcite:
     cdef bool legacy_syntax = kwargs.get("legacy_syntax", False)
     cdef bool is_explain = kwargs.get("is_explain", False)
     cdef bool is_view_optimize = kwargs.get("is_view_optimize", False)
-    return self.calcite.process(db_name, sql, self.schema_provider, self.config, filter_push_down_info, legacy_syntax, is_explain, is_view_optimize)
+    return self.calcite.process(db_name, sql, self.schema_provider.get(), self.config.get(), filter_push_down_info, legacy_syntax, is_explain, is_view_optimize)
 
 cdef class ExecutionResult:
   def row_count(self):

--- a/src/HDK.cpp
+++ b/src/HDK.cpp
@@ -40,8 +40,8 @@ ExecutionResult HDK::query(const std::string& sql, const bool is_explain) {
   CHECK(internal_->calcite);
   auto ra = internal_->calcite->process(internal_->db_name,
                                         sql,
-                                        internal_->storage,
-                                        internal_->config,
+                                        internal_->storage.get(),
+                                        internal_->config.get(),
                                         {},
                                         /*legacy_syntax=*/true);
 


### PR DESCRIPTION
The JNI interface to the JVM does not like to be called from multiple threads. In practice this is not a problem, but it appears possible to create a race condition if one CalciteJNI instance is created while another is being destroyed. 

To resolve this, we move to running a single instance of Calcite with a dedicated worker thread. Inbound requests are passed to worker thread, which passes the request to Calcite using JNI. The owner of the Calcite singleton is `CalciteMgr`, which creates an instance of itself at first call and is destroyed at shutdown. I thought about adding a destruct method, but it adds more complication and I didn't see the use case.

I believe I can remove the Reinit tests in `NoCatalogSqlTest`, but left them for now. I am also debugging some oddness in the `pyhdk` tests suite, but otherwise this is ready for review and passing all Gtests (at least locally). 