### PR TITLE
Fixed Calcite processing of queries with APPROX_QUANTILE aggregation.

### DIFF
--- a/omniscidb/Calcite/java/calcite/src/main/java/org/apache/calcite/rel/externalize/MapDRelJson.java
+++ b/omniscidb/Calcite/java/calcite/src/main/java/org/apache/calcite/rel/externalize/MapDRelJson.java
@@ -562,11 +562,6 @@ public class MapDRelJson {
   }
 
   SqlOperator toOp(RelInput relInput, String name) {
-    // in case different operator has the same kind, check with both name and kind.
-    String kind = name;
-    String syntax = "FUNCTION";
-    SqlKind sqlKind = SqlKind.valueOf(kind);
-    SqlSyntax sqlSyntax = SqlSyntax.valueOf(syntax);
     MapDSqlOperatorTable operatorTable =
             new MapDSqlOperatorTable(SqlStdOperatorTable.instance());
     MapDSqlOperatorTable.addUDF(operatorTable, null);


### PR DESCRIPTION
The removed code seems redundant and it fails with "IllegalArgumentException: No enum constant org.apache.calcite.sql.SqlKind.APPROX_QUANTILE" if the query contains an APPROX_QUANTILE aggregation.

The stack trace:
```java
java.lang.IllegalArgumentException: No enum constant org.apache.calcite.sql.SqlKind.APPROX_QUANTILE
        at java.lang.Enum.valueOf(Enum.java:273) ~[?:?]
        at org.apache.calcite.sql.SqlKind.valueOf(SqlKind.java:81) ~[calcite-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
        at org.apache.calcite.rel.externalize.MapDRelJson.toOp(MapDRelJson.java:568) ~[calcite-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
        at org.apache.calcite.rel.externalize.MapDRelJson.toAggregation(MapDRelJson.java:590) ~[calcite-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
        at org.apache.calcite.rel.externalize.MapDRelJsonReader.toAggCall(MapDRelJsonReader.java:293) ~[calcite-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
        at org.apache.calcite.rel.externalize.MapDRelJsonReader.access$500(MapDRelJsonReader.java:61) ~[calcite-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
        at org.apache.calcite.rel.externalize.MapDRelJsonReader$2.getAggregateCalls(MapDRelJsonReader.java:175) ~[calcite-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
        at org.apache.calcite.rel.core.Aggregate.<init>(Aggregate.java:228) ~[calcite-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
        at org.apache.calcite.rel.logical.LogicalAggregate.<init>(LogicalAggregate.java:107) ~[calcite-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
        at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:?]
        at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77) ~[?:?]
        at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:?]
        at java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499) ~[?:?]
        at java.lang.reflect.Constructor.newInstance(Constructor.java:480) ~[?:?]
        at org.apache.calcite.rel.externalize.MapDRelJsonReader.readRel(MapDRelJsonReader.java:266) ~[calcite-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
        at org.apache.calcite.rel.externalize.MapDRelJsonReader.readRels(MapDRelJsonReader.java:92) ~[calcite-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
        at org.apache.calcite.rel.externalize.MapDRelJsonReader.read(MapDRelJsonReader.java:86) ~[calcite-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
        at org.apache.calcite.prepare.MapDPlanner.optimizeRaQuery(MapDPlanner.java:229) ~[calcite-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
        at com.mapd.calcite.parser.MapDParser.optimizeRAQuery(MapDParser.java:204) ~[calcite-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
        at com.mapd.parser.server.CalciteServerHandler.process(CalciteServerHandler.java:154) [calcite-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
```