### PR TITLE
Support shape property for scan nodes.

### DIFF
--- a/omniscidb/ArrowStorage/ArrowStorage.cpp
+++ b/omniscidb/ArrowStorage/ArrowStorage.cpp
@@ -351,7 +351,7 @@ TableInfoPtr ArrowStorage::createTable(const std::string& table_name,
     mapd_unique_lock<mapd_shared_mutex> schema_lock(schema_mutex_);
     table_id = next_table_id_++;
     checkNewTableParams(table_name, columns, options);
-    res = addTableInfo(db_id_, table_id, table_name, false, 0);
+    res = addTableInfo(db_id_, table_id, table_name, false, 0, 0);
     std::unordered_map<int, int> dict_ids;
     for (auto& col : columns) {
       auto type = col.type;
@@ -646,7 +646,9 @@ void ArrowStorage::appendArrowTable(std::shared_ptr<arrow::Table> at, int table_
     table.row_count = at->num_rows();
   }
 
-  getTableInfo(db_id_, table_id)->fragments = table.fragments.size();
+  auto table_info = getTableInfo(db_id_, table_id);
+  table_info->fragments = table.fragments.size();
+  table_info->row_count = table.row_count;
 }
 
 TableInfoPtr ArrowStorage::importCsvFile(const std::string& file_name,

--- a/omniscidb/QueryBuilder/QueryBuilder.cpp
+++ b/omniscidb/QueryBuilder/QueryBuilder.cpp
@@ -2501,6 +2501,13 @@ ColumnInfoPtr BuilderNode::columnInfo(const std::string& col_name) const {
                                       false);
 }
 
+size_t BuilderNode::rowCount() const {
+  if (auto scan = node_->as<hdk::ir::Scan>()) {
+    return scan->getTableInfo()->row_count;
+  }
+  throw InvalidQueryError("Row count is available for scan nodes only.");
+}
+
 QueryBuilder::QueryBuilder(Context& ctx,
                            SchemaProviderPtr schema_provider,
                            ConfigPtr config)

--- a/omniscidb/QueryBuilder/QueryBuilder.h
+++ b/omniscidb/QueryBuilder/QueryBuilder.h
@@ -476,6 +476,7 @@ class BuilderNode {
   int size() const { return node_->size(); }
   ColumnInfoPtr columnInfo(int col_index) const;
   ColumnInfoPtr columnInfo(const std::string& col_name) const;
+  size_t rowCount() const;
 
  protected:
   friend class QueryBuilder;

--- a/omniscidb/ResultSetRegistry/ResultSetRegistry.cpp
+++ b/omniscidb/ResultSetRegistry/ResultSetRegistry.cpp
@@ -107,7 +107,7 @@ ResultSetTableTokenPtr ResultSetRegistry::put(ResultSetTable table) {
   auto table_id = next_table_id_++;
   auto table_name = std::string("__result_set_") + std::to_string(table_id);
   // Add schema information for the ResultSet.
-  auto tinfo = addTableInfo(db_id_, table_id, table_name, false, table.size());
+  auto tinfo = addTableInfo(db_id_, table_id, table_name, false, table.size(), 0);
   auto& first_rs = table.result(0);
   bool has_varlen = false;
   bool has_array = false;
@@ -137,6 +137,7 @@ ResultSetTableTokenPtr ResultSetRegistry::put(ResultSetTable table) {
     row_count += frag.row_count;
     table_data->fragments.emplace_back(std::move(frag));
   }
+  tinfo->row_count = row_count;
   table_data->row_count = row_count;
   table_data->has_varlen_col = has_varlen;
   // We use ColumnarResults for all cases except those when can use

--- a/omniscidb/SchemaMgr/TableInfo.h
+++ b/omniscidb/SchemaMgr/TableInfo.h
@@ -49,17 +49,20 @@ struct TableInfo : public TableRef {
             const std::string name_,
             bool is_view_,
             size_t fragments_,
+            size_t row_count_,
             bool is_stream_ = false)
       : TableRef(db_id, table_id)
       , name(name_)
       , is_view(is_view_)
       , fragments(fragments_)
+      , row_count(row_count_)
       , is_stream(is_stream_) {}
 
   std::string name;
   bool is_view;
   // For add_window_function_pre_project in RelAlgDagBuilder.
   size_t fragments;
+  size_t row_count;
   bool is_stream;
 
   std::string toString() const {

--- a/omniscidb/Tests/NoCatalogRelAlgTest.cpp
+++ b/omniscidb/Tests/NoCatalogRelAlgTest.cpp
@@ -40,7 +40,7 @@ class TestSchemaProvider : public SimpleSchemaProvider {
   TestSchemaProvider()
       : SimpleSchemaProvider(hdk::ir::Context::defaultCtx(), TEST_SCHEMA_ID, "test") {
     // Table test1
-    addTableInfo(TEST_DB_ID, TEST1_TABLE_ID, "test1", false, 1);
+    addTableInfo(TEST_DB_ID, TEST1_TABLE_ID, "test1", false, 1, 5);
     addColumnInfo(TEST_DB_ID, TEST1_TABLE_ID, 1, "col_bi", ctx_.int64(), false);
     addColumnInfo(TEST_DB_ID, TEST1_TABLE_ID, 2, "col_i", ctx_.int32(), false);
     addColumnInfo(TEST_DB_ID, TEST1_TABLE_ID, 3, "col_f", ctx_.fp32(), false);
@@ -48,7 +48,7 @@ class TestSchemaProvider : public SimpleSchemaProvider {
     addRowidColumn(TEST_DB_ID, TEST1_TABLE_ID, 5);
 
     // Table test2
-    addTableInfo(TEST_DB_ID, TEST2_TABLE_ID, "test2", false, 1);
+    addTableInfo(TEST_DB_ID, TEST2_TABLE_ID, "test2", false, 3, 9);
     addColumnInfo(TEST_DB_ID, TEST2_TABLE_ID, 1, "col_bi", ctx_.int64(), false);
     addColumnInfo(TEST_DB_ID, TEST2_TABLE_ID, 2, "col_i", ctx_.int32(), false);
     addColumnInfo(TEST_DB_ID, TEST2_TABLE_ID, 3, "col_f", ctx_.fp32(), false);
@@ -56,13 +56,13 @@ class TestSchemaProvider : public SimpleSchemaProvider {
     addRowidColumn(TEST_DB_ID, TEST2_TABLE_ID, 5);
 
     // Table test2 in db2
-    addTableInfo(TEST_DB2_ID, TEST2_TABLE_ID, "db2.test2", false, 1);
+    addTableInfo(TEST_DB2_ID, TEST2_TABLE_ID, "db2.test2", false, 2, 3);
     addColumnInfo(TEST_DB2_ID, TEST2_TABLE_ID, 1, "col_bi", ctx_.int64(), false);
     addColumnInfo(TEST_DB2_ID, TEST2_TABLE_ID, 2, "col_i", ctx_.int32(), false);
     addRowidColumn(TEST_DB2_ID, TEST2_TABLE_ID, 3);
 
     // Table test_agg
-    addTableInfo(TEST_DB_ID, TEST_AGG_TABLE_ID, "test_agg", false, 1);
+    addTableInfo(TEST_DB_ID, TEST_AGG_TABLE_ID, "test_agg", false, 2, 10);
     addColumnInfo(TEST_DB_ID, TEST_AGG_TABLE_ID, 1, "id", ctx_.int32(), false);
     addColumnInfo(TEST_DB_ID, TEST_AGG_TABLE_ID, 2, "val", ctx_.int32(), false);
     addRowidColumn(TEST_DB_ID, TEST_AGG_TABLE_ID, 3);

--- a/omniscidb/Tests/NoCatalogSqlTest.cpp
+++ b/omniscidb/Tests/NoCatalogSqlTest.cpp
@@ -43,7 +43,7 @@ class TestSchemaProvider : public SimpleSchemaProvider {
   TestSchemaProvider()
       : SimpleSchemaProvider(hdk::ir::Context::defaultCtx(), TEST_SCHEMA_ID, "test") {
     // Table test1
-    addTableInfo(TEST_DB_ID, TEST1_TABLE_ID, "test1", false, 1);
+    addTableInfo(TEST_DB_ID, TEST1_TABLE_ID, "test1", false, 1, 5);
     addColumnInfo(TEST_DB_ID, TEST1_TABLE_ID, 1, "col_bi", ctx_.int64(), false);
     addColumnInfo(TEST_DB_ID, TEST1_TABLE_ID, 2, "col_i", ctx_.int32(), false);
     addColumnInfo(TEST_DB_ID, TEST1_TABLE_ID, 3, "col_f", ctx_.fp32(), false);
@@ -51,7 +51,7 @@ class TestSchemaProvider : public SimpleSchemaProvider {
     addRowidColumn(TEST_DB_ID, TEST1_TABLE_ID, 5);
 
     // Table test2
-    addTableInfo(TEST_DB_ID, TEST2_TABLE_ID, "test2", false, 1);
+    addTableInfo(TEST_DB_ID, TEST2_TABLE_ID, "test2", false, 3, 9);
     addColumnInfo(TEST_DB_ID, TEST2_TABLE_ID, 1, "col_bi", ctx_.int64(), false);
     addColumnInfo(TEST_DB_ID, TEST2_TABLE_ID, 2, "col_i", ctx_.int32(), false);
     addColumnInfo(TEST_DB_ID, TEST2_TABLE_ID, 3, "col_f", ctx_.fp32(), false);
@@ -59,7 +59,7 @@ class TestSchemaProvider : public SimpleSchemaProvider {
     addRowidColumn(TEST_DB_ID, TEST2_TABLE_ID, 5);
 
     // Table test_agg
-    addTableInfo(TEST_DB_ID, TEST_AGG_TABLE_ID, "test_agg", false, 1);
+    addTableInfo(TEST_DB_ID, TEST_AGG_TABLE_ID, "test_agg", false, 2, 10);
     addColumnInfo(TEST_DB_ID, TEST_AGG_TABLE_ID, 1, "id", ctx_.int32(), false);
     addColumnInfo(TEST_DB_ID, TEST_AGG_TABLE_ID, 2, "val", ctx_.int32(), false);
     addRowidColumn(TEST_DB_ID, TEST_AGG_TABLE_ID, 3);

--- a/python/pyhdk/_builder.pxd
+++ b/python/pyhdk/_builder.pxd
@@ -85,6 +85,7 @@ cdef extern from "omniscidb/QueryBuilder/QueryBuilder.h":
     int size() const
     CColumnInfoPtr columnInfoByIndex "columnInfo"(int) except +
     CColumnInfoPtr columnInfoByName "columnInfo"(const string&) except +
+    size_t rowCount() except +
 
     CBuilderExpr refByIndex "ref"(int) except +
     CBuilderExpr refByName "ref"(const string&) except +

--- a/python/pyhdk/_builder.pyx
+++ b/python/pyhdk/_builder.pyx
@@ -576,6 +576,12 @@ cdef class QueryNode:
       res = res - 1
     return res
 
+  @property
+  def shape(self):
+    if not self.is_scan:
+      raise RuntimeError("Only scan nodes provide shape.")
+    return (self.c_node.rowCount(), self.size)
+
   def column_info(self, col):
     cdef CExpr *c_expr
     if isinstance(col, QueryExpr) and col.is_ref:

--- a/python/pyhdk/_storage.pxd
+++ b/python/pyhdk/_storage.pxd
@@ -31,9 +31,10 @@ cdef extern from "omniscidb/SchemaMgr/TableInfo.h":
     string name
     bool is_view
     size_t fragments
+    size_t row_count
     bool is_stream
 
-    CTableInfo(int, int, string, bool, MemoryLevel, size_t, bool);
+    CTableInfo(int, int, string, bool, size_t, size_t, bool);
     string toString()
 
 ctypedef shared_ptr[CTableInfo] CTableInfoPtr

--- a/python/tests/test_pyhdk_api.py
+++ b/python/tests/test_pyhdk_api.py
@@ -935,6 +935,22 @@ class TestBuilder(BaseTest):
 
         hdk.drop_table(ht)
 
+    def test_shape(self):
+        hdk = pyhdk.init()
+        ht = hdk.import_pydict({"a": [1, 2, 3, 4, 5], "b": [10, 20, 30, 40, 50]})
+        assert ht.shape == (5, 2)
+        hdk.import_pydict({"a": [1, 2, 3, 4, 5], "b": [10, 20, 30, 40, 50]}, ht)
+        assert ht.shape == (10, 2)
+
+        res1 = ht.filter(ht["a"] > 3).run()
+        assert res1.shape == (4, 2)
+
+        res2 = res1.proj("a").run()
+        assert res2.shape == (4, 1)
+
+        with pytest.raises(RuntimeError):
+            res2.proj(0).shape
+
 
 class TestSql(BaseTest):
     def test_no_alias(self):


### PR DESCRIPTION
This allows us to get the shape of the imported table or execution result in Python. I'm not very comfortable with adding this info into the schema, but there is already fragments count and an alternative way is to add DataMgr/DataProvider to the builder. What do you think?

Resolves #434 