### PR TITLE
Remove const from input nodes.

### DIFF
--- a/omniscidb/QueryEngine/RelAlgDagBuilder.cpp
+++ b/omniscidb/QueryEngine/RelAlgDagBuilder.cpp
@@ -2382,7 +2382,7 @@ class RelAlgDispatcher {
     return {key, val};
   }
 
-  std::shared_ptr<const hdk::ir::Node> prev(const rapidjson::Value& crt_node) {
+  hdk::ir::NodePtr prev(const rapidjson::Value& crt_node) {
     const auto id = node_id(crt_node);
     CHECK(id);
     CHECK_EQ(static_cast<size_t>(id), nodes_.size());
@@ -2432,7 +2432,6 @@ RelAlgDagBuilder::RelAlgDagBuilder(const std::string& query_ra,
         "Failed to parse relational algebra tree. Possible query syntax error.");
   }
   CHECK(query_ast.IsObject());
-  hdk::ir::Node::resetRelAlgFirstId();
   build(query_ast, *this);
 }
 


### PR DESCRIPTION
I found it really inconvenient to have `const` qualifier for `Node` inputs. Thus, having a root node we cannot walk and transform the DAG and have to use non-const pointers list stored in the DAG (which cannot even be rebuilt through the DAG walk from the root). I don't see why we should have this `const ` qualifier, `Node` objects are not immutable. 