### PR TITLE
Fix rows order in parallel fetch for projections and sorted results.

### DIFF
--- a/omniscidb/QueryEngine/DataRecycler/HashtableRecycler.cpp
+++ b/omniscidb/QueryEngine/DataRecycler/HashtableRecycler.cpp
@@ -16,8 +16,9 @@
 
 #include "HashtableRecycler.h"
 #include "QueryEngine/Execute.h"
+#include "Shared/funcannotations.h"
 
-extern bool g_is_test_env;
+EXTERN extern bool g_is_test_env;
 
 bool HashtableRecycler::hasItemInCache(
     QueryPlanHash key,

--- a/omniscidb/QueryEngine/Execute.cpp
+++ b/omniscidb/QueryEngine/Execute.cpp
@@ -71,6 +71,7 @@
 #include "QueryEngine/StringDictionaryGenerations.h"
 #include "QueryEngine/Visitors/TransientStringLiteralsVisitor.h"
 #include "Shared/checked_alloc.h"
+#include "Shared/funcannotations.h"
 #include "Shared/measure.h"
 #include "Shared/misc.h"
 #include "Shared/scope.h"
@@ -81,16 +82,9 @@ using namespace std::string_literals;
 
 extern std::unique_ptr<llvm::Module> udf_gpu_module;
 extern std::unique_ptr<llvm::Module> udf_cpu_module;
-bool g_enable_table_functions{false};
-unsigned g_pending_query_interrupt_freq{1000};
-bool g_is_test_env{false};  // operating under a unit test environment. Currently only
-                            // limits the allocation for the output buffer arena
-                            // and data recycler test
-
-size_t g_approx_quantile_buffer{1000};
-size_t g_approx_quantile_centroids{300};
-
-size_t g_max_log_length{500};
+EXTERN extern bool g_is_test_env;
+EXTERN extern size_t g_approx_quantile_buffer;
+EXTERN extern size_t g_approx_quantile_centroids;
 
 int const Executor::max_gpu_count;
 

--- a/omniscidb/QueryEngine/RelAlgExecutor.cpp
+++ b/omniscidb/QueryEngine/RelAlgExecutor.cpp
@@ -42,6 +42,7 @@
 #include "ResultSetRegistry/ResultSetRegistry.h"
 #include "SchemaMgr/SchemaMgr.h"
 #include "SessionInfo.h"
+#include "Shared/funcannotations.h"
 #include "Shared/measure.h"
 #include "Shared/misc.h"
 
@@ -59,7 +60,7 @@ size_t g_estimator_failure_max_groupby_size{256000000};
 bool g_columnar_large_projections{true};
 size_t g_columnar_large_projections_threshold{1000000};
 
-extern bool g_enable_table_functions;
+EXTERN extern bool g_enable_table_functions;
 
 namespace {
 

--- a/omniscidb/QueryEngine/RelAlgOptimizer.cpp
+++ b/omniscidb/QueryEngine/RelAlgOptimizer.cpp
@@ -18,6 +18,7 @@
 #include "IR/ExprCollector.h"
 #include "IR/ExprRewriter.h"
 #include "Logger/Logger.h"
+#include "Shared/funcannotations.h"
 #include "Visitors/SubQueryCollector.h"
 
 #include <boost/make_unique.hpp>
@@ -25,7 +26,7 @@
 #include <string>
 #include <unordered_map>
 
-extern size_t g_max_log_length;
+EXTERN extern size_t g_max_log_length;
 
 namespace {
 

--- a/omniscidb/ResultSet/ResultSet.cpp
+++ b/omniscidb/ResultSet/ResultSet.cpp
@@ -387,8 +387,16 @@ void ResultSet::append(ResultSet& that) {
   }
 }
 
-const ResultSetStorage* ResultSet::getStorage() const {
-  return storage_.get();
+const ResultSetStorage* ResultSet::getStorage(size_t idx) const {
+  if (!idx) {
+    return storage_.get();
+  }
+  CHECK_LE(idx, appended_storage_.size());
+  return appended_storage_[idx - 1].get();
+}
+
+size_t ResultSet::getStorageCount() const {
+  return storage_.get() ? 1 + appended_storage_.size() : 0;
 }
 
 size_t ResultSet::colCount() const {

--- a/omniscidb/ResultSet/ResultSet.h
+++ b/omniscidb/ResultSet/ResultSet.h
@@ -279,7 +279,8 @@ class ResultSet {
 
   void append(ResultSet& that);
 
-  const ResultSetStorage* getStorage() const;
+  const ResultSetStorage* getStorage(size_t idx = 0) const;
+  size_t getStorageCount() const;
 
   size_t colCount() const;
 

--- a/omniscidb/ResultSet/ResultSetStorage.h
+++ b/omniscidb/ResultSet/ResultSetStorage.h
@@ -108,6 +108,8 @@ class ResultSetStorage {
 
   size_t getEntryCount() const { return query_mem_desc_.getEntryCount(); }
 
+  size_t binSearchRowCount() const;
+
   const QueryMemoryDescriptor& getQueryMemDesc() const { return query_mem_desc_; }
 
   const std::vector<TargetInfo>& getTargets() const { return targets_; }
@@ -150,8 +152,6 @@ class ResultSetStorage {
   void addCountDistinctSetPointerMapping(const int64_t remote_ptr, const int64_t ptr);
 
   int64_t mappedPtr(const int64_t) const;
-
-  size_t binSearchRowCount() const;
 
   const std::vector<TargetInfo> targets_;
   QueryMemoryDescriptor query_mem_desc_;

--- a/omniscidb/ResultSetRegistry/ColumnarResults.h
+++ b/omniscidb/ResultSetRegistry/ColumnarResults.h
@@ -119,6 +119,10 @@ class ColumnarResults {
                             const size_t row_idx,
                             const size_t column_idx);
   void materializeAllColumnsDirectly(const ResultSet& rows, const size_t num_columns);
+  void materializeAllGroupbyColumnsThroughIteration(const ResultSet& rows,
+                                                    const size_t num_columns);
+  void materializeAllProjectionColumnsThroughIteration(const ResultSet& rows,
+                                                       const size_t num_columns);
   void materializeAllColumnsThroughIteration(const ResultSet& rows,
                                              const size_t num_columns);
 

--- a/omniscidb/Shared/CMakeLists.txt
+++ b/omniscidb/Shared/CMakeLists.txt
@@ -7,7 +7,8 @@ set(shared_source_files
     thread_count.cpp
     threading.cpp
     MathUtils.cpp
-    file_path_util.cpp)
+    file_path_util.cpp
+    globals.cpp)
 
 include_directories(${CMAKE_SOURCE_DIR})
 if("${MAPD_EDITION_LOWER}" STREQUAL "ee")

--- a/omniscidb/Shared/globals.cpp
+++ b/omniscidb/Shared/globals.cpp
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 OmniSci, Inc.
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <cstddef>
+
+bool g_enable_table_functions{false};
+unsigned g_pending_query_interrupt_freq{1000};
+bool g_is_test_env{false};  // operating under a unit test environment. Currently only
+                            // limits the allocation for the output buffer arena
+                            // and data recycler test
+
+size_t g_approx_quantile_buffer{1000};
+size_t g_approx_quantile_centroids{300};
+
+size_t g_max_log_length{500};

--- a/python/tests/helpers.py
+++ b/python/tests/helpers.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+#
+# Copyright 2022 Intel Corporation.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+def check_schema(schema, expected):
+    assert len(schema) == len(expected)
+    assert schema.keys() == expected.keys()
+    for key in schema.keys():
+        assert str(schema[key].type) == expected[key]
+
+
+def check_res(res, expected):
+    df = res.to_arrow().to_pandas()
+    expected_cols = list(expected.keys())
+    actual_cols = df.columns.to_list()
+    assert actual_cols == expected_cols
+    for col in actual_cols:
+        vals = df[col].fillna("null").to_list()
+        assert len(vals) == len(expected[col])
+        for expected_val, actual_val in zip(expected[col], vals):
+            if type(expected_val) is float:
+                assert abs(expected_val - actual_val) < 0.0001
+            else:
+                assert expected_val == actual_val

--- a/python/tests/test_regtests.py
+++ b/python/tests/test_regtests.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+#
+# Copyright 2023 Intel Corporation.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pandas as pd
+import pytest
+import pyhdk
+import numpy as np
+import pyarrow as pa
+
+from helpers import check_res
+
+
+class TestRegressions:
+    def test_issue439(self):
+        hdk = pyhdk.init()
+        ht = hdk.import_arrow(pa.Table.from_pandas(pd.DataFrame({"a": range(100000)})))
+
+        res = ht.proj("a").run()
+        res = res.proj("a").run()
+        check_res(res, {"a": [i for i in range(100000)]})
+
+        res = ht.sort(("a", "desc")).run()
+        check_res(res, {"a": [i for i in range(99999, -1, -1)]})
+        res = res.proj("a").run()
+        check_res(res, {"a": [i for i in range(99999, -1, -1)]})


### PR DESCRIPTION
Current parallel fetch through iteration for ResultSet doesn't care about the order of the rows. This is not expected behavior for projection results and also for sorted results. We don't see any problems in tests because of the parallel fetch threshold (20 000 rows).

This patch disables parallel fetch for sorted groupby buffers and introduces the new code for parallel projection fetch which preserves row order. The patch also enforces parallel fetch for tests for better code coverage.

Resolves #439