### PR TITLE
[Warns] Reduce warnings amount

### DIFF
--- a/omniscidb/QueryEngine/CardinalityEstimator.cpp
+++ b/omniscidb/QueryEngine/CardinalityEstimator.cpp
@@ -70,7 +70,8 @@ RelAlgExecutionUnit create_ndv_execution_unit(const RelAlgExecutionUnit& ra_exe_
     auto tinfo = schema_provider->getTableInfo(outer_input_it->getDatabaseId(),
                                                outer_input_it->getTableId());
     CHECK(tinfo);
-    if (tinfo->row_count < config.exec.group_by.large_ndv_threshold) {
+    if (static_cast<int64_t>(tinfo->row_count) <
+        config.exec.group_by.large_ndv_threshold) {
       LOG(INFO) << "Avoid large estimator because of the small input ("
                 << tinfo->row_count << " rows).";
       use_large_estimator = false;

--- a/omniscidb/QueryEngine/DateTruncate.cpp
+++ b/omniscidb/QueryEngine/DateTruncate.cpp
@@ -35,6 +35,8 @@
 #include <ctime>
 #include <limits>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
 #define DATE_TRUNC_FUNC_JIT(funcname)                                                \
   extern "C" RUNTIME_EXPORT ALWAYS_INLINE DEVICE int64_t funcname(int64_t timeval) { \
     return funcname##_##impl(timeval);                                               \
@@ -574,3 +576,5 @@ DateDiffHighPrecisionNullable(const hdk::ir::DateTruncField datepart,
   }
   return DateDiffHighPrecision(datepart, startdate, enddate, start_dim, end_dim);
 }
+
+#pragma GCC diagnostic pop

--- a/omniscidb/QueryEngine/Execute.cpp
+++ b/omniscidb/QueryEngine/Execute.cpp
@@ -1989,9 +1989,8 @@ Executor::getExecutionPolicyForTargets(const RelAlgExecutionUnit& ra_exe_unit,
               << toString(ra_exe_unit.templs) << " cost_model=" << ra_exe_unit.cost_model
               << ", cost model in config: "
               << (config_->exec.enable_cost_model ? "enabled" : "disabled")
-              << ", heterogeneous execution: " << cfg.enable_heterogeneous_execution
-      ? "enabled"
-      : "disabled";
+              << ", heterogeneous execution: "
+              << (cfg.enable_heterogeneous_execution ? "enabled" : "disabled");
 
   if (cfg.enable_heterogeneous_execution) {
     if (cfg.forced_heterogeneous_distribution) {

--- a/omniscidb/QueryEngine/Optimization/AnnotateInternalFunctionsPass.h
+++ b/omniscidb/QueryEngine/Optimization/AnnotateInternalFunctionsPass.h
@@ -37,8 +37,6 @@ class AnnotateInternalFunctionsPass
                               llvm::CGSCCAnalysisManager& AM,
                               llvm::LazyCallGraph& CG,
                               llvm::CGSCCUpdateResult& UR) {
-    bool updated_function_defs = false;
-
 #if 0
     for (llvm::LazyCallGraph::Node& N : InitialC) {
       llvm::Function* Fn = &N.getFunction();
@@ -57,7 +55,6 @@ class AnnotateInternalFunctionsPass
       }
       if (isInternalStatelessFunction(fcn->getName()) ||
           isInternalMathFunction(fcn->getName())) {
-        updated_function_defs = true;
         std::vector<llvm::Attribute::AttrKind> attrs{llvm::Attribute::NoFree,
                                                      llvm::Attribute::NoSync,
                                                      llvm::Attribute::NoUnwind,
@@ -68,7 +65,6 @@ class AnnotateInternalFunctionsPass
           fcn->addFnAttr(attr);
         }
       } else if (isReadOnlyFunction(fcn->getName())) {
-        updated_function_defs = true;
         fcn->addFnAttr(llvm::Attribute::ReadOnly);
       }
     }

--- a/omniscidb/ResultSet/ResultSetStorage.cpp
+++ b/omniscidb/ResultSet/ResultSetStorage.cpp
@@ -51,6 +51,8 @@ int8_t* VarlenOutputInfo::computeCpuOffset(const int64_t gpu_offset_address) con
 
 namespace {
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
 ALWAYS_INLINE
 void fill_empty_key_32(int32_t* key_ptr_i32, const size_t key_count) {
   for (size_t i = 0; i < key_count; ++i) {
@@ -64,6 +66,7 @@ void fill_empty_key_64(int64_t* key_ptr_i64, const size_t key_count) {
     key_ptr_i64[i] = EMPTY_KEY_64;
   }
 }
+#pragma GCC diagnostic pop
 
 template <typename T>
 inline size_t make_bin_search(size_t l, size_t r, T&& is_empty_fn) {

--- a/omniscidb/ResultSet/TargetValue.cpp
+++ b/omniscidb/ResultSet/TargetValue.cpp
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#pragma once
-
 #include "TargetValue.h"
 
 #include "IR/Type.h"

--- a/omniscidb/Tests/ArrowStorageTest.cpp
+++ b/omniscidb/Tests/ArrowStorageTest.cpp
@@ -13,6 +13,7 @@
  */
 
 #include "ArrowStorage/ArrowStorage.h"
+#include "Shared/ArrowUtil.h"
 
 #include "TestHelpers.h"
 
@@ -736,11 +737,10 @@ TEST_F(ArrowStorageTest, ImportArrowTable) {
   ArrowStorage storage(TEST_SCHEMA_ID, "test", TEST_DB_ID, config_);
   auto col_a = std::make_shared<arrow::Field>("A", arrow::null());
   auto schema = arrow::schema({col_a});
-
   std::shared_ptr<arrow::Array> empty_array;
   arrow::NumericBuilder<arrow::FloatType> float64_builder;
-  float64_builder.AppendValues({});
-  float64_builder.Finish(&empty_array);
+  ARROW_THROW_NOT_OK(float64_builder.AppendValues({}));
+  ARROW_THROW_NOT_OK(float64_builder.Finish(&empty_array));
   auto table = arrow::Table::Make(schema, {empty_array});
   ASSERT_NO_THROW(
       storage.importArrowTable(table, "test_empty", ArrowStorage::TableOptions{1}));

--- a/omniscidb/Utils/ExtractFromTime.cpp
+++ b/omniscidb/Utils/ExtractFromTime.cpp
@@ -51,6 +51,9 @@ DEVICE unsigned week_start_from_yoe(unsigned const yoe) {
 
 }  // namespace
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
+
 extern "C" RUNTIME_EXPORT ALWAYS_INLINE DEVICE int64_t
 extract_hour(const int64_t lcltime) {
   return unsigned_mod(lcltime, kSecsPerDay) / kSecsPerHour;
@@ -267,6 +270,7 @@ extract_year(const int64_t timeval) {
   return 2000 + era * 400 + yoe + (MARJAN <= doy);
 }
 
+#pragma GCC diagnostic pop
 /*
  * @brief support the SQL EXTRACT function
  */


### PR DESCRIPTION
This commit is an initial step to remove warnings from build. Currently
it's focused on linux build.

Always_inline attribute warning works incorrectly. In this case we want
to keep symbol and than inline it during target llvm ir optimisation.

See also: #521

Signed-off-by: Dmitrii Makarenko <dmitrii.makarenko@intel.com>