### PR TITLE
Enable shared memory by default

### DIFF
--- a/omniscidb/L0Mgr/L0Mgr.h
+++ b/omniscidb/L0Mgr/L0Mgr.h
@@ -79,6 +79,7 @@ class L0Device {
   L0Device(const L0Driver& driver, ze_device_handle_t device);
   uint32_t maxGroupCount() const;
   uint32_t maxGroupSize() const;
+  uint32_t maxSharedLocalMemory() const;
   ze_device_handle_t device() const;
   ze_context_handle_t ctx() const;
   ~L0Device();

--- a/omniscidb/QueryEngine/CMakeLists.txt
+++ b/omniscidb/QueryEngine/CMakeLists.txt
@@ -175,6 +175,7 @@ add_dependencies(QueryEngine QueryEngineFunctionsTargets)
 
 set(cpu_runtime_function_sources RuntimeFunctions.cpp DateAdd.cpp DateTruncate.cpp)
 set(intel_gpu_runtime_function_sources l0_mapd_rt.cpp DateAdd.cpp DateTruncate.cpp)
+set(intel_gpu_helpers_sources genx.cpp)
 
 
 set(hdk_default_runtime_functions_module_dependencies
@@ -250,15 +251,20 @@ link_runtime_module(${intel_gpu_module_name} "${intel_gpu_precompiled_module_lis
 link_runtime_module(${cpu_module_name} "${cpu_precompiled_module_list}")
 
 # SPIRV helper functions & intrinsics
-set(spirv_helper_functions_module genx.bc)
+set(spirv_helper_functions_module genx_impl.bc)
 add_custom_command(
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Compiler/genx.ll
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/genx.bc
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${spirv_helper_functions_module}
     COMMAND ${llvm_as_cmd} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/Compiler/genx.ll -o ${CMAKE_CURRENT_BINARY_DIR}/${spirv_helper_functions_module}
 )
 
+set(spirv_runtime_module genx.bc)
+precompile_modules("genx_mod_lst" ${intel_gpu_module_internal_suffix} ${precompile_intel_gpu_module_cmd} Compiler/genx.cpp)
+list(APPEND genx_mod_lst ${spirv_helper_functions_module})
+link_runtime_module(${spirv_runtime_module} "${genx_mod_lst}")
+
 if(ENABLE_L0)
-    add_custom_target(IntelGPURuntimeModule DEPENDS ${intel_gpu_module_name} ${spirv_helper_functions_module})
+    add_custom_target(IntelGPURuntimeModule DEPENDS ${intel_gpu_module_name} ${spirv_runtime_module})
     add_dependencies(QueryEngine IntelGPURuntimeModule)
 endif()
 

--- a/omniscidb/QueryEngine/CMakeLists.txt
+++ b/omniscidb/QueryEngine/CMakeLists.txt
@@ -296,7 +296,7 @@ set(query_engine_install_artefacts
 if(ENABLE_L0)
     list(APPEND query_engine_install_artefacts
         ${CMAKE_CURRENT_BINARY_DIR}/${intel_gpu_module_name}
-        ${CMAKE_CURRENT_BINARY_DIR}/${spirv_helper_functions_module})
+        ${CMAKE_CURRENT_BINARY_DIR}/${spirv_runtime_module})
 endif()
 install(FILES ${query_engine_install_artefacts} DESTINATION QueryEngine COMPONENT "QE")
 

--- a/omniscidb/QueryEngine/Compiler/Backend.cpp
+++ b/omniscidb/QueryEngine/Compiler/Backend.cpp
@@ -1063,7 +1063,6 @@ std::shared_ptr<Backend> getBackend(
       if (gpu_target.gpu_mgr->getPlatform() == GpuMgrPlatform::CUDA)
         return std::make_shared<CUDABackend>(exts, is_gpu_smem_used_, gpu_target);
       if (gpu_target.gpu_mgr->getPlatform() == GpuMgrPlatform::L0) {
-        CHECK(!is_gpu_smem_used_);
         return std::make_shared<L0Backend>(exts, gpu_target);
       }
     default:

--- a/omniscidb/QueryEngine/Compiler/Backend.cpp
+++ b/omniscidb/QueryEngine/Compiler/Backend.cpp
@@ -918,8 +918,33 @@ void replace_function(llvm::Module* from, llvm::Module* to, const std::string& f
         auto new_call = llvm::CallInst::Create(local_callee, args, call->getName());
 
         llvm::ReplaceInstWithInst(call, new_call);
+        inst = new_call;
+      }
+      for (unsigned op_idx = 0; op_idx < inst->getNumOperands(); ++op_idx) {
+        auto op = inst->getOperand(op_idx);
+        if (auto* global = llvm::dyn_cast<llvm::GlobalVariable>(op)) {
+          auto local_global = to->getGlobalVariable(global->getName(), true);
+          CHECK(local_global);
+          inst->setOperand(op_idx, local_global);
+        }
       }
     }
+  }
+}
+
+void insert_globals(llvm::Module* from, llvm::Module* to) {
+  for (const llvm::GlobalVariable& I : from->globals()) {
+    llvm::GlobalVariable* new_gv =
+        new llvm::GlobalVariable(*to,
+                                 I.getValueType(),
+                                 I.isConstant(),
+                                 I.getLinkage(),
+                                 (llvm::Constant*)nullptr,
+                                 I.getName(),
+                                 (llvm::GlobalVariable*)nullptr,
+                                 I.getThreadLocalMode(),
+                                 I.getType()->getAddressSpace());
+    new_gv->copyAttributesFrom(&I);
   }
 }
 
@@ -940,6 +965,7 @@ std::shared_ptr<L0CompilationContext> L0Backend::generateNativeGPUCode(
 
   CHECK(exts.find(ExtModuleKinds::spirv_helper_funcs_module) != exts.end());
 
+  insert_globals(exts.at(ExtModuleKinds::spirv_helper_funcs_module).get(), module);
   for (auto& F : *(exts.at(ExtModuleKinds::spirv_helper_funcs_module))) {
     insert_declaration(exts.at(ExtModuleKinds::spirv_helper_funcs_module).get(),
                        module,
@@ -1079,11 +1105,7 @@ void setSharedMemory(ExecutorDeviceType dt,
     case ExecutorDeviceType::CPU:
       return;
     case ExecutorDeviceType::GPU:
-      if (gpu_target.gpu_mgr->getPlatform() == GpuMgrPlatform::CUDA)
-        backend->setSharedMemory(is_gpu_smem_used_);
-      if (gpu_target.gpu_mgr->getPlatform() == GpuMgrPlatform::L0) {
-        CHECK(!is_gpu_smem_used_);
-      }
+      backend->setSharedMemory(is_gpu_smem_used_);
       return;
     default:
       CHECK(false);

--- a/omniscidb/QueryEngine/Compiler/CommonRuntimeDefs.h
+++ b/omniscidb/QueryEngine/Compiler/CommonRuntimeDefs.h
@@ -1,0 +1,20 @@
+/**
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include "Shared/funcannotations.h"
+
+template <class T>
+struct remove_addr_space {
+  typedef T type;
+};
+
+#ifdef L0_RUNTIME_ENABLED
+template <class T>
+struct remove_addr_space<GENERIC_ADDR_SPACE T> {
+  typedef T type;
+};
+#endif

--- a/omniscidb/QueryEngine/Compiler/HelperFunctions.cpp
+++ b/omniscidb/QueryEngine/Compiler/HelperFunctions.cpp
@@ -70,6 +70,7 @@ void verify_function_ir(const llvm::Function* func) {
     err_os << "\n-----\n";
     func->print(err_os, nullptr);
     err_os << "\n-----\n";
+    DUMP_MODULE(func->getParent(), "invalid.ll");
     LOG(FATAL) << err_ss.str();
   }
 }

--- a/omniscidb/QueryEngine/Compiler/genx.cpp
+++ b/omniscidb/QueryEngine/Compiler/genx.cpp
@@ -43,11 +43,11 @@ DEF_AGG_ID_INT_SHARED(8)
 #undef DEF_AGG_ID_INT_SHARED
 
 void agg_id_float_shared(GENERIC_ADDR_SPACE int32_t* agg, const float val) {
-  *agg = static_cast<int32_t>(val);
+  *reinterpret_cast<GENERIC_ADDR_SPACE float*>(agg) = val;
 }
 
 void agg_id_double_shared(GENERIC_ADDR_SPACE int64_t* agg, const double val) {
-  *agg = static_cast<int64_t>(val);
+  *reinterpret_cast<GENERIC_ADDR_SPACE double*>(agg) = val;
 }
 
 uint32_t agg_count_float_shared(GENERIC_ADDR_SPACE uint32_t* agg, const float val) {

--- a/omniscidb/QueryEngine/Compiler/genx.cpp
+++ b/omniscidb/QueryEngine/Compiler/genx.cpp
@@ -1,0 +1,107 @@
+/**
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <algorithm>
+#include <cstdint>
+
+#include "Shared/funcannotations.h"
+
+extern "C" {
+int64_t atomic_cas_int_64(GENERIC_ADDR_SPACE int64_t*, int64_t, int64_t);
+int32_t atomic_cas_int_32(GENERIC_ADDR_SPACE int32_t*, int32_t, int32_t);
+int64_t atomic_xchg_int_64(GENERIC_ADDR_SPACE int64_t*, int64_t);
+int32_t atomic_xchg_int_32(GENERIC_ADDR_SPACE int32_t*, int32_t);
+double atomic_min_double(GENERIC_ADDR_SPACE double* addr, const double val);
+double atomic_min_float(GENERIC_ADDR_SPACE float* addr, const float val);
+double atomic_max_double(GENERIC_ADDR_SPACE double* addr, const double val);
+double atomic_max_float(GENERIC_ADDR_SPACE float* addr, const float val);
+
+void agg_max_shared(GENERIC_ADDR_SPACE int64_t* agg, const int64_t val);
+int64_t agg_count_shared(GENERIC_ADDR_SPACE int64_t* agg, const int64_t val);
+uint32_t agg_count_int32_shared(GENERIC_ADDR_SPACE uint32_t* agg, const int32_t val);
+
+const GENERIC_ADDR_SPACE int64_t* init_shared_mem_nop(
+    const GENERIC_ADDR_SPACE int64_t* groups_buffer,
+    const int32_t groups_buffer_size) {
+  return groups_buffer;
+}
+
+// TODO: these are almost the same in cuda, move to a single source
+#define DEF_AGG_ID_INT_SHARED(n)                                             \
+  extern "C" void agg_id_int##n##_shared(GENERIC_ADDR_SPACE int##n##_t* agg, \
+                                         const int##n##_t val) {             \
+    *agg = val;                                                              \
+  }
+
+DEF_AGG_ID_INT_SHARED(32)
+DEF_AGG_ID_INT_SHARED(16)
+DEF_AGG_ID_INT_SHARED(8)
+
+#undef DEF_AGG_ID_INT_SHARED
+
+void agg_id_float_shared(GENERIC_ADDR_SPACE int32_t* agg, const float val) {
+  *agg = static_cast<int32_t>(val);
+}
+
+void agg_id_double_shared(GENERIC_ADDR_SPACE int64_t* agg, const double val) {
+  *agg = static_cast<int64_t>(val);
+}
+
+uint32_t agg_count_float_shared(GENERIC_ADDR_SPACE uint32_t* agg, const float val) {
+  return agg_count_int32_shared(agg, val);
+}
+
+int64_t agg_count_double_shared(GENERIC_ADDR_SPACE int64_t* agg, const double val) {
+  return agg_count_shared(agg, static_cast<int64_t>(val));
+}
+
+void agg_min_float_shared(GENERIC_ADDR_SPACE int32_t* agg, const float val) {
+  atomic_min_float(reinterpret_cast<GENERIC_ADDR_SPACE float*>(agg), val);
+}
+
+void agg_min_double_shared(GENERIC_ADDR_SPACE int64_t* agg, const double val) {
+  atomic_min_double(reinterpret_cast<GENERIC_ADDR_SPACE double*>(agg), val);
+}
+
+void agg_min_float_skip_val_shared(GENERIC_ADDR_SPACE int32_t* agg,
+                                   const float val,
+                                   const float skip_val) {
+  if (val != skip_val) {
+    agg_min_float_shared(agg, val);
+  }
+}
+
+void agg_min_double_skip_val_shared(GENERIC_ADDR_SPACE int64_t* agg,
+                                    const double val,
+                                    const double skip_val) {
+  if (val != skip_val) {
+    agg_min_double_shared(agg, val);
+  }
+}
+
+void agg_max_float_shared(GENERIC_ADDR_SPACE int32_t* agg, const float val) {
+  atomic_max_float(reinterpret_cast<GENERIC_ADDR_SPACE float*>(agg), val);
+}
+void agg_max_double_shared(GENERIC_ADDR_SPACE int64_t* agg, const double val) {
+  atomic_max_double(reinterpret_cast<GENERIC_ADDR_SPACE double*>(agg), val);
+}
+
+void agg_max_float_skip_val_shared(GENERIC_ADDR_SPACE int32_t* agg,
+                                   const float val,
+                                   const float skip_val) {
+  if (val != skip_val) {
+    agg_max_float_shared(agg, val);
+  }
+}
+
+void agg_max_double_skip_val_shared(GENERIC_ADDR_SPACE int64_t* agg,
+                                    const double val,
+                                    const double skip_val) {
+  if (val != skip_val) {
+    agg_max_double_shared(agg, val);
+  }
+}
+}

--- a/omniscidb/QueryEngine/Execute.cpp
+++ b/omniscidb/QueryEngine/Execute.cpp
@@ -271,6 +271,11 @@ void Executor::update_extension_modules(bool update_runtime_modules_only) {
       }
     }
   };
+  auto patch_l0_module = [](ExtModuleKinds kind, llvm::Module* m) {
+    if (kind == ExtModuleKinds::l0_template_module) {
+      m->setTargetTriple("spir64-unknown-unknown");
+    }
+  };
   auto update_module = [&](ExtModuleKinds module_kind, bool erase_not_found = false) {
     CHECK(extension_module_context_);
     auto& extension_modules = extension_module_context_->getExtensionModules();
@@ -279,6 +284,7 @@ void Executor::update_extension_modules(bool update_runtime_modules_only) {
     if (it != Executor::extension_module_sources.end()) {
       auto llvm_module = read_module(module_kind, it->second);
       if (llvm_module) {
+        patch_l0_module(module_kind, llvm_module.get());
         extension_modules[module_kind] = std::move(llvm_module);
       } else if (erase_not_found) {
         extension_modules.erase(module_kind);

--- a/omniscidb/QueryEngine/GpuSharedMemoryUtils.cpp
+++ b/omniscidb/QueryEngine/GpuSharedMemoryUtils.cpp
@@ -159,12 +159,8 @@ void GpuSharedMemCodeBuilder::codegenReduction(const CompilationOptions& co) {
       executor_);
   auto reduction_code = rs_reduction_jit->codegen(co);
   CHECK(reduction_code.module);
-  reduction_code.module->setDataLayout(
-      "e-p:64:64:64-i1:8:8-i8:8:8-"
-      "i16:16:16-i32:32:32-i64:64:64-"
-      "f32:32:32-f64:64:64-v16:16:16-"
-      "v32:32:32-v64:64:64-v128:128:128-n16:32:64");
-  reduction_code.module->setTargetTriple("nvptx64-nvidia-cuda");
+  reduction_code.module->setDataLayout(cgen_traits.dataLayout());
+  reduction_code.module->setTargetTriple(cgen_traits.triple());
   llvm::Linker linker(*module_);
   std::unique_ptr<llvm::Module> owner(reduction_code.module);
   bool link_error = linker.linkInModule(std::move(owner));

--- a/omniscidb/QueryEngine/JoinHashTable/Runtime/HashJoinRuntime.cpp
+++ b/omniscidb/QueryEngine/JoinHashTable/Runtime/HashJoinRuntime.cpp
@@ -384,7 +384,7 @@ DEVICE void SUFFIX(init_baseline_hash_join_buff)(int8_t* hash_buff,
   const int32_t step = 1;
 #endif
   auto hash_entry_size = (key_component_count + (with_val_slot ? 1 : 0)) * sizeof(T);
-  const T empty_key = SUFFIX(get_invalid_key)<T>();
+  const T empty_key = SUFFIX(get_invalid_key)<typename remove_addr_space<T>::type>();
   for (int64_t h = start; h < end; h += step) {
     int64_t off = h * hash_entry_size;
     auto row_ptr = reinterpret_cast<T*>(hash_buff + off);

--- a/omniscidb/QueryEngine/JoinHashTable/Runtime/HashJoinRuntime.h
+++ b/omniscidb/QueryEngine/JoinHashTable/Runtime/HashJoinRuntime.h
@@ -35,6 +35,7 @@
 #else
 #include "../../RuntimeFunctions.h"
 #endif
+#include "../../../QueryEngine/Compiler/CommonRuntimeDefs.h"
 #include "../../../Shared/funcannotations.h"
 
 struct GenericKeyHandler;

--- a/omniscidb/QueryEngine/JoinHashTable/Runtime/JoinHashTableQueryRuntime.cpp
+++ b/omniscidb/QueryEngine/JoinHashTable/Runtime/JoinHashTableQueryRuntime.cpp
@@ -20,6 +20,7 @@
 
 #include "QueryEngine/CompareKeysInl.h"
 #include "QueryEngine/MurmurHash.h"
+#include "QueryEngine/Compiler/CommonRuntimeDefs.h"
 
 DEVICE bool compare_to_key(GENERIC_ADDR_SPACE const int8_t* entry,
                            GENERIC_ADDR_SPACE const int8_t* key,

--- a/omniscidb/QueryEngine/JoinHashTable/Runtime/JoinHashTableQueryRuntime.cpp
+++ b/omniscidb/QueryEngine/JoinHashTable/Runtime/JoinHashTableQueryRuntime.cpp
@@ -49,7 +49,7 @@ DEVICE int64_t get_matching_slot(GENERIC_ADDR_SPACE const int8_t* hash_buff,
     return *reinterpret_cast<GENERIC_ADDR_SPACE const T*>(lookup_result_ptr + key_bytes);
   }
   if (*reinterpret_cast<GENERIC_ADDR_SPACE const T*>(lookup_result_ptr) ==
-      SUFFIX(get_invalid_key) < T > ()) {
+      SUFFIX(get_invalid_key) < typename remove_addr_space<T>::type > ()) {
     return kNotPresent;
   }
   return kNoMatch;
@@ -142,7 +142,8 @@ FORCE_INLINE DEVICE int64_t get_composite_key_index_impl(const T* key,
     if (keys_are_equal(&composite_key_dict[off], key, key_component_count)) {
       return h_probe;
     }
-    if (composite_key_dict[off] == SUFFIX(get_invalid_key) < T > ()) {
+    if (composite_key_dict[off] ==
+        SUFFIX(get_invalid_key) < typename remove_addr_space<T>::type > ()) {
       return -1;
     }
     h_probe = (h_probe + 1) % entry_count;

--- a/omniscidb/QueryEngine/JoinHashTable/Runtime/JoinHashTableQueryRuntime.cpp
+++ b/omniscidb/QueryEngine/JoinHashTable/Runtime/JoinHashTableQueryRuntime.cpp
@@ -19,8 +19,8 @@
 #include <cstdlib>
 
 #include "QueryEngine/CompareKeysInl.h"
-#include "QueryEngine/MurmurHash.h"
 #include "QueryEngine/Compiler/CommonRuntimeDefs.h"
+#include "QueryEngine/MurmurHash.h"
 
 DEVICE bool compare_to_key(GENERIC_ADDR_SPACE const int8_t* entry,
                            GENERIC_ADDR_SPACE const int8_t* key,

--- a/omniscidb/QueryEngine/ResultSetReductionJIT.cpp
+++ b/omniscidb/QueryEngine/ResultSetReductionJIT.cpp
@@ -1333,8 +1333,11 @@ ReductionCode GpuReductionHelperJIT::codegen(const CompilationOptions& co) const
       executor_->getContext());
   auto cgen_state = reduction_code.cgen_state = cgen_state_.get();
   // CHECK(executor->thread_id_ == logger::thread_id());  // do we need compilation mutex?
+  bool is_l0 = co.device_type == ExecutorDeviceType::GPU && executor_->getDataMgr() &&
+               executor_->getDataMgr()->getGpuMgr() &&
+               executor_->getDataMgr()->getGpuMgr()->getPlatform() == GpuMgrPlatform::L0;
   cgen_state->set_module_shallow_copy(
-      executor_->getExtensionModuleContext()->getRTModule(/*is_l0=*/false));
+      executor_->getExtensionModuleContext()->getRTModule(is_l0));
   reduction_code.module = cgen_state->module_;
 
   AUTOMATIC_IR_METADATA(cgen_state);

--- a/omniscidb/QueryEngine/ResultSetReductionJIT.cpp
+++ b/omniscidb/QueryEngine/ResultSetReductionJIT.cpp
@@ -1333,9 +1333,8 @@ ReductionCode GpuReductionHelperJIT::codegen(const CompilationOptions& co) const
       executor_->getContext());
   auto cgen_state = reduction_code.cgen_state = cgen_state_.get();
   // CHECK(executor->thread_id_ == logger::thread_id());  // do we need compilation mutex?
-  bool is_l0 = co.device_type == ExecutorDeviceType::GPU && executor_->getDataMgr() &&
-               executor_->getDataMgr()->getGpuMgr() &&
-               executor_->getDataMgr()->getGpuMgr()->getPlatform() == GpuMgrPlatform::L0;
+  bool is_l0 = co.device_type == ExecutorDeviceType::GPU &&
+               co.codegen_traits_desc.triple_ == "spir64-unknown-unknown";
   cgen_state->set_module_shallow_copy(
       executor_->getExtensionModuleContext()->getRTModule(is_l0));
   reduction_code.module = cgen_state->module_;

--- a/omniscidb/QueryEngine/RuntimeFunctions.cpp
+++ b/omniscidb/QueryEngine/RuntimeFunctions.cpp
@@ -1131,7 +1131,7 @@ extern "C" RUNTIME_EXPORT NEVER_INLINE void write_back_nop(
 #endif
 }
 
-extern "C" RUNTIME_EXPORT int64_t* init_shared_mem(
+extern "C" RUNTIME_EXPORT GENERIC_ADDR_SPACE int64_t* init_shared_mem(
     GENERIC_ADDR_SPACE const int64_t* global_groups_buffer,
     const int32_t groups_buffer_size) {
   return nullptr;

--- a/omniscidb/QueryEngine/RuntimeFunctions.h
+++ b/omniscidb/QueryEngine/RuntimeFunctions.h
@@ -17,6 +17,7 @@
 #ifndef QUERYENGINE_RUNTIMEFUNCTIONS_H
 #define QUERYENGINE_RUNTIMEFUNCTIONS_H
 
+#include "Compiler/CommonRuntimeDefs.h"
 #include "Shared/EmptyKeyValues.h"
 #include "Shared/funcannotations.h"
 
@@ -24,18 +25,6 @@
 #include <ctime>
 #include <limits>
 #include <type_traits>
-
-template <class T>
-struct remove_addr_space {
-  typedef T type;
-};
-
-#ifdef L0_RUNTIME_ENABLED
-template <class T>
-struct remove_addr_space<GENERIC_ADDR_SPACE T> {
-  typedef T type;
-};
-#endif
 
 extern "C" RUNTIME_EXPORT int64_t agg_sum(GENERIC_ADDR_SPACE int64_t* agg,
                                           const int64_t val);

--- a/omniscidb/QueryEngine/TargetExprBuilder.cpp
+++ b/omniscidb/QueryEngine/TargetExprBuilder.cpp
@@ -437,8 +437,6 @@ void TargetExprCodegen::codegenAggregate(
         agg_args.push_back(null_lv);
       }
       if (!target_info.is_distinct) {
-        BOOST_PRAGMA_MESSAGE("Shared functions temporarily disabled for L0")
-#ifndef HAVE_L0
         if (co.device_type == ExecutorDeviceType::GPU &&
             query_mem_desc.threadsShareMemory()) {
           agg_fname += "_shared";
@@ -446,7 +444,6 @@ void TargetExprCodegen::codegenAggregate(
             agg_fname = patch_agg_fname(agg_fname);
           }
         }
-#endif
         auto agg_fname_call_ret_lv = row_func_builder->emitCall(agg_fname, agg_args);
 
         if (agg_fname.find("checked") != std::string::npos) {

--- a/omniscidb/Tests/L0MgrExecuteTest.cpp
+++ b/omniscidb/Tests/L0MgrExecuteTest.cpp
@@ -150,6 +150,7 @@ std::unique_ptr<llvm::Module> read_gen_module_from_bc(const std::string& bc_file
   auto owner = llvm::parseBitcodeFile(buffer->getMemBufferRef(), context);
   CHECK(!owner.takeError());
   CHECK(owner->get());
+  owner->get()->setTargetTriple("spir64-unknown-unknown");
   return std::move(owner.get());
 }
 


### PR DESCRIPTION
The PR adds proper code generation for Intel GPUs.

Notes:
* The shared buffer is allocated statically within the `genx.ll` module and its size is not checked for now.
* L0 backend now uses smem by default.
* There was an issue with cgen: `emitCall` would use the wrong runtime module. This is now fixed by patching the module triple upon extension module load.
* We currently produce some redundant address space casts between generic and shared-local. Those produce actual runtime checks and affect perf. I left the warnings in the log.