### PR TITLE
Lazily materialize string dictionaries

### DIFF
--- a/omniscidb/ArrowStorage/ArrowStorage.cpp
+++ b/omniscidb/ArrowStorage/ArrowStorage.cpp
@@ -777,7 +777,7 @@ void ArrowStorage::appendArrowTable(std::shared_ptr<arrow::Table> at, int table_
                           col_type));
                     } else {
                       int32_t min = 0;
-                      int32_t max = static_cast<int32_t>(col_arr->length());
+                      int32_t max = -1;
                       meta->fillChunkStats(min, max, /*has_nulls=*/true);
                     }
                     frag.metadata[col_idx] = meta;

--- a/omniscidb/ArrowStorage/ArrowStorage.cpp
+++ b/omniscidb/ArrowStorage/ArrowStorage.cpp
@@ -370,7 +370,9 @@ void ArrowStorage::materializeDictionary(DictionaryData* dict) {
   const int elem_size = dict_desc->dictNBits / 8;
 
   for (const auto table_id : dict->table_ids) {
+    mapd_shared_lock<mapd_shared_mutex> data_lock(data_mutex_);
     auto& table = *tables_.at(table_id);
+    data_lock.unlock();
 
     // TODO: should we add the data lock here?
     mapd_unique_lock<mapd_shared_mutex> table_lock(table.mutex);

--- a/omniscidb/ArrowStorage/ArrowStorage.h
+++ b/omniscidb/ArrowStorage/ArrowStorage.h
@@ -130,6 +130,23 @@ class ArrowStorage : public SimpleSchemaProvider, public AbstractDataProvider {
 
   int dbId() const { return db_id_; }
 
+  std::shared_ptr<arrow::Table> parseCsvFile(const std::string& file_name,
+                                             const CsvParseOptions parse_options,
+                                             const ColumnInfoList& col_infos = {}) const;
+  std::shared_ptr<arrow::Table> parseCsvData(const std::string& csv_data,
+                                             const CsvParseOptions parse_options,
+                                             const ColumnInfoList& col_infos = {}) const;
+  std::shared_ptr<arrow::Table> parseCsv(std::shared_ptr<arrow::io::InputStream> input,
+                                         const CsvParseOptions parse_options,
+                                         const ColumnInfoList& col_infos = {}) const;
+  std::shared_ptr<arrow::Table> parseJsonData(const std::string& json_data,
+                                              const JsonParseOptions parse_options,
+                                              const ColumnInfoList& col_infos = {}) const;
+  std::shared_ptr<arrow::Table> parseJson(std::shared_ptr<arrow::io::InputStream> input,
+                                          const JsonParseOptions parse_options,
+                                          const ColumnInfoList& col_infos = {}) const;
+  std::shared_ptr<arrow::Table> parseParquetFile(const std::string& file_name) const;
+
  private:
   struct DataFragment {
     size_t offset = 0;
@@ -191,22 +208,6 @@ class ArrowStorage : public SimpleSchemaProvider, public AbstractDataProvider {
                       std::shared_ptr<arrow::Schema> rhs);
   ChunkStats computeStats(std::shared_ptr<arrow::ChunkedArray> arr,
                           const hdk::ir::Type* type);
-  std::shared_ptr<arrow::Table> parseCsvFile(const std::string& file_name,
-                                             const CsvParseOptions parse_options,
-                                             const ColumnInfoList& col_infos = {});
-  std::shared_ptr<arrow::Table> parseCsvData(const std::string& csv_data,
-                                             const CsvParseOptions parse_options,
-                                             const ColumnInfoList& col_infos = {});
-  std::shared_ptr<arrow::Table> parseCsv(std::shared_ptr<arrow::io::InputStream> input,
-                                         const CsvParseOptions parse_options,
-                                         const ColumnInfoList& col_infos = {});
-  std::shared_ptr<arrow::Table> parseJsonData(const std::string& json_data,
-                                              const JsonParseOptions parse_options,
-                                              const ColumnInfoList& col_infos = {});
-  std::shared_ptr<arrow::Table> parseJson(std::shared_ptr<arrow::io::InputStream> input,
-                                          const JsonParseOptions parse_options,
-                                          const ColumnInfoList& col_infos = {});
-  std::shared_ptr<arrow::Table> parseParquetFile(const std::string& file_name);
   TableFragmentsInfo getEmptyTableMetadata(int table_id) const;
   void fetchFixedLenData(const TableData& table,
                          size_t frag_idx,

--- a/omniscidb/Benchmarks/taxi/taxi_full_bench.cpp
+++ b/omniscidb/Benchmarks/taxi/taxi_full_bench.cpp
@@ -15,8 +15,6 @@ size_t g_fragment_size = 160000000 / num_threads;
 bool g_use_parquet{false};
 ExecutorDeviceType g_device_type{ExecutorDeviceType::GPU};
 
-EXTERN extern bool g_lazy_materialize_dictionaries;
-
 using namespace TestHelpers::ArrowSQLRunner;
 
 // #define USE_HOT_DATA
@@ -409,10 +407,11 @@ int main(int argc, char* argv[]) {
                          ->default_value(ExecutorDeviceType::CPU),
                      "Device type to use.");
 
-  desc.add_options()("use-lazy-materialization",
-                     po::value<bool>(&g_lazy_materialize_dictionaries)
-                         ->implicit_value(true)
-                         ->default_value(g_lazy_materialize_dictionaries));
+  desc.add_options()(
+      "use-lazy-materialization",
+      po::value<bool>(&config->storage.enable_lazy_dict_materialization)
+          ->implicit_value(true)
+          ->default_value(config->storage.enable_lazy_dict_materialization));
 
   logger::LogOptions log_options(argv[0]);
   log_options.severity_ = logger::Severity::FATAL;
@@ -430,7 +429,7 @@ int main(int argc, char* argv[]) {
   logger::init(log_options);
   init(config);
 
-  if (g_lazy_materialize_dictionaries) {
+  if (config->storage.enable_lazy_dict_materialization) {
     std::cout << "Using lazy materialization!" << std::endl;
   }
 

--- a/omniscidb/DataProvider/DictDescriptor.h
+++ b/omniscidb/DataProvider/DictDescriptor.h
@@ -39,7 +39,6 @@ struct DictDescriptor {
   int refcount;
   bool dictIsTemp;
   std::shared_ptr<StringDictionary> stringDict;
-  std::shared_ptr<std::mutex> string_dict_mutex;
   DictDescriptor(DictRef dict_ref,
                  const std::string& name,
                  int nbits,
@@ -54,8 +53,7 @@ struct DictDescriptor {
       , dictFolderPath(fname)
       , refcount(rc)
       , dictIsTemp(temp)
-      , stringDict(nullptr)
-      , string_dict_mutex(std::make_shared<std::mutex>()) {}
+      , stringDict(nullptr) {}
 
   DictDescriptor(int db_id,
                  int dict_id,
@@ -71,8 +69,7 @@ struct DictDescriptor {
       , dictFolderPath(fname)
       , refcount(rc)
       , dictIsTemp(temp)
-      , stringDict(nullptr)
-      , string_dict_mutex(std::make_shared<std::mutex>()) {
+      , stringDict(nullptr) {
     dictRef.dbId = db_id;
     dictRef.dictId = dict_id;
   }

--- a/omniscidb/Shared/Config.h
+++ b/omniscidb/Shared/Config.h
@@ -172,6 +172,10 @@ struct DebugConfig {
   bool enable_automatic_ir_metadata = true;
 };
 
+struct StorageConfig {
+  bool enable_lazy_dict_materialization = false;
+};
+
 struct Config {
   ExecutionConfig exec;
   OptimizationsConfig opts;
@@ -179,6 +183,7 @@ struct Config {
   MemoryConfig mem;
   CacheConfig cache;
   DebugConfig debug;
+  StorageConfig storage;
 };
 
 using ConfigPtr = std::shared_ptr<Config>;

--- a/omniscidb/StringDictionary/StringDictionary.h
+++ b/omniscidb/StringDictionary/StringDictionary.h
@@ -70,9 +70,6 @@ class StringDictionary {
   template <class T, class String>
   void getOrAddBulkParallel(const std::vector<String>& string_vec, T* encoded_vec);
   template <class String>
-  void getOrAddBulkArray(const std::vector<std::vector<String>>& string_array_vec,
-                         std::vector<std::vector<int32_t>>& ids_array_vec);
-  template <class String>
   int32_t getIdOfString(const String&) const;
   std::string getString(int32_t string_id) const;
   std::pair<char*, size_t> getStringBytes(int32_t string_id) const noexcept;
@@ -93,9 +90,6 @@ class StringDictionary {
                                      const size_t generation) const;
 
   std::vector<std::string> copyStrings() const;
-
-  std::vector<std::string_view> getStringViews() const;
-  std::vector<std::string_view> getStringViews(const size_t generation) const;
 
   std::vector<int32_t> buildDictionaryTranslationMap(
       const std::shared_ptr<StringDictionary> dest_dict,

--- a/omniscidb/Tests/ArrowSQLRunner/ArrowSQLRunner.cpp
+++ b/omniscidb/Tests/ArrowSQLRunner/ArrowSQLRunner.cpp
@@ -318,7 +318,8 @@ class ArrowSQLRunnerImpl {
       config_ = std::make_shared<Config>();
     }
 
-    storage_ = std::make_shared<ArrowStorage>(TEST_SCHEMA_ID, "test", TEST_DB_ID);
+    storage_ =
+        std::make_shared<ArrowStorage>(TEST_SCHEMA_ID, "test", TEST_DB_ID, config_);
     rs_registry_ = std::make_shared<hdk::ResultSetRegistry>(config_);
     schema_mgr_ = std::make_shared<SchemaMgr>();
     schema_mgr_->registerProvider(TEST_SCHEMA_ID, storage_);

--- a/omniscidb/Tests/ArrowStorageTest.cpp
+++ b/omniscidb/Tests/ArrowStorageTest.cpp
@@ -778,8 +778,10 @@ TEST_F(ArrowStorageTest, DropTable_SharedDicts) {
     ASSERT_EQ(storage.getColumnInfo(*col_info), nullptr);
   }
 
-  ASSERT_NE(storage.getDictMetadata(getDictId(col1_info->type)), nullptr);
-  ASSERT_EQ(storage.getDictMetadata(getDictId(col2_info->type)), nullptr);
+  ASSERT_NE(storage.getDictMetadata(getDictId(col1_info->type), /*load_dict=*/false),
+            nullptr);
+  ASSERT_EQ(storage.getDictMetadata(getDictId(col2_info->type), /*load_dict=*/false),
+            nullptr);
 }
 
 void Test_ImportCsv_Numbers(const std::string& file_name,

--- a/omniscidb/Tests/QueryBuilderTest.cpp
+++ b/omniscidb/Tests/QueryBuilderTest.cpp
@@ -264,7 +264,8 @@ class QueryBuilderTest : public TestSuite {
   static void SetUpTestSuite() {
     auto data_mgr = getDataMgr();
     auto ps_mgr = data_mgr->getPersistentStorageMgr();
-    storage2_ = std::make_shared<ArrowStorage>(TEST_SCHEMA_ID2, "test2", TEST_DB_ID2);
+    storage2_ = std::make_shared<ArrowStorage>(
+        TEST_SCHEMA_ID2, "test2", TEST_DB_ID2, configPtr());
     ps_mgr->registerDataProvider(TEST_SCHEMA_ID2, storage2_);
     schema_mgr_ = std::make_shared<SchemaMgr>();
     schema_mgr_->registerProvider(TEST_SCHEMA_ID, getStorage());

--- a/omniscidb/Tests/StringDictionaryTest.cpp
+++ b/omniscidb/Tests/StringDictionaryTest.cpp
@@ -85,24 +85,6 @@ TEST(StringDictionary, ManyAddsAndGets) {
   }
 }
 
-TEST(StringDictionary, GetStringViews) {
-  const DictRef dict_ref(-1, 1);
-  std::shared_ptr<StringDictionary> string_dict =
-      std::make_shared<StringDictionary>(dict_ref, g_cache_string_hash);
-  std::vector<std::string> strings;
-  std::vector<int32_t> string_ids(g_op_count);
-  for (int i = 0; i < g_op_count; ++i) {
-    strings.emplace_back(std::to_string(i));
-  }
-  string_dict->getOrAddBulk(strings, string_ids.data());
-
-  const auto string_views = string_dict->getStringViews();
-  ASSERT_EQ(string_views.size(), static_cast<size_t>(g_op_count));
-  for (int i = 0; i < g_op_count; ++i) {
-    ASSERT_EQ(strings[i], std::string(string_views[i]));
-  }
-}
-
 TEST(StringDictionary, GetOrAddBulk) {
   const DictRef dict_ref(-1, 1);
   StringDictionary string_dict(dict_ref, g_cache_string_hash);

--- a/python/pyhdk/_common.pxd
+++ b/python/pyhdk/_common.pxd
@@ -240,6 +240,9 @@ cdef extern from "omniscidb/Shared/Config.h":
     string use_ra_cache
     bool enable_automatic_ir_metadata
 
+  cdef cppclass CStorageConfig "StorageConfig":
+    bool enable_lazy_dict_materialization
+
   cdef cppclass CConfig "Config":
     CExecutionConfig exec
     COptimizationsConfig opts
@@ -247,6 +250,7 @@ cdef extern from "omniscidb/Shared/Config.h":
     CMemoryConfig mem
     CCacheConfig cache
     CDebugConfig debug
+    CStorageConfig storage
 
 ctypedef shared_ptr[CConfig] CConfigPtr
 

--- a/python/pyhdk/_storage.pxd
+++ b/python/pyhdk/_storage.pxd
@@ -127,8 +127,8 @@ cdef class Storage(SchemaProvider):
   cdef shared_ptr[CAbstractBufferMgr] c_abstract_buffer_mgr
 
 cdef extern from "omniscidb/ArrowStorage/ArrowStorage.h":
-  cdef cppclass CArrowStorage "ArrowStorage"(CSchemaProvider, CAbstractDataProvider):
-    CArrowStorage(int, string, int) except +;
+  cdef cppclass CArrowStorage "ArrowStorage"(CSchemaProvider, CAbstractDataProvider, shared_ptr[CConfig]):
+    CArrowStorage(int, string, int, shared_ptr[CConfig]) except +;
 
     CTableInfoPtr createTable(const string&, const vector[CColumnDescription]&, const CTableOptions&) except +
 

--- a/python/pyhdk/_storage.pyx
+++ b/python/pyhdk/_storage.pyx
@@ -14,6 +14,7 @@ from pyarrow.lib cimport pyarrow_unwrap_table
 from pyarrow.lib cimport CTable as CArrowTable
 
 from pyhdk._common cimport TypeInfo, Config, CConfig, CContext
+from pyhdk._common import buildConfig
 
 from collections.abc import Iterable
 
@@ -238,10 +239,10 @@ cdef class CsvParseOptions:
 cdef class ArrowStorage(Storage):
   cdef shared_ptr[CArrowStorage] c_storage
 
-  def __cinit__(self, int schema_id):
+  def __cinit__(self, int schema_id, Config config = buildConfig()):
     cdef string schema_name = f"schema_#{schema_id}"
     cdef int db_id = (schema_id << 24) + 1
-    self.c_storage = make_shared[CArrowStorage](schema_id, schema_name, db_id)
+    self.c_storage = make_shared[CArrowStorage](schema_id, schema_name, db_id, config.c_config)
     self.c_schema_provider = static_pointer_cast[CSchemaProvider, CArrowStorage](self.c_storage)
     self.c_abstract_buffer_mgr = static_pointer_cast[CAbstractBufferMgr, CArrowStorage](self.c_storage)
 

--- a/python/pyhdk/hdk.py
+++ b/python/pyhdk/hdk.py
@@ -1657,7 +1657,7 @@ class HDK:
         if "debug_logs" in kwargs:
             initLogger(debug_logs=kwargs.pop("debug_logs"))
         self._config = buildConfig(**kwargs)
-        self._storage = ArrowStorage(1)
+        self._storage = ArrowStorage(1, self._config)
         rs_registry = ResultSetRegistry(self._config)
         self._data_mgr = DataMgr(self._config)
         self._data_mgr.registerDataProvider(self._storage)

--- a/python/tests/test_pyhdk_api.py
+++ b/python/tests/test_pyhdk_api.py
@@ -1054,7 +1054,7 @@ class TestTaxiSql(BaseTaxiTest):
     def test_taxi_over_csv_modular(self):
         # Initialize HDK components
         config = pyhdk.buildConfig()
-        storage = pyhdk.storage.ArrowStorage(1)
+        storage = pyhdk.storage.ArrowStorage(1, config)
         data_mgr = pyhdk.storage.DataMgr(config)
         data_mgr.registerDataProvider(storage)
         calcite = pyhdk.sql.Calcite(storage, config)
@@ -1265,7 +1265,7 @@ class TestTaxiIR(BaseTaxiTest):
     def test_taxi_over_csv_modular(self):
         # Initialize HDK components
         config = pyhdk.buildConfig()
-        storage = pyhdk.storage.ArrowStorage(1)
+        storage = pyhdk.storage.ArrowStorage(1, config)
         data_mgr = pyhdk.storage.DataMgr(config)
         data_mgr.registerDataProvider(storage)
         executor = pyhdk.Executor(data_mgr, config)

--- a/python/tests/test_pyhdk_bindings.py
+++ b/python/tests/test_pyhdk_bindings.py
@@ -14,7 +14,8 @@ import pytest
 
 class TestArrowStorage:
     def test_import_arrow_table(self):
-        storage = pyhdk.storage.ArrowStorage(123)
+        config = pyhdk.buildConfig()
+        storage = pyhdk.storage.ArrowStorage(123, config)
         assert storage is not None
         assert storage.getId() == 123
 
@@ -62,12 +63,18 @@ class TestArrowStorage:
         assert columns[2].type.size == 8
         assert columns[2].is_rowid == True
 
+    # TODO: remove once modin has been updated
+    def test_default_constructed_config(self):
+        storage = pyhdk.storage.ArrowStorage(456)
+        assert storage is not None
+        assert storage.getId() == 456
+
 
 class TestCalcite:
     @classmethod
     def setup_class(cls):
         cls.config = pyhdk.buildConfig()
-        cls.storage = pyhdk.storage.ArrowStorage(1)
+        cls.storage = pyhdk.storage.ArrowStorage(1, cls.config)
         cls.calcite = pyhdk.sql.Calcite(cls.storage, cls.config)
 
         at = pyarrow.Table.from_pandas(

--- a/python/tests/test_pyhdk_calcite_json.py
+++ b/python/tests/test_pyhdk_calcite_json.py
@@ -17,7 +17,7 @@ class TestCalciteJson:
     def setup_class(cls):
         # pyhdk.initLogger(debug_logs=True)
         cls.config = pyhdk.buildConfig()
-        cls.storage = pyhdk.storage.ArrowStorage(1)
+        cls.storage = pyhdk.storage.ArrowStorage(1, cls.config)
         cls.data_mgr = pyhdk.storage.DataMgr(cls.config)
         cls.data_mgr.registerDataProvider(cls.storage)
 

--- a/python/tests/test_pyhdk_sql.py
+++ b/python/tests/test_pyhdk_sql.py
@@ -18,7 +18,7 @@ class TestSql:
     def setup_class(cls):
         # pyhdk.initLogger(debug_logs=True)
         cls.config = pyhdk.buildConfig()
-        cls.storage = pyhdk.storage.ArrowStorage(1)
+        cls.storage = pyhdk.storage.ArrowStorage(1, cls.config)
         cls.data_mgr = pyhdk.storage.DataMgr(cls.config)
         cls.data_mgr.registerDataProvider(cls.storage)
 

--- a/src/HDK.cpp
+++ b/src/HDK.cpp
@@ -82,7 +82,7 @@ HDK::HDK() : internal_(std::make_unique<Internal>()) {
   internal_->config = buildConfig();
 
   internal_->storage = std::make_shared<ArrowStorage>(
-      internal_->schema_id, internal_->db_name, internal_->db_id);
+      internal_->schema_id, internal_->db_name, internal_->db_id, internal_->config);
 
   internal_->data_mgr =
       std::make_shared<Data_Namespace::DataMgr>(*internal_->config.get());


### PR DESCRIPTION
Store the raw arrow strings in col data. When the dictionary buffer is accessed, the dictionary will be materialized by reading through all the strings and passing them into the dictionary. The original col data is then replaced with col indices, and metadata for the column is computed. Because metadata is computed when the dict is accessed through the descriptor, all queries that rely on dictionary metadata will materialize the dictionary before creating group by buffers. Shared dictionaries across multiple tables are supported. 

I ran some benchmarks and of course lazy dictionaries are much better than not having lazy dictionaries for taxi queries, but the gap between batch mode and interactive mode is still quite large. 