### PR TITLE
Add window functions support in QueryBuilder.

### DIFF
--- a/omniscidb/IR/Expr.cpp
+++ b/omniscidb/IR/Expr.cpp
@@ -1644,6 +1644,20 @@ std::string WindowFunction::toString() const {
   for (const auto& arg : args_) {
     result += " " + arg->toString();
   }
+  if (!partition_keys_.empty()) {
+    result += " PARTITION BY";
+    for (const auto& part_key : partition_keys_) {
+      result += " " + part_key->toString();
+    }
+  }
+  if (!order_keys_.empty()) {
+    result += " ORDER BY";
+    for (size_t i = 0; i < order_keys_.size(); ++i) {
+      result += " " + order_keys_[i]->toString();
+      result += collation_[i].is_desc ? " DESC" : " ASC";
+      result += collation_[i].nulls_first ? " NULLS FIRST" : " NULLS LAST";
+    }
+  }
   return result + ") ";
 }
 

--- a/omniscidb/IR/Expr.h
+++ b/omniscidb/IR/Expr.h
@@ -64,6 +64,8 @@ class Expr : public std::enable_shared_from_this<Expr> {
   virtual std::string toString() const = 0;
   virtual void print() const;
 
+  bool equal(const Expr* rhs) const { return *this == *rhs; }
+
   /*
    * @brief decompress adds cast operator to decompress encoded result
    */

--- a/omniscidb/QueryBuilder/QueryBuilder.h
+++ b/omniscidb/QueryBuilder/QueryBuilder.h
@@ -22,6 +22,30 @@ class InvalidQueryError : public Error {
 class QueryBuilder;
 class BuilderNode;
 class ExprRewriter;
+class BuilderExpr;
+
+class BuilderOrderByKey {
+ public:
+  BuilderOrderByKey();
+  BuilderOrderByKey(const BuilderExpr& expr,
+                    SortDirection dir = SortDirection::Ascending,
+                    NullSortedPosition null_pos = NullSortedPosition::Last);
+  BuilderOrderByKey(const BuilderExpr& expr,
+                    const std::string& dir,
+                    const std::string& null_pos = "last");
+
+  ExprPtr expr() const { return expr_; }
+  SortDirection dir() const { return dir_; }
+  NullSortedPosition nullsPosition() const { return null_pos_; }
+
+  static SortDirection parseSortDirection(const std::string& val);
+  static NullSortedPosition parseNullPosition(const std::string& val);
+
+ protected:
+  ExprPtr expr_;
+  SortDirection dir_;
+  NullSortedPosition null_pos_;
+};
 
 class BuilderExpr {
  public:
@@ -54,6 +78,11 @@ class BuilderExpr {
   BuilderExpr singleValue() const;
   BuilderExpr stdDev() const;
   BuilderExpr corr(const BuilderExpr& arg) const;
+
+  BuilderExpr lag(int n = 1) const;
+  BuilderExpr lead(int n = 1) const;
+  BuilderExpr firstValue() const;
+  BuilderExpr lastValue() const;
 
   BuilderExpr agg(const std::string& agg_str, const BuilderExpr& arg) const;
   BuilderExpr agg(const std::string& agg_str, double val = HUGE_VAL) const;
@@ -172,6 +201,31 @@ class BuilderExpr {
   BuilderExpr at(const BuilderExpr& idx) const;
   BuilderExpr at(int idx) const;
   BuilderExpr at(int64_t idx) const;
+
+  BuilderExpr over() const;
+  BuilderExpr over(const BuilderExpr& key) const;
+  BuilderExpr over(const std::vector<BuilderExpr>& keys) const;
+
+  BuilderExpr orderBy(BuilderExpr key,
+                      SortDirection dir = SortDirection::Ascending,
+                      NullSortedPosition null_pos = NullSortedPosition::Last) const;
+  BuilderExpr orderBy(BuilderExpr key,
+                      const std::string& dir,
+                      const std::string& null_pos = "last") const;
+  BuilderExpr orderBy(std::initializer_list<BuilderExpr> keys,
+                      SortDirection dir = SortDirection::Ascending,
+                      NullSortedPosition null_pos = NullSortedPosition::Last) const;
+  BuilderExpr orderBy(std::initializer_list<BuilderExpr> keys,
+                      const std::string& dir,
+                      const std::string& null_pos = "last") const;
+  BuilderExpr orderBy(const std::vector<BuilderExpr>& keys,
+                      SortDirection dir = SortDirection::Ascending,
+                      NullSortedPosition null_pos = NullSortedPosition::Last) const;
+  BuilderExpr orderBy(const std::vector<BuilderExpr>& keys,
+                      const std::string& dir,
+                      const std::string& null_pos = "last") const;
+  BuilderExpr orderBy(const BuilderOrderByKey& key) const;
+  BuilderExpr orderBy(const std::vector<BuilderOrderByKey>& keys) const;
 
   BuilderExpr rewrite(ExprRewriter& rewriter) const;
 
@@ -506,6 +560,11 @@ class QueryBuilder {
   BuilderNode scan(const TableRef& table_ref) const;
 
   BuilderExpr count() const;
+  BuilderExpr rowNumber() const;
+  BuilderExpr rank() const;
+  BuilderExpr denseRank() const;
+  BuilderExpr percentRank() const;
+  BuilderExpr nTile(int tile_count) const;
 
   BuilderExpr cst(int val) const;
   BuilderExpr cst(int val, const Type* type) const;

--- a/python/pyhdk/_builder.pxd
+++ b/python/pyhdk/_builder.pxd
@@ -17,6 +17,10 @@ from pyhdk._sql cimport CExecutionResult, CQueryDag
 
 cdef extern from "omniscidb/QueryBuilder/QueryBuilder.h":
   cdef cppclass CQueryBuilder "hdk::ir::QueryBuilder"
+  cdef cppclass CBuilderExpr "hdk::ir::BuilderExpr"
+
+  cdef cppclass CBuilderOrderByKey "hdk::ir::BuilderOrderByKey":
+    CBuilderOrderByKey(const CBuilderExpr&, const string&, const string&) except +
 
   cdef cppclass CBuilderExpr "hdk::ir::BuilderExpr":
     CBuilderExpr()
@@ -37,6 +41,11 @@ cdef extern from "omniscidb/QueryBuilder/QueryBuilder.h":
     CBuilderExpr sample() except +
     CBuilderExpr singleValue() except +
     CBuilderExpr stdDev() except +
+
+    CBuilderExpr lag(int) except +
+    CBuilderExpr lead(int) except +
+    CBuilderExpr firstValue() except +
+    CBuilderExpr lastValue() except +
 
     CBuilderExpr extract(const string&) except +
 
@@ -74,6 +83,8 @@ cdef extern from "omniscidb/QueryBuilder/QueryBuilder.h":
 
     CBuilderExpr at(const CBuilderExpr&) except +
 
+    CBuilderExpr over(const vector[CBuilderExpr]&) except +
+    CBuilderExpr orderBy(const vector[CBuilderOrderByKey]&) except +
 
   cdef cppclass CBuilderSortField "hdk::ir::BuilderSortField":
     CBuilderSortField(CBuilderExpr, const string&, const string&) except +
@@ -111,6 +122,11 @@ cdef extern from "omniscidb/QueryBuilder/QueryBuilder.h":
     CBuilderNode proj(const vector[CBuilderExpr]&) except +
 
     CBuilderExpr count() except +
+    CBuilderExpr rowNumber() except +
+    CBuilderExpr rank() except +
+    CBuilderExpr denseRank() except +
+    CBuilderExpr percentRank() except +
+    CBuilderExpr nTile(int) except +
 
     CBuilderExpr cstFromIntNoType "cst"(int64_t) except +
     CBuilderExpr cstFromIntNoScale "cstNoScale"(int64_t, const CType*) except +

--- a/python/pyhdk/hdk.py
+++ b/python/pyhdk/hdk.py
@@ -269,6 +269,116 @@ class QueryExprAPI:
         """
         pass
 
+    def lag(self, n=1):
+        """
+        Create LAG window function with the current expression as its argument.
+
+        Parameters
+        ----------
+        n : int
+            Lag distance.
+
+        Returns
+        -------
+        QueryExpr
+
+        Examples
+        --------
+        >>> hdk = pyhdk.init()
+        >>> ht = hdk.import_pydict({"a": [1, 2, 3, 4, 5]})
+        >>> ht.proj("a", ht.ref("a").lag(2)).run()
+        Schema:
+          a: INT64
+          a_lag: INT64
+        Data:
+        1|null
+        2|null
+        3|1
+        4|2
+        5|3
+        """
+        pass
+
+    def lead(self, n=1):
+        """
+        Create LEAD window function with the current expression as its argument.
+
+        Parameters
+        ----------
+        n : int
+            Lead distance.
+
+        Returns
+        -------
+        QueryExpr
+
+        Examples
+        --------
+        >>> hdk = pyhdk.init()
+        >>> ht = hdk.import_pydict({"a": [1, 2, 3, 4, 5]})
+        >>> ht.proj("a", ht.ref("a").lead(2)).run()
+        Schema:
+          a: INT64
+          a_lead: INT64
+        Data:
+        1|3
+        2|4
+        3|5
+        4|null
+        5|null
+        """
+        pass
+
+    def first_value(self):
+        """
+        Create FIRST_VALUE window function with the current expression as its argument.
+
+        Returns
+        -------
+        QueryExpr
+
+        Examples
+        --------
+        >>> hdk = pyhdk.init()
+        >>> ht = hdk.import_pydict({"a": [1, 2, 3, 4, 5], "b": [1, 2, 1, 2, 1]})
+        >>> ht.proj("a", ht.ref("a").first_value().over(ht.ref("b"))).run()
+        Schema:
+          a: INT64
+          a_first_value: INT64
+        Data:
+        1|1
+        2|2
+        3|1
+        4|2
+        5|1
+        """
+        pass
+
+    def last_value(self):
+        """
+        Create LAST_VALUE window function with the current expression as its argument.
+
+        Returns
+        -------
+        QueryExpr
+
+        Examples
+        --------
+        >>> hdk = pyhdk.init()
+        >>> ht = hdk.import_pydict({"a": [1, 2, 3, 4, 5], "b": [1, 2, 1, 2, 1]})
+        >>> ht.proj("a", ht.ref("a").last_value().over(ht.ref("b"))).run()
+        Schema:
+          a: INT64
+          a_last_value: INT64
+        Data:
+        1|1
+        2|2
+        3|3
+        4|4
+        5|5
+        """
+        pass
+
     def extract(self, field):
         """
         Create EXTRACT expression to extract a part of date from the current expression.
@@ -1075,6 +1185,71 @@ class QueryExprAPI:
         Data:
         1|2|null
         2|4|null
+        """
+        pass
+
+    def over(self, *args):
+        """
+        Add partition keys to window function expression. Also, transforms min, max, sum, avg, and count
+        aggregates to corresponding window functions.
+
+
+        Parameters
+        ----------
+        *args : list of QueryExpr
+            Partition keys. Should be column references.
+
+        Returns
+        -------
+        QueryExpr
+
+        Examples
+        --------
+        >>> hdk=pyhdk.init()
+        >>> ht = hdk.import_pydict({"a": [1, 2, 1, 2, 1]})
+        >>> ht.proj("a", hdk.count().over(ht.ref("a"))).run()
+        Schema:
+          a: INT64
+          count: INT32[NN]
+        Data:
+        1|3
+        2|2
+        1|3
+        2|2
+        1|3
+        """
+        pass
+
+    def order_by(self, *args):
+        """
+        Add order keys to window function expression.
+
+
+        Parameters
+        ----------
+        *args : list of QueryExpr or tuples
+            Order keys. Each argument is QueryExpr or a tuple holding key, sort
+            order ('asc' or 'desc') and optional nulls position ('first' or
+            'last'). By default, sort is ascending and nulls position is last.
+
+        Returns
+        -------
+        QueryExpr
+
+        Examples
+        --------
+        >>> hdk=pyhdk.init()
+        >>> ht = hdk.import_pydict({"a": [4, 2, 1, 3, 5]})
+        >>> ht.proj("a", hdk.percent_rank().order_by(ht.ref("a"))).run()
+        Schema:
+          a: INT64
+          percent_rank: FP64[NN]
+        Data:
+        4|0.75
+        2|0.25
+        1|0
+        3|0.5
+        5|1
         """
         pass
 
@@ -2282,6 +2457,124 @@ class HDK:
         5
         """
         return self._builder.count()
+
+    def row_number(self):
+        """
+        Create a ROW_NUMBER window function expression.
+
+        Returns
+        -------
+        QueryExpr
+        >>> hdk = pyhdk.init()
+        >>> ht = hdk.import_pydict({"a": [1, 2, 1, 2, 1]})
+        >>> ht.proj("a", hdk.row_number().over(ht.ref("a"))).run()
+        Schema:
+          a: INT64
+          row_number: INT64[NN]
+        Data:
+        1|1
+        2|1
+        1|2
+        2|2
+        1|3
+
+        """
+        return self._builder.row_number()
+
+    def rank(self):
+        """
+        Create a RANK window function expression.
+
+        Returns
+        -------
+        QueryExpr
+        >>> hdk = pyhdk.init()
+        >>> ht = hdk.import_pydict({"a": [1, 2, 1, 2, 1], "b":[2, 2, 1, 3, 1]})
+        >>> ht.proj("a", "b", hdk.rank().over(ht.ref("a")).order_by(ht.ref("b"))).run()
+        Schema:
+          a: INT64
+          b: INT64
+          rank: INT64[NN]
+        Data:
+        1|2|3
+        2|2|1
+        1|1|1
+        2|3|2
+        1|1|1
+        """
+        return self._builder.rank()
+
+    def dense_rank(self):
+        """
+        Create a DENSE_RANK window function expression.
+
+        Returns
+        -------
+        QueryExpr
+        >>> hdk = pyhdk.init()
+        >>> ht = hdk.import_pydict({"a": [1, 2, 1, 2, 1], "b":[2, 2, 1, 3, 1]})
+        >>> ht.proj("a", "b", hdk.dense_rank().over(ht.ref("a")).order_by(ht.ref("b"))).run()
+        Schema:
+          a: INT64
+          b: INT64
+          dense_rank: INT64[NN]
+        Data:
+        1|2|2
+        2|2|1
+        1|1|1
+        2|3|2
+        1|1|1
+        """
+        return self._builder.dense_rank()
+
+    def percent_rank(self):
+        """
+        Create a PERCENT_RANK window function expression.
+
+        Returns
+        -------
+        QueryExpr
+        >>> hdk = pyhdk.init()
+        >>> ht = hdk.import_pydict({"a": [4, 2, 1, 3, 5]})
+        >>> ht.proj("a", hdk.percent_rank().order_by(ht.ref("a"))).run()
+        Schema:
+          a: INT64
+          percent_rank: FP64[NN]
+        Data:
+        4|0.75
+        2|0.25
+        1|0
+        3|0.5
+        5|1
+        """
+        return self._builder.percent_rank()
+
+    def ntile(self, tile_count):
+        """
+        Create a NTILE window function expression.
+
+        Parameters
+        ----------
+        tile_count : int
+            Number of generated tiles.
+
+        Returns
+        -------
+        QueryExpr
+        >>> hdk = pyhdk.init()
+        >>> ht = hdk.import_pydict({"a": [1, 2, 1, 2, 1]})
+        >>> ht.proj("a", hdk.ntile(2).over(ht.ref("a"))).run()
+        Schema:
+          a: INT64
+          ntile: INT64[NN]
+        Data:
+        1|1
+        2|1
+        1|1
+        2|2
+        1|2
+        """
+        return self._builder.ntile(tile_count)
 
 
 def init(**kwargs):


### PR DESCRIPTION
This allows using window functions with no SQL. It's required for one of the H2O queries.

This also fixes NULLs position when ORDER BY rule uses descending sort.