### PR TITLE
[Python build] Reduce warnings

### DIFF
--- a/python/pyhdk/_builder.pyx
+++ b/python/pyhdk/_builder.pyx
@@ -676,7 +676,7 @@ cdef class QueryBuilder:
     if not isinstance(scale_decimal, int):
       raise TypeError("Use True or False for 'scale_decimal' arg.")
 
-    cdef const CType *c_type
+    cdef const CType *c_type = NULL
     cdef vector[CBuilderExpr] elems
 
     if cst_type is not None:

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -44,7 +44,9 @@ def get_hdk_shared_libs() -> list:
 
 
 def gen_compile_flags() -> list:
-    cpp_version_flags = ["-std=c++17"]
+    # A lot of ununsed variables warnings generated during
+    # cimport of pyarrow_unwrap_table, CTable
+    cpp_version_flags = ["-std=c++17", "-Wno-unused-variable"]
     if os.name == "nt":
         cpp_version_flags = [
             "/std:c++17",


### PR DESCRIPTION
This commit removes warnings generated during compilation of python auto-generated files.

Signed-off-by: Dmitrii Makarenko <dmitrii.makarenko@intel.com>