### PR TITLE
Improve detection of cases for large NDV estimator.

### DIFF
--- a/omniscidb/QueryEngine/CardinalityEstimator.h
+++ b/omniscidb/QueryEngine/CardinalityEstimator.h
@@ -44,6 +44,7 @@ class CardinalityEstimationRequired : public std::runtime_error {
 };
 
 RelAlgExecutionUnit create_ndv_execution_unit(const RelAlgExecutionUnit& ra_exe_unit,
+                                              SchemaProvider* schema_provider,
                                               const Config& config,
                                               const int64_t range);
 

--- a/omniscidb/ResultSet/ResultSet.cpp
+++ b/omniscidb/ResultSet/ResultSet.cpp
@@ -1163,7 +1163,8 @@ size_t ResultSet::getNDVEstimator() const {
   if (ratio == 0.) {
     LOG(WARNING)
         << "Failed to get a high quality cardinality estimation, falling back to "
-           "approximate group by buffer size guess.";
+           "approximate group by buffer size guess. Estimator buffer size is "
+        << total_bits << " bits.";
     return 0;
   }
   return -static_cast<double>(total_bits) * log(ratio);


### PR DESCRIPTION
Add range information for cases when range exceeds baseline threshold and when overflow happens on range computation. Also, don't use large estimator if the number of input rows is not big enough.