### PR TITLE
Use functions to map column indexes to IDs.

### DIFF
--- a/omniscidb/QueryBuilder/QueryBuilder.cpp
+++ b/omniscidb/QueryBuilder/QueryBuilder.cpp
@@ -2269,9 +2269,10 @@ BuilderNode BuilderNode::sort(const std::vector<BuilderSortField>& fields,
   auto base = node_;
   if (node_->is<Scan>()) {
     // Filter out rowid column if it's not used in the sort.
+    auto scan = node_->as<Scan>();
     bool uses_rowid =
         std::any_of(collation.begin(), collation.end(), [&](const SortField& field) {
-          return field.getField() == node_->size() - 1;
+          return scan->isVirtualCol(field.getField());
         });
     int cols_to_proj = uses_rowid ? node_->size() : node_->size() - 1;
     std::vector<int> col_indices(cols_to_proj);

--- a/omniscidb/QueryEngine/WorkUnitBuilder.cpp
+++ b/omniscidb/QueryEngine/WorkUnitBuilder.cpp
@@ -349,7 +349,7 @@ void WorkUnitBuilder::process(const ir::Node* node) {
         col_var = ir::makeExpr<ir::ColumnVar>(node->getOutputMetainfo()[i].type(),
                                               token->dbId(),
                                               token->tableId(),
-                                              i + 1,
+                                              token->columnId(i),
                                               rte_idx,
                                               false);
       }

--- a/omniscidb/ResultSetRegistry/ResultSetMetadata.cpp
+++ b/omniscidb/ResultSetRegistry/ResultSetMetadata.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "ResultSetMetadata.h"
+#include "ResultSetTableToken.h"
 
 #include "Shared/thread_count.h"
 
@@ -80,7 +81,8 @@ ChunkMetadataMap synthesizeMetadata(const ResultSet* rows) {
     for (size_t i = 0; i < rows->colCount(); ++i) {
       decoders.emplace_back(Encoder::Create(nullptr, rows->colType(i)));
       const auto it_ok =
-          metadata_map.emplace(i + 1, decoders.back()->getMetadata(rows->colType(i)));
+          metadata_map.emplace(ResultSetTableToken::columnId(i),
+                               decoders.back()->getMetadata(rows->colType(i)));
       CHECK(it_ok.second);
     }
     return metadata_map;
@@ -204,7 +206,7 @@ ChunkMetadataMap synthesizeMetadata(const ResultSet* rows) {
         num_bytes,
         rows->rowCount(),
         dummy_encoders[0][i]->getMetadata(elem_type)->chunkStats());
-    const auto it_ok = metadata_map.emplace(i + 1, meta);
+    const auto it_ok = metadata_map.emplace(ResultSetTableToken::columnId(i), meta);
     CHECK(it_ok.second);
   }
   return metadata_map;

--- a/omniscidb/ResultSetRegistry/ResultSetTableToken.h
+++ b/omniscidb/ResultSetRegistry/ResultSetTableToken.h
@@ -37,6 +37,11 @@ class ResultSetTableToken {
   int dbId() const { return tinfo_->db_id; }
   int tableId() const { return tinfo_->table_id; }
 
+  // Column ID <-> Index mapping. Use a significant offset to early catch
+  // cases of indexes used as IDs and vice versa.
+  static int columnId(size_t col_idx) { return static_cast<int>(col_idx + 2000); }
+  static size_t columnIndex(int col_id) { return static_cast<size_t>(col_id - 2000); }
+
   size_t rowCount() const { return row_count_; }
 
   size_t resultSetCount() const { return tinfo_->fragments; }

--- a/omniscidb/SchemaMgr/SimpleSchemaProvider.h
+++ b/omniscidb/SchemaMgr/SimpleSchemaProvider.h
@@ -157,9 +157,8 @@ class SimpleSchemaProvider : public SchemaProvider {
     return addColumnInfo(std::make_shared<ColumnInfo>(args...));
   }
 
-  ColumnInfoPtr addRowidColumn(int db_id, int table_id) {
+  ColumnInfoPtr addRowidColumn(int db_id, int table_id, int col_id) {
     CHECK_EQ(column_index_by_name_.count({db_id, table_id}), (size_t)1);
-    int col_id = static_cast<int>(column_index_by_name_[{db_id, table_id}].size() + 1);
     return addColumnInfo(db_id, table_id, col_id, "rowid", ctx_.int64(), true);
   }
 

--- a/omniscidb/Tests/NoCatalogRelAlgTest.cpp
+++ b/omniscidb/Tests/NoCatalogRelAlgTest.cpp
@@ -50,7 +50,7 @@ class TestSchemaProvider : public SimpleSchemaProvider {
     addColumnInfo(TEST_DB_ID, TEST1_TABLE_ID, 2, "col_i", ctx_.int32(), false);
     addColumnInfo(TEST_DB_ID, TEST1_TABLE_ID, 3, "col_f", ctx_.fp32(), false);
     addColumnInfo(TEST_DB_ID, TEST1_TABLE_ID, 4, "col_d", ctx_.fp64(), false);
-    addRowidColumn(TEST_DB_ID, TEST1_TABLE_ID);
+    addRowidColumn(TEST_DB_ID, TEST1_TABLE_ID, 5);
 
     // Table test2
     addTableInfo(TEST_DB_ID,
@@ -63,7 +63,7 @@ class TestSchemaProvider : public SimpleSchemaProvider {
     addColumnInfo(TEST_DB_ID, TEST2_TABLE_ID, 2, "col_i", ctx_.int32(), false);
     addColumnInfo(TEST_DB_ID, TEST2_TABLE_ID, 3, "col_f", ctx_.fp32(), false);
     addColumnInfo(TEST_DB_ID, TEST2_TABLE_ID, 4, "col_d", ctx_.fp64(), false);
-    addRowidColumn(TEST_DB_ID, TEST2_TABLE_ID);
+    addRowidColumn(TEST_DB_ID, TEST2_TABLE_ID, 5);
 
     // Table test2 in db2
     addTableInfo(TEST_DB2_ID,
@@ -74,7 +74,7 @@ class TestSchemaProvider : public SimpleSchemaProvider {
                  1);
     addColumnInfo(TEST_DB2_ID, TEST2_TABLE_ID, 1, "col_bi", ctx_.int64(), false);
     addColumnInfo(TEST_DB2_ID, TEST2_TABLE_ID, 2, "col_i", ctx_.int32(), false);
-    addRowidColumn(TEST_DB2_ID, TEST2_TABLE_ID);
+    addRowidColumn(TEST_DB2_ID, TEST2_TABLE_ID, 3);
 
     // Table test_agg
     addTableInfo(TEST_DB_ID,
@@ -85,7 +85,7 @@ class TestSchemaProvider : public SimpleSchemaProvider {
                  1);
     addColumnInfo(TEST_DB_ID, TEST_AGG_TABLE_ID, 1, "id", ctx_.int32(), false);
     addColumnInfo(TEST_DB_ID, TEST_AGG_TABLE_ID, 2, "val", ctx_.int32(), false);
-    addRowidColumn(TEST_DB_ID, TEST_AGG_TABLE_ID);
+    addRowidColumn(TEST_DB_ID, TEST_AGG_TABLE_ID, 3);
   }
 
   ~TestSchemaProvider() override = default;

--- a/omniscidb/Tests/NoCatalogSqlTest.cpp
+++ b/omniscidb/Tests/NoCatalogSqlTest.cpp
@@ -53,7 +53,7 @@ class TestSchemaProvider : public SimpleSchemaProvider {
     addColumnInfo(TEST_DB_ID, TEST1_TABLE_ID, 2, "col_i", ctx_.int32(), false);
     addColumnInfo(TEST_DB_ID, TEST1_TABLE_ID, 3, "col_f", ctx_.fp32(), false);
     addColumnInfo(TEST_DB_ID, TEST1_TABLE_ID, 4, "col_d", ctx_.fp64(), false);
-    addRowidColumn(TEST_DB_ID, TEST1_TABLE_ID);
+    addRowidColumn(TEST_DB_ID, TEST1_TABLE_ID, 5);
 
     // Table test2
     addTableInfo(TEST_DB_ID,
@@ -66,7 +66,7 @@ class TestSchemaProvider : public SimpleSchemaProvider {
     addColumnInfo(TEST_DB_ID, TEST2_TABLE_ID, 2, "col_i", ctx_.int32(), false);
     addColumnInfo(TEST_DB_ID, TEST2_TABLE_ID, 3, "col_f", ctx_.fp32(), false);
     addColumnInfo(TEST_DB_ID, TEST2_TABLE_ID, 4, "col_d", ctx_.fp64(), false);
-    addRowidColumn(TEST_DB_ID, TEST2_TABLE_ID);
+    addRowidColumn(TEST_DB_ID, TEST2_TABLE_ID, 5);
 
     // Table test_agg
     addTableInfo(TEST_DB_ID,
@@ -77,7 +77,7 @@ class TestSchemaProvider : public SimpleSchemaProvider {
                  1);
     addColumnInfo(TEST_DB_ID, TEST_AGG_TABLE_ID, 1, "id", ctx_.int32(), false);
     addColumnInfo(TEST_DB_ID, TEST_AGG_TABLE_ID, 2, "val", ctx_.int32(), false);
-    addRowidColumn(TEST_DB_ID, TEST_AGG_TABLE_ID);
+    addRowidColumn(TEST_DB_ID, TEST_AGG_TABLE_ID, 3);
   }
 
   ~TestSchemaProvider() override = default;


### PR DESCRIPTION
As @kurapov-peter noticed in one of his reviews, there are many `+/-1` expressions used to transform column index to column ID and back. That scheme is not obvious to the reader and is error-prone. So, this patch replaces these expressions with function calls. Also, it introduces a new first-column ID for ArrowStorage (1000) and ResultSetRegistry (2000). Thus, it would be trivial to catch an error when the column index is used as ID and vice-versa, or wrong storage is used to fetch the column (we still might have code that assumes table IDs are unique).
