### PR TITLE
Add execution mode option to PyHDK python tests

### DIFF
--- a/omniscidb/ConfigBuilder/ConfigBuilder.cpp
+++ b/omniscidb/ConfigBuilder/ConfigBuilder.cpp
@@ -574,6 +574,12 @@ bool ConfigBuilder::parseCommandLineArgs(int argc,
                              ->default_value(config_->debug.enable_automatic_ir_metadata)
                              ->implicit_value(true),
                          "Enable automatic IR metadata (debug builds only).");
+  opt_desc.add_options()(
+      "enable-gpu-code-compilation-cache",
+      po::value<bool>(&config_->debug.enable_gpu_code_compilation_cache)
+          ->default_value(config_->debug.enable_gpu_code_compilation_cache)
+          ->implicit_value(true),
+      "Enable GPU compilation code caching.");
 
   // storage
   opt_desc.add_options()(

--- a/omniscidb/QueryEngine/NativeCodegen.cpp
+++ b/omniscidb/QueryEngine/NativeCodegen.cpp
@@ -385,7 +385,7 @@ std::shared_ptr<CompilationContext> Executor::optimizeAndCodegenGPU(
 
   auto key = get_code_cache_key(query_func, cgen_state_.get());
   auto cached_code = Executor::gpu_code_accessor->get_value(key);
-  if (cached_code) {
+  if (config_->debug.enable_gpu_code_compilation_cache && cached_code) {
     return cached_code;
   }
 

--- a/omniscidb/Shared/Config.h
+++ b/omniscidb/Shared/Config.h
@@ -171,6 +171,7 @@ struct DebugConfig {
   std::string build_ra_cache = "";
   std::string use_ra_cache = "";
   bool enable_automatic_ir_metadata = true;
+  bool enable_gpu_code_compilation_cache = true;
   std::string log_dir = "hdk_log";
 };
 

--- a/python/pyhdk/hdk.py
+++ b/python/pyhdk/hdk.py
@@ -1750,7 +1750,7 @@ class QueryNodeAPI:
         """
         pass
 
-    def run(self):
+    def run(self, **kwargs):
         """
         Run query with the current node as a query root node.
 
@@ -2624,6 +2624,7 @@ class HDK:
 def init(**kwargs):
     if init._instance is None:
         init._instance = HDK(**kwargs)
+    # TODO: kwargs are ignored here
     return init._instance
 
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,38 @@
+#
+# Copyright 2022 Intel Corporation.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+from pytest import fixture
+from dataclasses import dataclass
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--device", action="store", default="CPU", help="Choose device type (CPU/GPU)."
+    )
+
+
+@dataclass
+class ExecutionConfig:
+    enable_heterogeneous: bool
+    device_type: str
+
+
+cpu_cfg = ExecutionConfig(False, "CPU")
+gpu_cfg = ExecutionConfig(False, "GPU")
+het_cfg = ExecutionConfig(True, "AUTO")
+
+
+def get_execution_config(device_type: str):
+    if device_type.lower() == "cpu":
+        return cpu_cfg
+    if device_type.lower() == "gpu":
+        return gpu_cfg
+    raise ValueError("Unsupported exeuction config: " + str(device_type))
+
+
+@fixture
+def exe_cfg(request):
+    return get_execution_config(request.config.getoption("--device"))

--- a/python/tests/test_pyhdk_api.py
+++ b/python/tests/test_pyhdk_api.py
@@ -1261,7 +1261,7 @@ class BaseTaxiTest:
 class TestTaxiSql(BaseTaxiTest):
     def test_taxi_over_csv_modular(self, exe_cfg):
         # Initialize HDK components
-        config = pyhdk.buildConfig()
+        config = pyhdk.buildConfig(enable_gpu_code_compilation_cache=False)
         storage = pyhdk.storage.ArrowStorage(1, config)
         data_mgr = pyhdk.storage.DataMgr(config)
         data_mgr.registerDataProvider(storage)
@@ -1490,7 +1490,7 @@ class TestTaxiSql(BaseTaxiTest):
 class TestTaxiIR(BaseTaxiTest):
     def test_taxi_over_csv_modular(self, exe_cfg):
         # Initialize HDK components
-        config = pyhdk.buildConfig()
+        config = pyhdk.buildConfig(enable_gpu_code_compilation_cache=False)
         storage = pyhdk.storage.ArrowStorage(1, config)
         data_mgr = pyhdk.storage.DataMgr(config)
         data_mgr.registerDataProvider(storage)

--- a/python/tests/test_pyhdk_api.py
+++ b/python/tests/test_pyhdk_api.py
@@ -10,20 +10,8 @@ import pandas
 import pytest
 import pyhdk
 import numpy as np
-from dataclasses import dataclass
 
 from helpers import check_schema, check_res
-
-
-@dataclass
-class ExecutionConfig:
-    enable_heterogeneous: bool
-    device_type: str
-
-
-cpu_cfg = ExecutionConfig(False, "CPU")
-gpu_cfg = ExecutionConfig(False, "GPU")
-het_cfg = ExecutionConfig(True, "AUTO")
 
 
 class BaseTest:
@@ -164,7 +152,6 @@ class TestImport(BaseTest):
         hdk.drop_table(table_name)
 
 
-@pytest.mark.parametrize("exe_cfg", [cpu_cfg, gpu_cfg])
 class TestBuilder(BaseTest):
     def test_scan(self, exe_cfg):
         hdk = pyhdk.init()
@@ -1137,7 +1124,6 @@ class TestBuilder(BaseTest):
         check_res(res, {"a_last_value": [1, 2, 3, 4, 5]})
 
 
-@pytest.mark.parametrize("exe_cfg", [cpu_cfg, gpu_cfg])
 class TestSql(BaseTest):
     def test_no_alias(self, exe_cfg):
         hdk = pyhdk.init()
@@ -1219,7 +1205,6 @@ class TestSql(BaseTest):
         check_res(res3, {"b": [4, 3, 2, 1, 0], "a": [2, 3, 4, 5, 6]})
 
 
-@pytest.mark.parametrize("exe_cfg", [cpu_cfg, gpu_cfg])
 class BaseTaxiTest:
     @staticmethod
     def check_taxi_q1_res(res):

--- a/python/tests/test_pyhdk_api.py
+++ b/python/tests/test_pyhdk_api.py
@@ -29,7 +29,6 @@ class BaseTest:
 class TestImport(BaseTest):
     def test_create_table(self):
         hdk = pyhdk.init()
-        pyhdk.initLogger(debug_logs=True)
 
         ht = hdk.create_table("test1", [("a", "int"), ("b", hdk.type("fp"))])
         check_schema(ht.schema, {"a": "INT64", "b": "FP64"})


### PR DESCRIPTION
The PR introduces a `--device` option to pytests to allow for switching between execution modes. The default behavior remains unchanged.
It also provides a quick simple fix (by disabling L0 compilation context caching with `enable-gpu-code-compilation-cache=false`) to the following problem:
When HDK components are handled manually and the data manager is reinitialized the compilation cache may outlive the GPU manager (since its lifetime is bound to the data manager's lifetime). The compilation context would then try to access an invalid instance `L0Device` with a valid device handle (the driver returns the same handle on consequent calls).