### PR TITLE
Disable most compiler warnings on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,14 @@ if (WIN32)
   # corresponding to the real C++ language standard version. Without this option Microsoft compiler
   # always defines __cplusplus to 199711L. A valid number is needed in llvm headers.
   add_compile_options(/Zc:__cplusplus)
+  # MSVC warnings management
+  option(ENABLE_NO_WINWARNINGS "disable most windows warnings" ON)
+  add_compile_definitions("NOMINMAX")
+  if(ENABLE_NO_WINWARNINGS)
+    add_compile_options(/W0 /wd5045)
+  else()
+    add_compile_options(/W4 /permisive-)
+  endif()
 else()
   set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
   # Do not allow undefined symbols when linking shared libraries because such symbols break

--- a/omniscidb/CMakeLists.txt
+++ b/omniscidb/CMakeLists.txt
@@ -338,19 +338,7 @@ set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
 
 option(FORCE_COLORED_COMPILER_OUTPUT "Enable ANSI-coloring for gnu/clang." OFF)
 
-if(MSVC)
-  option(ENABLE_NO_WINWARNINGS "disable most windows warnings" ON)
-  add_compile_definitions("NOMINMAX")
-  if(ENABLE_NO_WINWARNINGS)
-    add_compile_definitions("_STL_EXTRA_DISABLED_WARNINGS=4146 4242 4244 4267 4355 4365 4458 4624 4820 4996 5204 5219" "NOMINMAX")
-    # disable 4702 unreachable code warning
-    # with /Qspectre set, disable the warning C5045
-    add_compile_options(/W0 /wd4702 /wd5045)
-  else()
-    add_compile_options(/W4 /permisive-)
-  endif()
-  add_compile_options(/EHsc /std:c++17 /Qspectre)
-else()
+if(NOT MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-local-typedefs -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS")
   if (${FORCE_COLORED_COMPILER_OUTPUT})
     if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/omniscidb/QueryEngine/CostModel/CMakeLists.txt
+++ b/omniscidb/QueryEngine/CostModel/CMakeLists.txt
@@ -31,4 +31,6 @@ endif()
 
 add_library(CostModel STATIC ${COST_MODEL_SOURCES})
 target_link_libraries(CostModel PRIVATE ${COST_MODEL_LIBS})
-target_compile_options(CostModel PRIVATE -fPIC)
+if(NOT MSVC)
+  target_compile_options(CostModel PRIVATE -fPIC)
+endif()

--- a/omniscidb/ThirdParty/googlebenchmark/CMakeLists.txt
+++ b/omniscidb/ThirdParty/googlebenchmark/CMakeLists.txt
@@ -97,9 +97,6 @@ if (BENCHMARK_BUILD_32_BITS)
 endif()
 
 if (MSVC)
-  # Turn compiler warnings up to 11
-  string(REGEX REPLACE "[-/]W[1-4]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 
   if (NOT BENCHMARK_ENABLE_EXCEPTIONS)

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -49,6 +49,7 @@ def gen_compile_flags() -> list:
         cpp_version_flags = [
             "/std:c++17",
             "/Zc:__cplusplus",
+            "/w",
             "/DBOOST_USE_WINAPI_VERSION=0x0600",
         ]
     return [


### PR DESCRIPTION
This PR doesn't disable all of compiler warnings, but with warning level 0 compiler produces only the most serious ones. There are not many of these.