### PR TITLE
Add ResultSetRegistry storage [6/N]

### DIFF
--- a/omniscidb/ArrowStorage/ArrowStorage.cpp
+++ b/omniscidb/ArrowStorage/ArrowStorage.cpp
@@ -156,7 +156,8 @@ std::unique_ptr<AbstractDataToken> ArrowStorage::getZeroCopyBufferMemory(
       const int8_t* ptr =
           chunk->data()->GetValues<int8_t>(1, chunk->data()->offset * arrow_elem_size);
       size_t chunk_size = chunk->length() * arrow_elem_size;
-      return std::make_unique<ArrowChunkDataToken>(std::move(chunk), ptr, chunk_size);
+      return std::make_unique<ArrowChunkDataToken>(
+          std::move(chunk), col_type, ptr, chunk_size);
     }
   }
 

--- a/omniscidb/ArrowStorage/ArrowStorage.h
+++ b/omniscidb/ArrowStorage/ArrowStorage.h
@@ -149,15 +149,18 @@ class ArrowStorage : public SimpleSchemaProvider, public AbstractDataProvider {
   class ArrowChunkDataToken : public Data_Namespace::AbstractDataToken {
    public:
     ArrowChunkDataToken(std::shared_ptr<arrow::Array> chunk,
+                        const hdk::ir::Type* type,
                         const int8_t* ptr,
                         size_t size)
-        : chunk_(std::move(chunk)), ptr_(ptr), size_(size) {}
+        : chunk_(std::move(chunk)), type_(type), ptr_(ptr), size_(size) {}
 
     const int8_t* getMemoryPtr() const override { return ptr_; }
     size_t getSize() const override { return size_; }
+    const hdk::ir::Type* getType() const override { return type_; }
 
    private:
     std::shared_ptr<arrow::Array> chunk_;
+    const hdk::ir::Type* type_;
     const int8_t* ptr_;
     size_t size_;
   };

--- a/omniscidb/DataMgr/AbstractBuffer.h
+++ b/omniscidb/DataMgr/AbstractBuffer.h
@@ -51,6 +51,7 @@ class AbstractDataToken {
 
   virtual const int8_t* getMemoryPtr() const = 0;
   virtual size_t getSize() const = 0;
+  virtual const hdk::ir::Type* getType() const = 0;
 };
 
 class AbstractBuffer {

--- a/omniscidb/DataMgr/BufferMgr/Buffer.cpp
+++ b/omniscidb/DataMgr/BufferMgr/Buffer.cpp
@@ -60,6 +60,7 @@ Buffer::Buffer(BufferMgr* bm,
     , token_(std::move(token)) {
   pin();
   setSize(token_->getSize());
+  initEncoder(token_->getType());
 }
 
 Buffer::~Buffer() {}

--- a/omniscidb/ResultSet/ResultSet.h
+++ b/omniscidb/ResultSet/ResultSet.h
@@ -462,6 +462,12 @@ class ResultSet {
   std::vector<std::pair<const int8_t*, size_t>> getChunkedColumnarBuffer(
       size_t column_idx) const;
 
+  // For columns with varlen data writes element offsets to the output buffer.
+  // It is 0 for the first element and cumulative length of all previous elements
+  // for others. The total length is written at the end.
+  // Returns the number of values written.
+  size_t computeVarLenOffsets(size_t col_idx, int32_t* offsets) const;
+
   QueryDescriptionType getQueryDescriptionType() const {
     return query_mem_desc_.getQueryDescriptionType();
   }

--- a/omniscidb/ResultSetRegistry/ColumnarResults.h
+++ b/omniscidb/ResultSetRegistry/ColumnarResults.h
@@ -78,6 +78,7 @@ class ColumnarResults {
       const std::vector<std::unique_ptr<ColumnarResults>>& sub_results);
 
   const std::vector<int8_t*>& getColumnBuffers() const { return column_buffers_; }
+  const std::vector<int8_t*>& getOffsetBuffers() const { return offset_buffers_; }
 
   const size_t size() const { return num_rows_; }
 
@@ -106,6 +107,8 @@ class ColumnarResults {
 
  protected:
   std::vector<int8_t*> column_buffers_;
+  // Offset buffers are used for varlen data.
+  std::vector<int8_t*> offset_buffers_;
   size_t num_rows_;
 
  private:

--- a/omniscidb/ResultSetRegistry/ResultSetRegistry.h
+++ b/omniscidb/ResultSetRegistry/ResultSetRegistry.h
@@ -51,9 +51,9 @@ class ResultSetRegistry : public SimpleSchemaProvider,
 
   const DictDescriptor* getDictMetadata(int dict_id, bool load_dict = true) override;
 
- private:
-  bool useColumnarResults(const ResultSet& rs) const;
+  std::vector<int> listDatabases() const override { return {{DB_ID}}; }
 
+ private:
   ChunkStats getChunkStats(int table_id, size_t frag_idx, size_t col_idx) const;
 
   struct DataFragment {
@@ -69,6 +69,8 @@ class ResultSetRegistry : public SimpleSchemaProvider,
     mapd_shared_mutex mutex;
     std::vector<DataFragment> fragments;
     size_t row_count;
+    bool use_columnar_res;
+    bool has_varlen_col;
   };
 
   const int db_id_;


### PR DESCRIPTION
We now allow ResultSet to be used as an input table but it still lacks support for fetching strings and arrays. This patch adds varlen data fetch to ResultSetRegistry. Fixed-length arrays will be supported separately.