### PR TITLE
[Null schema] Support emty data table.

### DIFF
--- a/omniscidb/ArrowStorage/ArrowStorage.cpp
+++ b/omniscidb/ArrowStorage/ArrowStorage.cpp
@@ -926,7 +926,7 @@ ChunkStats ArrowStorage::computeStats(std::shared_ptr<arrow::ChunkedArray> arr,
           chunk->data()->GetValues<int8_t>(1, chunk->data()->offset * elem_type->size()),
           chunk->length(),
           true);
-    } else {
+    } else if (chunk->length() != 0) {
       encoder->updateStatsEncoded(
           chunk->data()->GetValues<int8_t>(1, chunk->data()->offset * elem_type->size()),
           chunk->length());

--- a/omniscidb/Tests/ArrowStorageTest.cpp
+++ b/omniscidb/Tests/ArrowStorageTest.cpp
@@ -721,6 +721,21 @@ TEST_F(ArrowStorageTest, CreateTable_WrongDictId) {
   ASSERT_THROW(storage.createTable("table1", {{"col1", type}}), std::runtime_error);
 }
 
+TEST_F(ArrowStorageTest, ImportArrowTable) {
+  ArrowStorage storage(TEST_SCHEMA_ID, "test", TEST_DB_ID);
+  auto col_a = std::make_shared<arrow::Field>("A", arrow::null());
+  auto schema = arrow::schema({col_a});
+
+  std::shared_ptr<arrow::Array> empty_array;
+  arrow::NumericBuilder<arrow::FloatType> float64_builder;
+  float64_builder.AppendValues({});
+  float64_builder.Finish(&empty_array);
+  auto table = arrow::Table::Make(schema, {empty_array});
+  ASSERT_NO_THROW(
+      storage.importArrowTable(table, "test_empty", ArrowStorage::TableOptions{1}));
+  storage.dropTable("test_empty");
+}
+
 TEST_F(ArrowStorageTest, DropTable) {
   ArrowStorage storage(TEST_SCHEMA_ID, "test", TEST_DB_ID);
   auto tinfo = storage.createTable("table1",

--- a/python/tests/test_pyhdk_data_import.py
+++ b/python/tests/test_pyhdk_data_import.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+#
+# Copyright 2023 Intel Corporation.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import pyhdk
+import pyarrow
+
+
+class TestImport:
+    def test_null_schema(self):
+        table = pyarrow.table(
+            [[]], schema=pyarrow.schema([pyarrow.field("A", pyarrow.null())])
+        )
+        opt = pyhdk.storage.TableOptions(2)
+        hdk = pyhdk.init()
+        ht = hdk.import_arrow(table)
+        hdk.drop_table(ht)


### PR DESCRIPTION
This commit supports empty table. Used default table schema, so has_nulls is false in this case, min/max are default.

Resolves: #393

Signed-off-by: Dmitrii Makarenko <dmitrii.makarenko@intel.com>