### PR TITLE
Avoid null comparison for non-nullable args.

### DIFF
--- a/omniscidb/QueryEngine/RowFuncBuilder.cpp
+++ b/omniscidb/QueryEngine/RowFuncBuilder.cpp
@@ -730,6 +730,11 @@ llvm::Value* RowFuncBuilder::convertNullIfAny(const hdk::ir::Type* arg_type,
     }
   }
   if (need_conversion) {
+    // Boolean values can be represented as a i1 LLVM values and cannot be NULLs.
+    if (target->getType()->isIntegerTy(1)) {
+      return executor_->cgen_state_->castToTypeIn(target_to_cast, chosen_bytes << 3);
+    }
+
     auto cmp = arg_type->isFloatingPoint() ? LL_BUILDER.CreateFCmpOEQ(target, arg_null)
                                            : LL_BUILDER.CreateICmpEQ(target, arg_null);
     return LL_BUILDER.CreateSelect(

--- a/omniscidb/Tests/QueryBuilderTest.cpp
+++ b/omniscidb/Tests/QueryBuilderTest.cpp
@@ -5302,6 +5302,25 @@ TEST_F(Issue355, Reproducer) {
   compare_res_data(res, std::vector<int64_t>({1}), std::vector<int64_t>({12}));
 }
 
+class Issue513 : public TestSuite {
+ protected:
+  static void SetUpTestSuite() {
+    createTable("test_513", {{"A", ctx().int64()}});
+    insertCsvValues("test_513", "1\n2\n3");
+  }
+
+  static void TearDownTestSuite() { dropTable("test_513"); }
+};
+
+TEST_F(Issue513, Reproducer) {
+  QueryBuilder builder(ctx(), getStorage(), configPtr());
+  auto scan = builder.scan("test_513");
+  auto proj = scan.proj(scan.ref("A").isNull());
+  auto dag = proj.agg(std::vector<std::string>(), {proj.ref(0).count()}).finalize();
+  auto res = runQuery(std::move(dag));
+  compare_res_data(res, std::vector<int32_t>({3}));
+}
+
 TEST_F(QueryBuilderTest, RunOnResult) {
   QueryBuilder builder(ctx(), schema_mgr_, configPtr());
 


### PR DESCRIPTION
Boolean values can be represented with both i1 and i8 values and that affects comparison with NULL. The former is actually non-nullable but there is a corner case when the original value is not nullable but is used to compute nullable aggregate (non-groupby aggregation case). In this case, we have to use `_skip_value` version of aggregates and handle NULLs somehow.

The patch fixes the aggregation case found by Modin.

Resolves #513