### PR TITLE
Dumping IR after every optimization pass

### DIFF
--- a/omniscidb/ConfigBuilder/ConfigBuilder.cpp
+++ b/omniscidb/ConfigBuilder/ConfigBuilder.cpp
@@ -613,6 +613,13 @@ bool ConfigBuilder::parseCommandLineArgs(int argc,
                              ->default_value(config_->debug.enable_automatic_ir_metadata)
                              ->implicit_value(true),
                          "Enable automatic IR metadata (debug builds only).");
+  opt_desc.add_options()("dump-after-all",
+                         po::value<short>(&config_->debug.dump_llvm_ir_after_each_pass)
+                             ->default_value(config_->debug.dump_llvm_ir_after_each_pass)
+                             ->implicit_value(1),
+                         "Dump LLVM IR modules' optimizations(0: no dump, 1: "
+                         "before/after opt, 2: dump after _every_ "
+                         "pass (likely more than you need)).");
   opt_desc.add_options()(
       "enable-gpu-code-compilation-cache",
       po::value<bool>(&config_->debug.enable_gpu_code_compilation_cache)

--- a/omniscidb/QueryEngine/CompilationOptions.h
+++ b/omniscidb/QueryEngine/CompilationOptions.h
@@ -47,6 +47,7 @@ struct CompilationOptions {
   bool register_intel_jit_listener{false};
   bool use_groupby_buffer_desc{false};
   compiler::CodegenTraitsDescriptor codegen_traits_desc{};
+  short dump_llvm_ir_after_each_pass{0};
 
   static CompilationOptions makeCpuOnly(const CompilationOptions& in) {
     return CompilationOptions{ExecutorDeviceType::CPU,

--- a/omniscidb/QueryEngine/Compiler/HelperFunctions.h
+++ b/omniscidb/QueryEngine/Compiler/HelperFunctions.h
@@ -22,6 +22,8 @@
 #include "QueryEngine/CompilationOptions.h"
 
 namespace compiler {
+static std::atomic<size_t> w_unit_counter{0};
+static const std::string_view tstamp_module_varname{"ModuleTstamp"};
 
 #define MODULE_DUMP_ENABLE 1
 #ifdef MODULE_DUMP_ENABLE

--- a/omniscidb/QueryEngine/NativeCodegen.cpp
+++ b/omniscidb/QueryEngine/NativeCodegen.cpp
@@ -1498,6 +1498,8 @@ Executor::compileWorkUnit(const std::vector<InputTableInfo>& query_infos,
 
   CompilationOptions co_codegen_traits = co;
   co_codegen_traits.codegen_traits_desc = backend->traitsDesc();
+  co_codegen_traits.dump_llvm_ir_after_each_pass =
+      config_->debug.dump_llvm_ir_after_each_pass;
 
   if (is_gpu) {
     cgen_state_->module_->setDataLayout(traits.dataLayout());

--- a/omniscidb/Shared/Config.h
+++ b/omniscidb/Shared/Config.h
@@ -180,6 +180,7 @@ struct DebugConfig {
   bool enable_automatic_ir_metadata = true;
   bool enable_gpu_code_compilation_cache = true;
   std::string log_dir = "hdk_log";
+  short dump_llvm_ir_after_each_pass{0};
 };
 
 struct StorageConfig {

--- a/omniscidb/Tests/CMakeLists.txt
+++ b/omniscidb/Tests/CMakeLists.txt
@@ -73,7 +73,7 @@ if(ENABLE_L0)
   target_link_libraries(L0MgrExecuteTest L0Mgr gtest ${llvm_libs} Logger OSDependent)
   target_link_libraries(SpirvBuildTest gtest ${llvm_libs})
   target_link_libraries(DataMgrWithL0Test DataMgr gtest)
-  target_link_libraries(IntelGPUEnablingTest gtest QueryEngine ArrowQueryRunner)
+  target_link_libraries(IntelGPUEnablingTest gtest QueryEngine ArrowQueryRunner ConfigBuilder)
 
   add_test(L0MgrExecuteTest L0MgrExecuteTest ${TEST_ARGS})
   add_test(SpirvBuildTest SpirvBuildTest ${TEST_ARGS})


### PR DESCRIPTION
This PR introduces a new config flag `dump-after-all`, which when set to `1` will dump module-level IR before and after optimizations (`IR_UNOPT`/`IR_OPT`). When set to `2` will dump IR before optimizations, after each transformation pass (`IR_AFTER_#passCounter_#passName`) and after all transformations.

The intent behind this feature was to make the debugging of problematic queries easier.

With the introduction of the new pass builder and pass managers (e.g., FunctionPassManager), the transformation passes can now run more often, but on a smaller granularity scale (e.g., earlier it was _one pass_ for _all functions_, now it is one pass _per_ function). This way we cannot "summarize" passes (e.g., after GVN, after SROAP), since now the entire functions transformation pipeline runs for each function fully, so expect many (really many) files for even seemingly simple queries when the severity is set to `2`.

The example usage is in `IntelGPUEnablingTest`.
You can call it like e.g., `./IntelGPUEnablingTest --gtest_filter=JoinTest.SimpleJoin --dump-after-all=1`