### PR TITLE
Add support for DISTINCT clause

### DIFF
--- a/omniscidb/Tests/IntelGPUEnablingTest.cpp
+++ b/omniscidb/Tests/IntelGPUEnablingTest.cpp
@@ -840,8 +840,9 @@ TEST_F(BasicTest, SumAndAverage) {
 }
 
 TEST_F(BasicTest, Distinct) {
-  GTEST_SKIP();
   c("SELECT COUNT(distinct x) FROM test;", g_dt);
+  c("SELECT COUNT(distinct dd) FROM test;", g_dt);
+  c("SELECT COUNT(distinct b) FROM test;", g_dt);
 }
 
 TEST_F(BasicTest, Sort) {


### PR DESCRIPTION
This patch fixes the following tests:
- Select.CountDistinct
- Select.GroupBy
- Select.FilterAndGroupBy
- Insert.DictBoundary






























































