### PR TITLE
Use multifrag kernels on CPU for groupby with a big result.

### DIFF
--- a/omniscidb/ConfigBuilder/ConfigBuilder.cpp
+++ b/omniscidb/ConfigBuilder/ConfigBuilder.cpp
@@ -152,6 +152,12 @@ bool ConfigBuilder::parseCommandLineArgs(int argc,
           ->implicit_value(true),
       "Enable using GPU shared memory for grouped non-count aggregate queries.");
   opt_desc.add_options()(
+      "enable-cpu-groupby-multifrag-kernels",
+      po::value<bool>(&config_->exec.group_by.enable_cpu_multifrag_kernels)
+          ->default_value(config_->exec.group_by.enable_cpu_multifrag_kernels)
+          ->implicit_value(true),
+      "Enable multifragment kernels for groupby queries on CPU.");
+  opt_desc.add_options()(
       "gpu-shared-mem-threshold",
       po::value<size_t>(&config_->exec.group_by.gpu_smem_threshold)
           ->default_value(config_->exec.group_by.gpu_smem_threshold),

--- a/omniscidb/Shared/Config.h
+++ b/omniscidb/Shared/Config.h
@@ -45,6 +45,7 @@ struct GroupByConfig {
   bool enable_gpu_smem_group_by = true;
   bool enable_gpu_smem_non_grouped_agg = true;
   bool enable_gpu_smem_grouped_non_count_agg = true;
+  bool enable_cpu_multifrag_kernels = true;
   size_t gpu_smem_threshold = 4096;
   unsigned hll_precision_bits = 11;
   size_t baseline_threshold = 1'000'000;

--- a/omniscidb/Tests/CorrelatedSubqueryTest.cpp
+++ b/omniscidb/Tests/CorrelatedSubqueryTest.cpp
@@ -157,6 +157,14 @@ void runSingleValueTest(const hdk::ir::Type* colType, ExecutorDeviceType dt) {
     return;
   }
 
+  // Some tests assume multiple kernels and reduction, so disable multifragment
+  // kernels to provide it.
+  auto old_multifrag_opt = config().exec.group_by.enable_cpu_multifrag_kernels;
+  config().exec.group_by.enable_cpu_multifrag_kernels = false;
+  ScopeGuard guard([old_multifrag_opt]() {
+    config().exec.group_by.enable_cpu_multifrag_kernels = old_multifrag_opt;
+  });
+
   dropTable("test_facts");
   createTable("test_facts", {{"id", colType}, {"val", colType}}, {3});
 


### PR DESCRIPTION
The basic idea is to not use multiple kernels when each kernel produces a hash table comparable in size to the whole input data. Then execution would go in a single thread and we would avoid a very costly reduction.

I'm sure my criteria are too strong and we might benefit from a single kernel in much more cases but this one at least would allow us to run queries like H2O Q10 on big data sets until we switch to better aggregation algorithms.