### PR TITLE
Enable multifrag result set tables by default.

### DIFF
--- a/omniscidb/SchemaMgr/TableInfo.h
+++ b/omniscidb/SchemaMgr/TableInfo.h
@@ -31,6 +31,8 @@ struct TableRef {
     return table_id == other.table_id && db_id == other.db_id;
   }
 
+  bool operator!=(const TableRef& other) const { return !(*this == other); }
+
   bool operator<(const TableRef& other) const {
     return std::tie(db_id, table_id) < std::tie(other.db_id, other.table_id);
   }

--- a/omniscidb/Shared/Config.h
+++ b/omniscidb/Shared/Config.h
@@ -99,7 +99,7 @@ struct ExecutionConfig {
   bool enable_experimental_string_functions = false;
   bool enable_interop = false;
   size_t parallel_linearization_threshold = 10'000;
-  bool enable_multifrag_rs = false;
+  bool enable_multifrag_rs = true;
 
   size_t override_gpu_block_size = 0;
   size_t override_gpu_grid_size = 0;


### PR DESCRIPTION
I recently found we don't enable multi-fragment result set tables by default and this function is actually broken. It is supposed to improve parallelism for some queries, so I want to get it fixed and enabled by default.

There are also some UNION ALL related changes included due to failed tests. It appears UNION ALL on scans doesn't work so I restricted it explicitly. And the code in `WorkUnitBuilder::computeInputColDescs` is outdated and cannot properly handle inputs from different databases, so I fixed it as well.