### PR TITLE
Add head and tail API for execution results

### DIFF
--- a/omniscidb/QueryEngine/ArrowResultSetConverter.cpp
+++ b/omniscidb/QueryEngine/ArrowResultSetConverter.cpp
@@ -1007,7 +1007,7 @@ size_t convert_rowwise(
   CHECK_EQ(null_bitmap_seg.size(), col_count);
   const auto local_entry_count = end_entry - start_entry;
   size_t seg_row_count = 0;
-  size_t limit = results->getLimit();
+  size_t limit = results->getLimit() ? results->getLimit() : results->entryCount();
   size_t offset = results->getOffset();
   for (size_t i = start_entry; i < end_entry; ++i) {
     if (is_truncated && seg_row_count >= offset + limit) {

--- a/omniscidb/QueryEngine/Descriptors/RelAlgExecutionDescriptor.h
+++ b/omniscidb/QueryEngine/Descriptors/RelAlgExecutionDescriptor.h
@@ -56,6 +56,16 @@ class ExecutionResult {
     return result_token_->tableName();
   }
 
+  ExecutionResult head(size_t n) {
+    CHECK(result_token_);
+    return {result_token_->head(n), targets_meta_};
+  }
+
+  ExecutionResult tail(size_t n) {
+    CHECK(result_token_);
+    return {result_token_->tail(n), targets_meta_};
+  }
+
   const std::vector<TargetMetaInfo>& getTargetsMeta() const { return targets_meta_; }
 
   const std::vector<PushedDownFilterInfo>& getPushedDownFilterInfo() const;

--- a/omniscidb/ResultSetRegistry/ResultSetRegistry.h
+++ b/omniscidb/ResultSetRegistry/ResultSetRegistry.h
@@ -39,6 +39,9 @@ class ResultSetRegistry : public SimpleSchemaProvider,
   ResultSetPtr get(const ResultSetTableToken& token, size_t frag_id) const;
   void drop(const ResultSetTableToken& token);
 
+  ResultSetTableTokenPtr head(const ResultSetTableToken& token, size_t n);
+  ResultSetTableTokenPtr tail(const ResultSetTableToken& token, size_t n);
+
   void fetchBuffer(const ChunkKey& key,
                    Data_Namespace::AbstractBuffer* dest,
                    const size_t num_bytes = 0) override;

--- a/omniscidb/ResultSetRegistry/ResultSetTableToken.cpp
+++ b/omniscidb/ResultSetRegistry/ResultSetTableToken.cpp
@@ -35,4 +35,12 @@ void ResultSetTableToken::reset() {
   }
 }
 
+ResultSetTableTokenPtr ResultSetTableToken::head(size_t n) const {
+  return registry_->head(*this, n);
+}
+
+ResultSetTableTokenPtr ResultSetTableToken::tail(size_t n) const {
+  return registry_->tail(*this, n);
+}
+
 }  // namespace hdk

--- a/omniscidb/ResultSetRegistry/ResultSetTableToken.h
+++ b/omniscidb/ResultSetRegistry/ResultSetTableToken.h
@@ -14,8 +14,11 @@
 namespace hdk {
 
 class ResultSetRegistry;
+class ResultSetTableToken;
 
-class ResultSetTableToken {
+using ResultSetTableTokenPtr = std::shared_ptr<const ResultSetTableToken>;
+
+class ResultSetTableToken : public std::enable_shared_from_this<ResultSetTableToken> {
  public:
   ResultSetTableToken() = default;
   ResultSetTableToken(TableInfoPtr tinfo,
@@ -49,6 +52,9 @@ class ResultSetTableToken {
 
   const std::string& tableName() const { return tinfo_->name; }
 
+  ResultSetTableTokenPtr head(size_t n) const;
+  ResultSetTableTokenPtr tail(size_t n) const;
+
   std::string toString() const {
     return "ResultSetTableToken(" + std::to_string(dbId()) + ":" +
            std::to_string(tableId()) + ")";
@@ -61,7 +67,5 @@ class ResultSetTableToken {
   size_t row_count_;
   std::shared_ptr<ResultSetRegistry> registry_;
 };
-
-using ResultSetTableTokenPtr = std::shared_ptr<const ResultSetTableToken>;
 
 }  // namespace hdk

--- a/omniscidb/Tests/QueryBuilderTest.cpp
+++ b/omniscidb/Tests/QueryBuilderTest.cpp
@@ -5024,6 +5024,84 @@ TEST_F(QueryBuilderTest, FixedArrayInRes) {
   }
 }
 
+TEST_F(QueryBuilderTest, Head) {
+  QueryBuilder builder(ctx(), schema_mgr_, configPtr());
+
+  {
+    auto dag = builder.scan("test1").proj({0, 1}).finalize();
+    auto res = runQuery(std::move(dag));
+
+    auto res1 = res.head(10);
+    compare_res_data(res1,
+                     std::vector<int64_t>({1, 2, 3, 4, 5}),
+                     std::vector<int32_t>({11, 22, 33, 44, 55}));
+
+    auto res2 = res.head(3);
+    compare_res_data(
+        res2, std::vector<int64_t>({1, 2, 3}), std::vector<int32_t>({11, 22, 33}));
+
+    auto res3 = res.head(0);
+    compare_res_data(res3, std::vector<int64_t>({}), std::vector<int32_t>({}));
+  }
+
+  {
+    auto dag = builder.scan("test1")
+                   .proj({0, 1})
+                   .sort(std::vector<BuilderSortField>(), 3, 1)
+                   .finalize();
+    auto res = runQuery(std::move(dag));
+
+    auto res1 = res.head(10);
+    compare_res_data(
+        res1, std::vector<int64_t>({2, 3, 4}), std::vector<int32_t>({22, 33, 44}));
+
+    auto res2 = res.head(2);
+    compare_res_data(res2, std::vector<int64_t>({2, 3}), std::vector<int32_t>({22, 33}));
+
+    auto res3 = res.head(0);
+    compare_res_data(res3, std::vector<int64_t>({}), std::vector<int32_t>({}));
+  }
+}
+
+TEST_F(QueryBuilderTest, Tail) {
+  QueryBuilder builder(ctx(), schema_mgr_, configPtr());
+
+  {
+    auto dag = builder.scan("test1").proj({0, 1}).finalize();
+    auto res = runQuery(std::move(dag));
+
+    auto res1 = res.tail(10);
+    compare_res_data(res1,
+                     std::vector<int64_t>({1, 2, 3, 4, 5}),
+                     std::vector<int32_t>({11, 22, 33, 44, 55}));
+
+    auto res2 = res.tail(3);
+    compare_res_data(
+        res2, std::vector<int64_t>({3, 4, 5}), std::vector<int32_t>({33, 44, 55}));
+
+    auto res3 = res.tail(0);
+    compare_res_data(res3, std::vector<int64_t>({}), std::vector<int32_t>({}));
+  }
+
+  {
+    auto dag = builder.scan("test1")
+                   .proj({0, 1})
+                   .sort(std::vector<BuilderSortField>(), 3, 1)
+                   .finalize();
+    auto res = runQuery(std::move(dag));
+
+    auto res1 = res.tail(10);
+    compare_res_data(
+        res1, std::vector<int64_t>({2, 3, 4}), std::vector<int32_t>({22, 33, 44}));
+
+    auto res2 = res.tail(2);
+    compare_res_data(res2, std::vector<int64_t>({3, 4}), std::vector<int32_t>({33, 44}));
+
+    auto res3 = res.tail(0);
+    compare_res_data(res3, std::vector<int64_t>({}), std::vector<int32_t>({}));
+  }
+}
+
 class Taxi : public TestSuite {
  protected:
   static void SetUpTestSuite() {

--- a/python/pyhdk/_builder.pyx
+++ b/python/pyhdk/_builder.pyx
@@ -633,6 +633,10 @@ cdef class QueryNode:
     dag.c_dag.reset(c_dag)
     return dag
 
+  @property
+  def hdk(self):
+    return self._hdk
+
   def __repr__(self):
     return self.c_node.node().get().toString()
 

--- a/python/pyhdk/_sql.pxd
+++ b/python/pyhdk/_sql.pxd
@@ -61,6 +61,9 @@ cdef extern from "omniscidb/QueryEngine/Descriptors/RelAlgExecutionDescriptor.h"
     string getExplanation()
     const string& tableName()
 
+    CExecutionResult head(size_t) except +
+    CExecutionResult tail(size_t) except +
+
 cdef class ExecutionResult:
   cdef CExecutionResult c_result
   # DataMgr has to outlive ResultSet objects to avoid use-after-free errors.

--- a/python/pyhdk/_sql.pyx
+++ b/python/pyhdk/_sql.pyx
@@ -139,6 +139,22 @@ cdef class ExecutionResult:
 
     return res
 
+  def head(self, n):
+    res = ExecutionResult()
+    res.c_result = self.c_result.head(n)
+    res.c_data_mgr = self.c_data_mgr
+    if self._scan is not None:
+      res._scan = self._scan.hdk.scan(res.table_name)
+    return res
+
+  def tail(self, n):
+    res = ExecutionResult()
+    res.c_result = self.c_result.tail(n)
+    res.c_data_mgr = self.c_data_mgr
+    if self._scan is not None:
+      res._scan = self._scan.hdk.scan(res.table_name)
+    return res
+
   def __str__(self):
     res = "Schema:\n"
     for key, type_str in self.schema.items():

--- a/python/tests/test_pyhdk_api.py
+++ b/python/tests/test_pyhdk_api.py
@@ -925,6 +925,34 @@ class TestBuilder(BaseTest):
         with pytest.raises(RuntimeError):
             res2.proj(0).shape
 
+    def test_head(self):
+        hdk = pyhdk.init()
+        ht = hdk.import_pydict({"a": [1, 2, 3, 4, 5]})
+
+        res = ht.run()
+        res1 = res.head(10)
+        check_res(res1, {"a": [1, 2, 3, 4, 5]})
+        res2 = res.head(3)
+        check_res(res2, {"a": [1, 2, 3]})
+        res3 = res.head(0)
+        check_res(res3, {"a": []})
+
+        hdk.drop_table(ht)
+
+    def test_tail(self):
+        hdk = pyhdk.init()
+        ht = hdk.import_pydict({"a": [1, 2, 3, 4, 5]})
+
+        res = ht.run()
+        res1 = res.tail(10)
+        check_res(res1, {"a": [1, 2, 3, 4, 5]})
+        res2 = res.tail(3)
+        check_res(res2, {"a": [3, 4, 5]})
+        res3 = res.tail(0)
+        check_res(res3, {"a": []})
+
+        hdk.drop_table(ht)
+
 
 class TestSql(BaseTest):
     def test_no_alias(self):


### PR DESCRIPTION
We now can get the head and tail of a table using projection + sort, but I wanted to make it as zero-copy as possible. So I added shared result set storages, which allow us to make lightweight result set table copies. Then I used it for head/tail implementation.

Resolves #435