### PR TITLE
Support partitioned aggregation.

### DIFF
--- a/omniscidb/ConfigBuilder/ConfigBuilder.cpp
+++ b/omniscidb/ConfigBuilder/ConfigBuilder.cpp
@@ -183,6 +183,39 @@ bool ConfigBuilder::parseCommandLineArgs(int argc,
       po::value<size_t>(&config_->exec.group_by.large_ndv_multiplier)
           ->default_value(config_->exec.group_by.large_ndv_multiplier),
       "A multiplier applied to NDV estimator buffer size for large ranges.");
+  opt_desc.add_options()(
+      "enable-cpu-partitioned-groupby",
+      po::value<bool>(&config_->exec.group_by.enable_cpu_partitioned_groupby)
+          ->default_value(config_->exec.group_by.enable_cpu_partitioned_groupby)
+          ->implicit_value(true),
+      "Enable partitioned aggregation on CPU.");
+  opt_desc.add_options()(
+      "groupby-partitioning-buffer-size-threshold",
+      po::value<size_t>(&config_->exec.group_by.partitioning_buffer_size_threshold)
+          ->default_value(config_->exec.group_by.partitioning_buffer_size_threshold),
+      "Minimal estimated output buffer size to enable partitioned aggregation.");
+  opt_desc.add_options()(
+      "groupby-partitioning-group-size-threshold",
+      po::value<double>(&config_->exec.group_by.partitioning_group_size_threshold)
+          ->default_value(config_->exec.group_by.partitioning_group_size_threshold),
+      "Maximum average estimated number of rows per output group to enable partitioned "
+      "aggregation.");
+  opt_desc.add_options()("groupby-min-partitions",
+                         po::value<size_t>(&config_->exec.group_by.min_partitions)
+                             ->default_value(config_->exec.group_by.min_partitions),
+                         "A minimal number of partitions to be used for partitioned "
+                         "aggregation. 0 value is used for auto-detection.");
+  opt_desc.add_options()("groupby-max-partitions",
+                         po::value<size_t>(&config_->exec.group_by.max_partitions)
+                             ->default_value(config_->exec.group_by.max_partitions),
+                         "A maximum number of partitions to be used for partitioned "
+                         "aggregation.");
+  opt_desc.add_options()(
+      "groupby-partitioning-target-buffer-size",
+      po::value<size_t>(&config_->exec.group_by.partitioning_buffer_target_size)
+          ->default_value(config_->exec.group_by.partitioning_buffer_target_size),
+      "A preferred aggregation output buffer size used to compute number of partitions "
+      "to use.");
 
   // exec.window
   opt_desc.add_options()("enable-window-functions",
@@ -349,6 +382,12 @@ bool ConfigBuilder::parseCommandLineArgs(int argc,
           ->implicit_value(true),
       "Enable multi-fragment intermediate results to improve execution parallelism for "
       "queries with multiple execution steps");
+  opt_desc.add_options()(
+      "enable-multifrag-execution-result",
+      po::value<bool>(&config_->exec.enable_multifrag_execution_result)
+          ->default_value(config_->exec.enable_multifrag_execution_result)
+          ->implicit_value(true),
+      "Enable multi-fragment final execution result");
   opt_desc.add_options()("gpu-block-size",
                          po::value<size_t>(&config_->exec.override_gpu_block_size)
                              ->default_value(config_->exec.override_gpu_block_size),

--- a/omniscidb/IR/ExprCollector.h
+++ b/omniscidb/IR/ExprCollector.h
@@ -25,10 +25,21 @@ class ExprCollector : public ExprVisitor<void> {
     return collect(expr.get(), std::forward<Ts>(args)...);
   }
 
+  template <typename... Ts>
+  static ResultType collect(const ExprPtrVector& exprs, Ts&&... args) {
+    CollectorType collector(std::forward<Ts>(args)...);
+    for (auto& expr : exprs) {
+      collector.visit(expr.get());
+    }
+    return std::move(collector.result_);
+  }
+
   ResultType& result() { return result_; }
   const ResultType& result() const { return result_; }
 
  protected:
+  using BaseClass = ExprCollector<ResultType, CollectorType>;
+
   ResultType result_;
 };
 

--- a/omniscidb/IR/ExprVisitor.h
+++ b/omniscidb/IR/ExprVisitor.h
@@ -115,6 +115,7 @@ class ExprVisitor {
     if (auto agg = expr->as<AggExpr>()) {
       return visitAggExpr(agg);
     }
+    CHECK(false) << "Unhandled expr: " << expr->toString();
     return defaultResult(expr);
   }
 

--- a/omniscidb/QueryEngine/CardinalityEstimator.cpp
+++ b/omniscidb/QueryEngine/CardinalityEstimator.cpp
@@ -114,6 +114,9 @@ RelAlgExecutionUnit create_count_all_execution_unit(
           ra_exe_unit.hash_table_build_plan_dag,
           ra_exe_unit.table_id_to_node_map,
           ra_exe_unit.union_all,
+          ra_exe_unit.shuffle_fn,
+          ra_exe_unit.partition_offsets_col,
+          ra_exe_unit.partitioned_aggregation,
           ra_exe_unit.cost_model,
           {}};  // TODO(bagrorg): should we use costmodel here?
 }

--- a/omniscidb/QueryEngine/CardinalityEstimator.h
+++ b/omniscidb/QueryEngine/CardinalityEstimator.h
@@ -43,6 +43,22 @@ class CardinalityEstimationRequired : public std::runtime_error {
   const int64_t range_;
 };
 
+class RequestPartitionedAggregation : public std::runtime_error {
+ public:
+  RequestPartitionedAggregation(size_t entry_size, size_t estimated_buffer_entries)
+      : std::runtime_error("RequestPartitionedAggregation")
+      , entry_size_(entry_size)
+      , estimated_buffer_entries_(estimated_buffer_entries) {}
+
+  size_t entrySize() const { return entry_size_; }
+  size_t estimatedBufferEntries() const { return estimated_buffer_entries_; }
+  size_t estimatedBufferSize() const { return entry_size_ * estimated_buffer_entries_; }
+
+ private:
+  size_t entry_size_;
+  size_t estimated_buffer_entries_;
+};
+
 RelAlgExecutionUnit create_ndv_execution_unit(const RelAlgExecutionUnit& ra_exe_unit,
                                               SchemaProvider* schema_provider,
                                               const Config& config,

--- a/omniscidb/QueryEngine/CgenState.cpp
+++ b/omniscidb/QueryEngine/CgenState.cpp
@@ -209,7 +209,8 @@ bool is_l0_module(const llvm::Module* m) {
   return m->getTargetTriple().rfind("spir", 0) == 0;
 }
 
-llvm::Value* CgenState::emitCall(const std::string& fname,
+llvm::Value* CgenState::emitCall(llvm::IRBuilder<>& ir_builder,
+                                 const std::string& fname,
                                  const std::vector<llvm::Value*>& args) {
   // Get the function reference from the query module.
   auto func = module_->getFunction(fname);
@@ -218,7 +219,12 @@ llvm::Value* CgenState::emitCall(const std::string& fname,
   // module.
   maybeCloneFunctionRecursive(func, is_l0_module(module_));
 
-  return ir_builder_.CreateCall(func, args);
+  return ir_builder.CreateCall(func, args);
+}
+
+llvm::Value* CgenState::emitCall(const std::string& fname,
+                                 const std::vector<llvm::Value*>& args) {
+  return emitCall(ir_builder_, fname, args);
 }
 
 void CgenState::emitErrorCheck(llvm::Value* condition,

--- a/omniscidb/QueryEngine/CgenState.h
+++ b/omniscidb/QueryEngine/CgenState.h
@@ -283,6 +283,9 @@ struct CgenState {
     return result;
   }
 
+  llvm::Value* emitCall(llvm::IRBuilder<>& ir_builder,
+                        const std::string& fname,
+                        const std::vector<llvm::Value*>& args);
   llvm::Value* emitCall(const std::string& fname, const std::vector<llvm::Value*>& args);
 
   size_t getLiteralBufferUsage(const int device_id) {

--- a/omniscidb/QueryEngine/CompilationOptions.h
+++ b/omniscidb/QueryEngine/CompilationOptions.h
@@ -156,6 +156,12 @@ struct ExecutionOptions {
     return eo;
   }
 
+  ExecutionOptions with_columnar_output(bool enable = true) const {
+    ExecutionOptions eo = *this;
+    eo.output_columnar_hint = enable;
+    return eo;
+  }
+
  private:
   ExecutionOptions() {}
 };

--- a/omniscidb/QueryEngine/Execute.cpp
+++ b/omniscidb/QueryEngine/Execute.cpp
@@ -70,6 +70,7 @@
 #include "QueryEngine/SpeculativeTopN.h"
 #include "QueryEngine/StringDictionaryGenerations.h"
 #include "QueryEngine/Visitors/TransientStringLiteralsVisitor.h"
+#include "ResultSet/ColRangeInfo.h"
 #include "Shared/checked_alloc.h"
 #include "Shared/funcannotations.h"
 #include "Shared/measure.h"
@@ -1366,6 +1367,76 @@ ResultSetPtr Executor::reduceSpeculativeTopN(
   return m.asRows(ra_exe_unit, row_set_mem_owner, query_mem_desc, this, top_n, desc);
 }
 
+hdk::ResultSetTable Executor::reducePartitionHistogram(
+    std::vector<std::pair<ResultSetPtr, std::vector<size_t>>>& results_per_device,
+    const QueryMemoryDescriptor& query_mem_desc,
+    std::shared_ptr<RowSetMemoryOwner> row_set_mem_owner) const {
+  std::vector<ResultSetPtr> results;
+  std::vector<int64_t*> buffers;
+
+  results.reserve(results_per_device.size() + 1);
+  buffers.reserve(results_per_device.size() + 1);
+
+  // In the reduction result we want each fragment result to hold an offset in
+  // output buffer instead of number of rows. Also, we want to make an additional
+  // result set holding final partition sizes. Achieve it by using a new zero-filled
+  // buffer for the the first fragment and partial sums for all other having
+  // partition sizes in the last of them.
+  // Additionally, we want them to be columnar Projection instead of PerfectHash
+  // to later zero-copy fetch all rows.
+  using IndexedResultSet = std::pair<ResultSetPtr, std::vector<size_t>>;
+  std::sort(results_per_device.begin(),
+            results_per_device.end(),
+            [](const IndexedResultSet& lhs, const IndexedResultSet& rhs) {
+              CHECK_GE(lhs.second.size(), size_t(1));
+              CHECK_GE(rhs.second.size(), size_t(1));
+              return lhs.second.front() < rhs.second.front();
+            });
+
+  auto parts = query_mem_desc.getEntryCount();
+  auto proj_mem_desc = query_mem_desc;
+  proj_mem_desc.setQueryDescriptionType(QueryDescriptionType::Projection);
+  proj_mem_desc.setHasKeylessHash(false);
+  proj_mem_desc.clearGroupColWidths();
+  // Currently, all perfect hash tables are expected to to use 8 byte padded width.
+  CHECK_EQ(static_cast<int>(proj_mem_desc.getPaddedSlotWidthBytes(0)), 8);
+  auto first_rs =
+      std::make_shared<ResultSet>(results_per_device.front().first->getTargetInfos(),
+                                  ExecutorDeviceType::CPU,
+                                  proj_mem_desc,
+                                  row_set_mem_owner,
+                                  data_mgr_,
+                                  blockSize(),
+                                  gridSize());
+  first_rs->allocateStorage(plan_state_->init_agg_vals_);
+  results.push_back(first_rs);
+  buffers.push_back(
+      reinterpret_cast<int64_t*>(first_rs->getStorage()->getUnderlyingBuffer()));
+  for (auto& pr : results_per_device) {
+    auto buf = pr.first->getStorage()->getUnderlyingBuffer();
+    auto proj_rs =
+        std::make_shared<ResultSet>(results_per_device.front().first->getTargetInfos(),
+                                    ExecutorDeviceType::CPU,
+                                    proj_mem_desc,
+                                    row_set_mem_owner,
+                                    data_mgr_,
+                                    blockSize(),
+                                    gridSize());
+    proj_rs->allocateStorage(buf, {});
+    results.push_back(proj_rs);
+    buffers.push_back(reinterpret_cast<int64_t*>(buf));
+  }
+
+  memset(buffers[0], 0, sizeof(int64_t) * parts);
+  for (size_t i = 2; i < buffers.size(); ++i) {
+    for (size_t j = 0; j < parts; ++j) {
+      buffers[i][j] += buffers[i - 1][j];
+    }
+  }
+
+  return hdk::ResultSetTable(std::move(results));
+}
+
 namespace {
 
 std::unordered_set<int> get_available_gpus(const Data_Namespace::DataMgr* data_mgr) {
@@ -1628,6 +1699,15 @@ std::ostream& operator<<(std::ostream& os, const RelAlgExecutionUnit& ra_exe_uni
   if (ra_exe_unit.union_all) {
     os << "\n\tUnion: " << std::string(*ra_exe_unit.union_all ? "UNION ALL" : "UNION");
   }
+  if (ra_exe_unit.shuffle_fn) {
+    os << "\n\tShuffle: " << *ra_exe_unit.shuffle_fn;
+  }
+  if (ra_exe_unit.partition_offsets_col) {
+    os << "\n\tPartition offsets column: "
+       << ra_exe_unit.partition_offsets_col->toString();
+  }
+  os << "\n\tPartitioned aggregation: " << ra_exe_unit.partitioned_aggregation;
+
   return os;
 }
 
@@ -1649,6 +1729,9 @@ RelAlgExecutionUnit replace_scan_limit(const RelAlgExecutionUnit& ra_exe_unit_in
           ra_exe_unit_in.hash_table_build_plan_dag,
           ra_exe_unit_in.table_id_to_node_map,
           ra_exe_unit_in.union_all,
+          ra_exe_unit_in.shuffle_fn,
+          ra_exe_unit_in.partition_offsets_col,
+          ra_exe_unit_in.partitioned_aggregation,
           ra_exe_unit_in.cost_model,
           ra_exe_unit_in.templs};
 }
@@ -1695,6 +1778,7 @@ hdk::ResultSetTable Executor::executeWorkUnit(
     }
     return result;
   } catch (const CompilationRetryNewScanLimit& e) {
+    CHECK(!ra_exe_unit_in.shuffle_fn);
     auto result =
         executeWorkUnitImpl(max_groups_buffer_entry_guess,
                             is_agg,
@@ -1823,7 +1907,8 @@ hdk::ResultSetTable Executor::finishStreamExecution(
                                      *ctx->query_mem_desc,
                                      ctx->query_comp_desc->getDeviceType(),
                                      row_set_mem_owner_,
-                                     ctx->co);
+                                     ctx->co,
+                                     ctx->eo);
     } catch (ReductionRanOutOfSlots&) {
       throw QueryExecutionError(ERR_OUT_OF_SLOTS);
     } catch (QueryExecutionError& e) {
@@ -1925,6 +2010,93 @@ Executor::getExecutionPolicyForTargets(const RelAlgExecutionUnit& ra_exe_unit,
   return {std::move(exe_policy), requested_device_type};
 }
 
+// TODO: move this code to QueryMemoryInitializer
+void Executor::allocateShuffleBuffers(
+    const std::vector<InputTableInfo>& query_infos,
+    const RelAlgExecutionUnit& ra_exe_unit,
+    std::shared_ptr<RowSetMemoryOwner> row_set_mem_owner,
+    SharedKernelContext& shared_context) {
+  CHECK(ra_exe_unit.isShuffle());
+  auto partitions = ra_exe_unit.shuffle_fn->partitions;
+  std::vector<TargetInfo> target_infos;
+  for (auto& expr : ra_exe_unit.target_exprs) {
+    CHECK(expr->is<hdk::ir::ColumnVar>()) << "Unsupported expr: " << expr->toString();
+    target_infos.push_back(get_target_info(expr, getConfig().exec.group_by.bigint_count));
+  }
+
+  ColSlotContext slot_context(ra_exe_unit.target_exprs, {}, false);
+  QueryMemoryDescriptor query_mem_desc(
+      getDataMgr(),
+      getConfigPtr(),
+      query_infos,
+      false /*approx_quantile*/,
+      false /*allow_multifrag*/,
+      false /*keyless_hash*/,
+      false /*interleaved_bins_on_gpu*/,
+      -1 /*idx_target_as_key*/,
+      ColRangeInfo{QueryDescriptionType::Projection, 0, 0, 0, true},
+      slot_context,
+      {} /*group_col_widths*/,
+      8 /*group_col_compact_width*/,
+      {} /*target_groupby_indices*/,
+      0 /*entry_count*/,
+      {} /*count_distinct_descriptors*/,
+      false /*sort_on_gpu_hint*/,
+      true /*output_columnar*/,
+      false /*must_use_baseline_sort*/,
+      false /*use_streaming_top_n*/);
+
+  // Get buffer holding partition sizes. It is stored in the last fragment
+  // of the second input table.
+  CHECK_EQ(ra_exe_unit.input_descs.size(), (size_t)2);
+  auto count_table_info =
+      schema_provider_->getTableInfo(ra_exe_unit.input_descs.back().getTableRef());
+  CHECK_EQ(count_table_info->row_count, partitions * count_table_info->fragments);
+  auto count_cols = schema_provider_->listColumns(*count_table_info);
+  CHECK_EQ(count_cols.size(), (size_t)2);
+  auto count_col_info = count_cols.front();
+  auto unpin = [](Data_Namespace::AbstractBuffer* buf) { buf->unPin(); };
+  std::unique_ptr<Data_Namespace::AbstractBuffer, decltype(unpin)> sizes_buf(
+      data_mgr_->getChunkBuffer({count_col_info->db_id,
+                                 count_col_info->table_id,
+                                 count_col_info->column_id,
+                                 static_cast<int>(count_table_info->fragments)},
+                                Data_Namespace::MemoryLevel::CPU_LEVEL,
+                                0,
+                                partitions * sizeof(uint64_t)),
+      unpin);
+  CHECK_EQ(sizes_buf->size(), partitions * sizeof(uint64_t));
+  const uint64_t* sizes_ptr =
+      reinterpret_cast<const uint64_t*>(sizes_buf->getMemoryPtr());
+
+  // Create result set for each output partition.
+  shuffle_out_bufs_.clear();
+  shuffle_out_buf_ptrs_.clear();
+  shuffle_out_bufs_.reserve(partitions);
+  shuffle_out_buf_ptrs_.reserve(partitions);
+  for (size_t i = 0; i < partitions; ++i) {
+    query_mem_desc.setEntryCount(sizes_ptr[i]);
+    auto rs = std::make_shared<ResultSet>(target_infos,
+                                          ExecutorDeviceType::CPU,
+                                          query_mem_desc,
+                                          row_set_mem_owner,
+                                          getDataMgr(),
+                                          blockSize(),
+                                          gridSize());
+    rs->allocateStorage({});
+
+    shuffle_out_bufs_.emplace_back();
+    for (size_t target_idx = 0; target_idx < ra_exe_unit.target_exprs.size();
+         ++target_idx) {
+      shuffle_out_bufs_.back().push_back(
+          const_cast<int8_t*>(rs->getColumnarBuffer(target_idx)));
+    }
+    shuffle_out_buf_ptrs_.push_back(shuffle_out_bufs_.back().data());
+
+    shared_context.addDeviceResults(std::move(rs), 0, {i + 1});
+  }
+}
+
 hdk::ResultSetTable Executor::executeWorkUnitImpl(
     size_t& max_groups_buffer_entry_guess,
     const bool is_agg,
@@ -1949,6 +2121,11 @@ hdk::ResultSetTable Executor::executeWorkUnitImpl(
       column_fetcher.freeLinearizedBuf();
       column_fetcher.freeTemporaryCpuLinearizedIdxBuf();
     };
+
+    if (ra_exe_unit.isShuffle()) {
+      allocateShuffleBuffers(query_infos, ra_exe_unit, row_set_mem_owner, shared_context);
+    }
+
     std::map<ExecutorDeviceType, std::unique_ptr<QueryCompilationDescriptor>>
         query_comp_descs_owned;
     std::map<ExecutorDeviceType, std::unique_ptr<QueryMemoryDescriptor>>
@@ -2066,7 +2243,8 @@ hdk::ResultSetTable Executor::executeWorkUnitImpl(
                                        *query_mem_descs_owned[reduction_device_type],
                                        reduction_device_type,
                                        row_set_mem_owner,
-                                       co);
+                                       co,
+                                       eo);
       } catch (ReductionRanOutOfSlots&) {
         throw QueryExecutionError(ERR_OUT_OF_SLOTS);
       } catch (OverflowOrUnderflow&) {
@@ -2361,19 +2539,30 @@ ResultSetPtr build_row_for_empty_input(
 
 }  // namespace
 
-ResultSetPtr Executor::collectAllDeviceResults(
+hdk::ResultSetTable Executor::collectAllDeviceResults(
     SharedKernelContext& shared_context,
     const RelAlgExecutionUnit& ra_exe_unit,
     const QueryMemoryDescriptor& query_mem_desc,
     const ExecutorDeviceType device_type,
     std::shared_ptr<RowSetMemoryOwner> row_set_mem_owner,
-    const CompilationOptions& co) {
+    const CompilationOptions& co,
+    const ExecutionOptions& eo) {
   auto timer = DEBUG_TIMER(__func__);
   auto& result_per_device = shared_context.getFragmentResults();
   if (result_per_device.empty() && query_mem_desc.getQueryDescriptionType() ==
                                        QueryDescriptionType::NonGroupedAggregate) {
     return build_row_for_empty_input(
         this, ra_exe_unit.target_exprs, query_mem_desc, device_type);
+  }
+  if (ra_exe_unit.shuffle_fn) {
+    // Reduction of shuffle COUNT(*) results.
+    CHECK(ra_exe_unit.isShuffleCount()) << "unexpected shuffle results";
+    return reducePartitionHistogram(result_per_device, query_mem_desc, row_set_mem_owner);
+  }
+  // Partitioned aggregation results don't need to be merged unless it is required
+  // by execution options.
+  if (ra_exe_unit.partitioned_aggregation && eo.multifrag_result) {
+    return get_separate_results(result_per_device);
   }
   if (use_speculative_top_n(ra_exe_unit, query_mem_desc)) {
     try {
@@ -2461,6 +2650,7 @@ std::vector<std::unique_ptr<ExecutionKernel>> Executor::createKernels(
   // execution with no reduction required.
   if (device_type == ExecutorDeviceType::CPU && table_infos.size() == (size_t)1 &&
       config_->exec.group_by.enable_cpu_multifrag_kernels &&
+      !ra_exe_unit.partitioned_aggregation &&
       (query_mem_desc.getQueryDescriptionType() ==
            QueryDescriptionType::GroupByPerfectHash ||
        query_mem_desc.getQueryDescriptionType() ==
@@ -2742,7 +2932,7 @@ std::vector<size_t> Executor::getTableFragmentIndices(
   const auto outer_table_fragments = outer_table_fragments_it->second;
   CHECK(outer_table_fragments_it != selected_tables_fragments.end());
   CHECK_LT(outer_frag_idx, outer_table_fragments->size());
-  if (!table_idx) {
+  if (!table_idx || ra_exe_unit.isShuffle()) {
     return {outer_frag_idx};
   }
   const auto& outer_fragment_info = (*outer_table_fragments)[outer_frag_idx];

--- a/omniscidb/QueryEngine/Execute.h
+++ b/omniscidb/QueryEngine/Execute.h
@@ -474,13 +474,14 @@ class Executor : public StringDictionaryProxyProvider {
                                const std::vector<InputTableInfo>& query_infos,
                                size_t& max_groups_buffer_entry_guess);
 
-  ResultSetPtr collectAllDeviceResults(
+  hdk::ResultSetTable collectAllDeviceResults(
       SharedKernelContext& shared_context,
       const RelAlgExecutionUnit& ra_exe_unit,
       const QueryMemoryDescriptor& query_mem_desc,
       const ExecutorDeviceType device_type,
       std::shared_ptr<RowSetMemoryOwner> row_set_mem_owner,
-      const CompilationOptions& co);
+      const CompilationOptions& co,
+      const ExecutionOptions& eo);
 
   std::unordered_map<int, const hdk::ir::BinOper*> getInnerTabIdToJoinCond() const;
 
@@ -655,7 +656,15 @@ class Executor : public StringDictionaryProxyProvider {
       std::vector<std::pair<ResultSetPtr, std::vector<size_t>>>& all_fragment_results,
       std::shared_ptr<RowSetMemoryOwner>,
       const QueryMemoryDescriptor&) const;
+  hdk::ResultSetTable reducePartitionHistogram(
+      std::vector<std::pair<ResultSetPtr, std::vector<size_t>>>& results_per_device,
+      const QueryMemoryDescriptor& query_mem_desc,
+      std::shared_ptr<RowSetMemoryOwner> row_set_mem_owner) const;
 
+  void allocateShuffleBuffers(const std::vector<InputTableInfo>& query_infos,
+                              const RelAlgExecutionUnit& ra_exe_unit,
+                              std::shared_ptr<RowSetMemoryOwner> row_set_mem_owner,
+                              SharedKernelContext& shared_context);
   hdk::ResultSetTable executeWorkUnitImpl(size_t& max_groups_buffer_entry_guess,
                                           const bool is_agg,
                                           const bool allow_single_frag_table_opt,
@@ -980,6 +989,9 @@ class Executor : public StringDictionaryProxyProvider {
   Data_Namespace::DataMgr* data_mgr_;
   const TemporaryTables* temporary_tables_;
   TableIdToNodeMap table_id_to_node_map_;
+
+  std::vector<std::vector<int8_t*>> shuffle_out_bufs_;
+  std::vector<int8_t**> shuffle_out_buf_ptrs_;
 
   int64_t kernel_queue_time_ms_ = 0;
   int64_t compilation_queue_time_ms_ = 0;

--- a/omniscidb/QueryEngine/ExecutionKernel.cpp
+++ b/omniscidb/QueryEngine/ExecutionKernel.cpp
@@ -104,7 +104,7 @@ const std::vector<uint64_t>& SharedKernelContext::getFragOffsets() {
   return all_frag_row_offsets_;
 }
 
-void SharedKernelContext::addDeviceResults(ResultSetPtr&& device_results,
+void SharedKernelContext::addDeviceResults(ResultSetPtr device_results,
                                            int outer_table_id,
                                            std::vector<size_t> outer_table_fragment_ids) {
   std::lock_guard<std::mutex> lock(reduce_mutex_);
@@ -409,7 +409,7 @@ void ExecutionKernel::runImpl(Executor* executor,
     err = executor->executePlan(ra_exe_unit_,
                                 compilation_result,
                                 query_comp_desc.hoistLiterals(),
-                                &device_results_,
+                                ra_exe_unit_.isShuffle() ? nullptr : &device_results_,
                                 chosen_device_type,
                                 co,
                                 fetch_result->col_buffers,

--- a/omniscidb/QueryEngine/ExecutionKernel.h
+++ b/omniscidb/QueryEngine/ExecutionKernel.h
@@ -32,7 +32,7 @@ class SharedKernelContext {
 
   const std::vector<uint64_t>& getFragOffsets();
 
-  void addDeviceResults(ResultSetPtr&& device_results,
+  void addDeviceResults(ResultSetPtr device_results,
                         int outer_table_id,
                         std::vector<size_t> outer_table_fragment_ids);
 

--- a/omniscidb/QueryEngine/ExprDagVisitor.h
+++ b/omniscidb/QueryEngine/ExprDagVisitor.h
@@ -33,6 +33,8 @@ class ExprDagVisitor : public ScalarExprVisitor<void*> {
     } else if (auto translated_join =
                    dynamic_cast<const hdk::ir::TranslatedJoin*>(node)) {
       visitTranslatedJoin(translated_join);
+    } else if (auto shuffle = dynamic_cast<const hdk::ir::Shuffle*>(node)) {
+      visitShuffle(shuffle);
     } else {
       LOG(FATAL) << "Unsupported node type: " << node->toString();
     }
@@ -81,6 +83,15 @@ class ExprDagVisitor : public ScalarExprVisitor<void*> {
     }
     if (auto* outer_join_condition = translated_join->getOuterJoinCond()) {
       visit(outer_join_condition);
+    }
+  }
+
+  virtual void visitShuffle(const hdk::ir::Shuffle* shuffle) {
+    for (auto& expr : shuffle->keys()) {
+      visit(expr.get());
+    }
+    for (auto& expr : shuffle->exprs()) {
+      visit(expr.get());
     }
   }
 

--- a/omniscidb/QueryEngine/QueryPhysicalInputsCollector.cpp
+++ b/omniscidb/QueryEngine/QueryPhysicalInputsCollector.cpp
@@ -75,6 +75,16 @@ class PhysicalInputsNodeVisitor : public RelAlgVisitor<ResultType> {
     return result;
   }
 
+  ResultType visitShuffle(const hdk::ir::Shuffle* shuffle) const override {
+    ResultType result;
+    ExprVisitor visitor;
+    for (auto& expr : shuffle->exprs()) {
+      const auto inputs = visitor.visit(expr.get());
+      result.insert(inputs.begin(), inputs.end());
+    }
+    return result;
+  }
+
  protected:
   ResultType aggregateResult(const ResultType& aggregate,
                              const ResultType& next_result) const override {

--- a/omniscidb/QueryEngine/QueryRewrite.cpp
+++ b/omniscidb/QueryEngine/QueryRewrite.cpp
@@ -273,6 +273,9 @@ RelAlgExecutionUnit QueryRewriter::rewriteAggregateOnGroupByColumn(
                                          ra_exe_unit_in.query_plan_dag,
                                          ra_exe_unit_in.hash_table_build_plan_dag,
                                          ra_exe_unit_in.table_id_to_node_map,
-                                         ra_exe_unit_in.union_all};
+                                         ra_exe_unit_in.union_all,
+                                         ra_exe_unit_in.shuffle_fn,
+                                         ra_exe_unit_in.partition_offsets_col,
+                                         ra_exe_unit_in.partitioned_aggregation};
   return rewritten_exe_unit;
 }

--- a/omniscidb/QueryEngine/RelAlgExecutionUnit.h
+++ b/omniscidb/QueryEngine/RelAlgExecutionUnit.h
@@ -143,9 +143,21 @@ struct RelAlgExecutionUnit {
   TableIdToNodeMap table_id_to_node_map{};
   // empty if not a UNION, true if UNION ALL, false if regular UNION
   const std::optional<bool> union_all;
+  // If non-empty, then this unit is a shuffling unit with the specified
+  // function. groupby_exprs hold keys, target_exprs hold all output
+  // expressions.
+  std::optional<hdk::ir::ShuffleFunction> shuffle_fn;
+  // When shuffling data, this references the column holding computed
+  // partition offsets.
+  hdk::ir::ExprPtr partition_offsets_col;
+  // Set to true when aggregating partitioned input.
+  bool partitioned_aggregation;
 
   std::shared_ptr<costmodel::CostModel> cost_model;
   std::vector<costmodel::AnalyticalTemplate> templs;
+
+  bool isShuffleCount() const { return shuffle_fn && !partition_offsets_col; }
+  bool isShuffle() const { return shuffle_fn && partition_offsets_col; }
 };
 
 std::ostream& operator<<(std::ostream& os, const RelAlgExecutionUnit& ra_exe_unit);

--- a/omniscidb/QueryEngine/RelAlgExecutor.h
+++ b/omniscidb/QueryEngine/RelAlgExecutor.h
@@ -126,6 +126,11 @@ class RelAlgExecutor {
                    const CompilationOptions& co,
                    const ExecutionOptions& eo,
                    const int64_t queue_time_ms);
+  void executeStepWithPartitionedAggregation(const hdk::ir::Node* step_root,
+                                             const CompilationOptions& co,
+                                             const ExecutionOptions& eo,
+                                             size_t estimated_buffer_size,
+                                             const int64_t queue_time_ms);
   ExecutionResult executeStep(const hdk::ir::Node* step_root,
                               const CompilationOptions& co,
                               const ExecutionOptions& eo,

--- a/omniscidb/QueryEngine/RelAlgVisitor.h
+++ b/omniscidb/QueryEngine/RelAlgVisitor.h
@@ -59,6 +59,10 @@ class RelAlgVisitor {
     if (logical_union) {
       return aggregateResult(result, visitLogicalUnion(logical_union));
     }
+    const auto shuffle = dynamic_cast<const hdk::ir::Shuffle*>(rel_alg);
+    if (shuffle) {
+      return aggregateResult(result, visitShuffle(shuffle));
+    }
     LOG(FATAL) << "Unhandled rel_alg type: " << rel_alg->toString();
     return {};
   }
@@ -82,6 +86,8 @@ class RelAlgVisitor {
   virtual T visitLogicalUnion(const hdk::ir::LogicalUnion*) const {
     return defaultResult();
   }
+
+  virtual T visitShuffle(const hdk::ir::Shuffle*) const { return defaultResult(); }
 
  protected:
   virtual T aggregateResult(const T& aggregate, const T& next_result) const {

--- a/omniscidb/QueryEngine/RowFuncBuilder.h
+++ b/omniscidb/QueryEngine/RowFuncBuilder.h
@@ -60,6 +60,10 @@ class RowFuncBuilder {
       const QueryMemoryDescriptor& query_mem_desc,
       const CompilationOptions& co,
       DiamondCodegen& codegen);
+  std::tuple<llvm::Value*, llvm::Value*> codegenPartitionKey(
+      const QueryMemoryDescriptor& query_mem_desc,
+      const CompilationOptions& co,
+      DiamondCodegen& codegen);
 
   llvm::Value* codegenVarlenOutputBuffer(const QueryMemoryDescriptor& query_mem_desc,
                                          const CompilationOptions& co);
@@ -101,6 +105,11 @@ class RowFuncBuilder {
                        const CompilationOptions& co,
                        const GpuSharedMemoryContext& gpu_smem_context,
                        DiamondCodegen& diamond_codegen);
+  bool codegenShuffle(const std::tuple<llvm::Value*, llvm::Value*>& agg_out_ptr_w_idx,
+                      QueryMemoryDescriptor& query_mem_desc,
+                      const CompilationOptions& co,
+                      const GpuSharedMemoryContext& gpu_smem_context,
+                      DiamondCodegen& diamond_codegen);
 
   llvm::Value* codegenWindowRowPointer(const hdk::ir::WindowFunction* window_func,
                                        const QueryMemoryDescriptor& query_mem_desc,
@@ -138,6 +147,9 @@ class RowFuncBuilder {
   std::vector<llvm::Value*> codegenAggArg(const hdk::ir::Expr* target_expr,
                                           const CompilationOptions& co);
 
+  llvm::Value* emitCall(llvm::IRBuilder<>& ir_builder,
+                        const std::string& fname,
+                        const std::vector<llvm::Value*>& args);
   llvm::Value* emitCall(const std::string& fname, const std::vector<llvm::Value*>& args);
 
   void checkErrorCode(llvm::Value* retCode);

--- a/omniscidb/QueryEngine/TargetExprBuilder.cpp
+++ b/omniscidb/QueryEngine/TargetExprBuilder.cpp
@@ -628,6 +628,37 @@ void TargetExprCodegenBuilder::codegen(
   }
 }
 
+void TargetExprCodegenBuilder::codegenSingleTarget(
+    RowFuncBuilder* row_func_builder,
+    Executor* executor,
+    const QueryMemoryDescriptor& query_mem_desc,
+    const CompilationOptions& co,
+    const GpuSharedMemoryContext& gpu_smem_context,
+    const std::tuple<llvm::Value*, llvm::Value*>& agg_out_ptr_w_idx,
+    const std::vector<llvm::Value*>& agg_out_vec,
+    llvm::Value* output_buffer_byte_stream,
+    llvm::Value* out_row_idx,
+    llvm::Value* varlen_output_buffer,
+    DiamondCodegen& diamond_codegen,
+    size_t target_idx) const {
+  CHECK(row_func_builder);
+  CHECK(executor);
+  AUTOMATIC_IR_METADATA(executor->cgen_state_.get());
+
+  CHECK_LT(target_idx, target_exprs_to_codegen.size());
+  target_exprs_to_codegen[target_idx].codegen(row_func_builder,
+                                              executor,
+                                              query_mem_desc,
+                                              co,
+                                              gpu_smem_context,
+                                              agg_out_ptr_w_idx,
+                                              agg_out_vec,
+                                              output_buffer_byte_stream,
+                                              out_row_idx,
+                                              varlen_output_buffer,
+                                              diamond_codegen);
+}
+
 void TargetExprCodegenBuilder::codegenSampleExpressions(
     RowFuncBuilder* row_func_builder,
     Executor* executor,

--- a/omniscidb/QueryEngine/TargetExprBuilder.h
+++ b/omniscidb/QueryEngine/TargetExprBuilder.h
@@ -96,6 +96,20 @@ struct TargetExprCodegenBuilder {
                llvm::Value* varlen_output_buffer,
                DiamondCodegen& diamond_codegen) const;
 
+  void codegenSingleTarget(
+      RowFuncBuilder* row_func_builder,
+      Executor* executor,
+      const QueryMemoryDescriptor& query_mem_desc,
+      const CompilationOptions& co,
+      const GpuSharedMemoryContext& gpu_smem_context,
+      const std::tuple<llvm::Value*, llvm::Value*>& agg_out_ptr_w_idx,
+      const std::vector<llvm::Value*>& agg_out_vec,
+      llvm::Value* output_buffer_byte_stream,
+      llvm::Value* out_row_idx,
+      llvm::Value* varlen_output_buffer,
+      DiamondCodegen& diamond_codegen,
+      size_t target_idx) const;
+
   void codegenSampleExpressions(
       RowFuncBuilder* row_func_builder,
       Executor* executor,

--- a/omniscidb/QueryEngine/Visitors/TemplateAggregationVisitor.h
+++ b/omniscidb/QueryEngine/Visitors/TemplateAggregationVisitor.h
@@ -45,6 +45,10 @@ class TemplateAggregationVisitor : public RelAlgVisitor<TemplateSample> {
     return rejectNode();
   }
 
+  virtual TemplateSample visitShuffle(const hdk::ir::Shuffle*) const {
+    return rejectNode();
+  }
+
   std::vector<costmodel::AnalyticalTemplate> getTemplates() {
     std::vector<costmodel::AnalyticalTemplate> ret(collected_templates_);
     collected_templates_.clear();

--- a/omniscidb/QueryEngine/WorkUnitBuilder.h
+++ b/omniscidb/QueryEngine/WorkUnitBuilder.h
@@ -63,9 +63,11 @@ class WorkUnitBuilder {
   void processSort(const ir::Sort* sort);
   void processUnion(const ir::LogicalUnion* logical_union);
   void processJoin(const ir::Join* join);
+  void processShuffle(const ir::Shuffle* shuffle);
   std::list<hdk::ir::ExprPtr> makeJoinQuals(const hdk::ir::Expr* join_condition);
   void reorderTables();
   void computeSimpleQuals();
+  void assignUnionOrder(const ir::Node* node, int order);
   int assignNestLevels(const ir::Node* node, int start_idx = 0);
   void computeJoinTypes(const ir::Node* node, bool allow_join = true);
   void computeInputDescs();
@@ -133,6 +135,9 @@ class WorkUnitBuilder {
   HashTableBuildDagMap hash_table_build_plan_dag_;
   TableIdToNodeMap table_id_to_node_map_;
   std::optional<bool> union_all_;
+  std::optional<ir::ShuffleFunction> shuffle_fn_;
+  hdk::ir::ExprPtr partition_offsets_col_;
+  bool partitioned_aggregation_ = false;
 
   std::optional<unsigned> left_deep_tree_id_;
   size_t max_groups_buffer_entry_guess_;

--- a/omniscidb/Shared/Config.h
+++ b/omniscidb/Shared/Config.h
@@ -51,6 +51,12 @@ struct GroupByConfig {
   size_t baseline_threshold = 1'000'000;
   int64_t large_ndv_threshold = 10'000'000;
   size_t large_ndv_multiplier = 256;
+  bool enable_cpu_partitioned_groupby = true;
+  size_t partitioning_buffer_size_threshold = 1 << 30;
+  double partitioning_group_size_threshold = 2.0;
+  size_t min_partitions = 0;
+  size_t max_partitions = 1024;
+  size_t partitioning_buffer_target_size = 32 << 20;
 };
 
 struct WindowFunctionsConfig {
@@ -101,6 +107,7 @@ struct ExecutionConfig {
   bool enable_interop = false;
   size_t parallel_linearization_threshold = 10'000;
   bool enable_multifrag_rs = true;
+  bool enable_multifrag_execution_result = false;
 
   size_t override_gpu_block_size = 0;
   size_t override_gpu_grid_size = 0;

--- a/omniscidb/Shared/MathUtils.cpp
+++ b/omniscidb/Shared/MathUtils.cpp
@@ -14,20 +14,4 @@
  * limitations under the License.
  */
 
-namespace shared {
-
-bool isPowOfTwo(unsigned n) {
-  return (n & (n - 1)) == 0;
-}
-
-unsigned getExpOfTwo(unsigned n) {
-  unsigned i = 0;
-
-  while ((n = n >> 1)) {
-    ++i;
-  }
-
-  return i;
-}
-
-}  // namespace shared
+namespace shared {}  // namespace shared

--- a/omniscidb/Shared/MathUtils.h
+++ b/omniscidb/Shared/MathUtils.h
@@ -19,9 +19,32 @@
 
 namespace shared {
 
-bool isPowOfTwo(unsigned n);
+template <typename T, class = typename std::enable_if_t<std::is_unsigned<T>::value>>
+bool isPowOfTwo(T n) {
+  return (n & (n - 1)) == 0;
+}
 
-unsigned getExpOfTwo(unsigned n);
+template <typename T, class = typename std::enable_if_t<std::is_unsigned<T>::value>>
+unsigned getExpOfTwo(T n) {
+  unsigned i = 0;
+
+  while ((n = n >> 1)) {
+    ++i;
+  }
+
+  return i;
+}
+
+template <typename T, class = typename std::enable_if_t<std::is_unsigned<T>::value>>
+T roundUpToPow2(T val) {
+#ifdef _MSC_VER
+  return val == static_cast<T>(1) ? static_cast<T>(1)
+                                  : static_cast<T>(1) << (64 - __lzcnt64(val - 1));
+#else
+  return val == static_cast<T>(1) ? static_cast<T>(1)
+                                  : static_cast<T>(1) << (64 - __builtin_clzl(val - 1));
+#endif
+}
 
 }  // namespace shared
 

--- a/omniscidb/Tests/ArrowSQLRunner/ArrowSQLRunner.h
+++ b/omniscidb/Tests/ArrowSQLRunner/ArrowSQLRunner.h
@@ -74,6 +74,10 @@ ExecutionResult runSqlQuery(const std::string& sql,
                             ExecutorDeviceType device_type,
                             bool allow_loop_joins);
 
+ExecutionResult runQuery(std::unique_ptr<hdk::ir::QueryDag> dag,
+                         ExecutorDeviceType device_type = ExecutorDeviceType::CPU,
+                         bool allow_loop_joins = false);
+
 ExecutionOptions getExecutionOptions(bool allow_loop_joins, bool just_explain = false);
 
 CompilationOptions getCompilationOptions(ExecutorDeviceType device_type);

--- a/omniscidb/Tests/CMakeLists.txt
+++ b/omniscidb/Tests/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable(ArrowStorageSqlTest ArrowStorageSqlTest.cpp)
 add_executable(ResultSetArrowConversion ResultSetArrowConversion.cpp)
 add_executable(ExecutionSequenceTest ExecutionSequenceTest.cpp TestRelAlgDagBuilder.cpp)
 add_executable(QueryBuilderTest QueryBuilderTest.cpp TestRelAlgDagBuilder.cpp)
+add_executable(PartitionedGroupByTest PartitionedGroupByTest.cpp)
 
 if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
   add_executable(UdfTest UdfTest.cpp)
@@ -121,6 +122,7 @@ target_link_libraries(ParallelSortTest gtest TBB::tbb Logger)
 target_link_libraries(ResultSetArrowConversion gtest QueryEngine ArrowQueryRunner ArrowStorage ConfigBuilder)
 target_link_libraries(ExecutionSequenceTest gtest QueryEngine ArrowQueryRunner ArrowStorage ConfigBuilder)
 target_link_libraries(QueryBuilderTest gtest QueryBuilder QueryEngine ArrowQueryRunner IR ArrowStorage ConfigBuilder)
+target_link_libraries(PartitionedGroupByTest gtest QueryEngine ArrowQueryRunner IR ArrowStorage ConfigBuilder)
 
 if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
   target_link_libraries(UdfTest gtest UdfCompiler QueryEngine ArrowQueryRunner)
@@ -167,6 +169,7 @@ add_test(ParallelSortTest ParallelSortTest ${TEST_ARGS})
 add_test(ResultSetArrowConversion ResultSetArrowConversion ${TEST_ARGS})
 add_test(ExecutionSequenceTest ExecutionSequenceTest ${TEST_ARGS})
 add_test(QueryBuilderTest QueryBuilderTest ${TEST_ARGS})
+add_test(PartitionedGroupByTest PartitionedGroupByTest ${TEST_ARGS})
 
 add_test(NAME ArrowBasedExecuteTestColumnarOutputCpuOnly COMMAND ArrowBasedExecuteTest ${TEST_ARGS} "--enable-columnar-output")
 set_tests_properties(ArrowBasedExecuteTestColumnarOutputCpuOnly PROPERTIES LABELS "cpu_only")
@@ -226,6 +229,7 @@ set(TEST_PROGRAMS
   ResultSetArrowConversion
   ExecutionSequenceTest
   QueryBuilderTest
+  PartitionedGroupByTest
 )
 
 if(ENABLE_CUDA)

--- a/omniscidb/Tests/PartitionedGroupByTest.cpp
+++ b/omniscidb/Tests/PartitionedGroupByTest.cpp
@@ -1,0 +1,177 @@
+/**
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "ArrowTestHelpers.h"
+#include "TestHelpers.h"
+
+#include "ArrowSQLRunner/ArrowSQLRunner.h"
+#include "ConfigBuilder/ConfigBuilder.h"
+#include "QueryBuilder/QueryBuilder.h"
+#include "Shared/scope.h"
+
+using namespace std::string_literals;
+using namespace ArrowTestHelpers;
+using namespace TestHelpers::ArrowSQLRunner;
+using namespace hdk;
+using namespace hdk::ir;
+
+EXTERN extern bool g_enable_table_functions;
+
+class PartitionedGroupByTest : public ::testing::Test {
+ protected:
+  static constexpr int TEST_SCHEMA_ID2 = 2;
+  static constexpr int TEST_DB_ID2 = (TEST_SCHEMA_ID2 << 24) + 1;
+  static constexpr size_t row_count = 20;
+  static std::vector<int64_t> id1_vals;
+  static std::vector<int32_t> id2_vals;
+  static std::vector<int16_t> id3_vals;
+  static std::vector<std::string> id4_vals;
+  static std::vector<int32_t> v1_vals;
+  static std::vector<int32_t> v2_vals;
+  static std::vector<int64_t> v1_sums;
+  static std::vector<int64_t> v2_sums;
+
+  static void SetUpTestSuite() {
+    createTable("test1",
+                {{"id1", ctx().int64()},
+                 {"id2", ctx().int32()},
+                 {"id3", ctx().int16()},
+                 {"id4", ctx().extDict(ctx().text(), 0)},
+                 {"v1", ctx().int32()},
+                 {"v2", ctx().int32()}},
+                {row_count / 5});
+    std::stringstream ss;
+    for (size_t i = 1; i <= row_count; ++i) {
+      auto val = i == row_count ? 1000000000000 : i;  // to avoid perfect hash
+      id1_vals.push_back(val);
+      id2_vals.push_back(i * 10);
+      id3_vals.push_back(i * 100);
+      id4_vals.push_back("str"s + ::std::to_string(i));
+      v1_vals.push_back(i * 3);
+      v2_vals.push_back(i * 111);
+      v1_sums.push_back(i * 3);
+      v2_sums.push_back(i * 111);
+      ss << id1_vals.back() << "," << id2_vals.back() << "," << id3_vals.back() << ","
+         << id4_vals.back() << "," << v1_vals.back() << "," << v2_vals.back()
+         << std::endl;
+    }
+    insertCsvValues("test1", ss.str());
+  }
+
+  static void TearDownTestSuite() { dropTable("test1"); }
+};
+
+std::vector<int64_t> PartitionedGroupByTest::id1_vals;
+std::vector<int32_t> PartitionedGroupByTest::id2_vals;
+std::vector<int16_t> PartitionedGroupByTest::id3_vals;
+std::vector<std::string> PartitionedGroupByTest::id4_vals;
+std::vector<int32_t> PartitionedGroupByTest::v1_vals;
+std::vector<int32_t> PartitionedGroupByTest::v2_vals;
+std::vector<int64_t> PartitionedGroupByTest::v1_sums;
+std::vector<int64_t> PartitionedGroupByTest::v2_sums;
+
+TEST_F(PartitionedGroupByTest, SingleKey) {
+  auto old_exec_groupby = config().exec.group_by;
+  ScopeGuard g([&old_exec_groupby]() { config().exec.group_by = old_exec_groupby; });
+
+  config().exec.group_by.default_max_groups_buffer_entry_guess = 1;
+  config().exec.group_by.big_group_threshold = 1;
+  config().exec.group_by.enable_cpu_partitioned_groupby = true;
+  config().exec.group_by.partitioning_buffer_size_threshold = 10;
+  config().exec.group_by.partitioning_group_size_threshold = 1.5;
+  config().exec.group_by.min_partitions = 2;
+  config().exec.group_by.max_partitions = 8;
+  config().exec.group_by.partitioning_buffer_target_size = 200;
+  config().exec.enable_multifrag_execution_result = true;
+
+  QueryBuilder builder(ctx(), getSchemaProvider(), configPtr());
+  auto scan = builder.scan("test1");
+  auto dag1 = scan.agg({"id1"s}, {"sum(v1)"s}).finalize();
+  auto res1 = runQuery(std::move(dag1));
+  // Check the result has 4 fragments (partitions).
+  ASSERT_EQ(res1.getToken()->resultSetCount(), (size_t)4);
+  auto dag2 = builder.scan(res1.tableName()).sort({0}).finalize();
+  auto res2 = runQuery(std::move(dag2));
+  compare_res_data(res2, id1_vals, v1_sums);
+}
+
+TEST_F(PartitionedGroupByTest, MultipleKeys) {
+  auto old_exec = config().exec;
+  ScopeGuard g([&old_exec]() { config().exec = old_exec; });
+
+  config().exec.group_by.default_max_groups_buffer_entry_guess = 1;
+  config().exec.group_by.big_group_threshold = 1;
+  config().exec.group_by.enable_cpu_partitioned_groupby = true;
+  config().exec.group_by.partitioning_buffer_size_threshold = 10;
+  config().exec.group_by.partitioning_group_size_threshold = 1.5;
+  config().exec.group_by.min_partitions = 2;
+  config().exec.group_by.max_partitions = 8;
+  config().exec.group_by.partitioning_buffer_target_size = 612;
+  config().exec.enable_multifrag_execution_result = true;
+
+  QueryBuilder builder(ctx(), getSchemaProvider(), configPtr());
+  auto scan = builder.scan("test1");
+  auto dag1 =
+      scan.agg({"id1"s, "id2"s, "id3"s, "id4"s}, {"sum(v1)"s, "sum(v2)"s}).finalize();
+  auto res1 = runQuery(std::move(dag1));
+  // Check the result has 4 fragments (partitions).
+  ASSERT_EQ(res1.getToken()->resultSetCount(), (size_t)4);
+  auto dag2 = builder.scan(res1.tableName()).sort({0, 1, 2, 3}).finalize();
+  auto res2 = runQuery(std::move(dag2));
+  compare_res_data(res2, id1_vals, id2_vals, id3_vals, id4_vals, v1_sums, v2_sums);
+}
+
+TEST_F(PartitionedGroupByTest, ReorderedKeys) {
+  auto old_exec = config().exec;
+  ScopeGuard g([&old_exec]() { config().exec = old_exec; });
+
+  config().exec.group_by.default_max_groups_buffer_entry_guess = 1;
+  config().exec.group_by.big_group_threshold = 1;
+  config().exec.group_by.enable_cpu_partitioned_groupby = true;
+  config().exec.group_by.partitioning_buffer_size_threshold = 10;
+  config().exec.group_by.partitioning_group_size_threshold = 1.5;
+  config().exec.group_by.min_partitions = 2;
+  config().exec.group_by.max_partitions = 8;
+  config().exec.group_by.partitioning_buffer_target_size = 612;
+  config().exec.enable_multifrag_execution_result = true;
+
+  QueryBuilder builder(ctx(), getSchemaProvider(), configPtr());
+  auto scan = builder.scan("test1");
+  auto dag1 =
+      scan.agg({"id4"s, "id2"s, "id1"s, "id3"s}, {"sum(v1)"s, "sum(v2)"s}).finalize();
+  auto res1 = runQuery(std::move(dag1));
+  // Check the result has 4 fragments (partitions).
+  ASSERT_EQ(res1.getToken()->resultSetCount(), (size_t)4);
+  auto dag2 = builder.scan(res1.tableName()).sort({2}).finalize();
+  auto res2 = runQuery(std::move(dag2));
+  compare_res_data(res2, id4_vals, id2_vals, id1_vals, id3_vals, v1_sums, v2_sums);
+}
+
+int main(int argc, char* argv[]) {
+  TestHelpers::init_logger_stderr_only(argc, argv);
+  testing::InitGoogleTest(&argc, argv);
+
+  ConfigBuilder builder;
+  builder.parseCommandLineArgs(argc, argv, true);
+  auto config = builder.config();
+
+  // Avoid Calcite initialization for this suite.
+  config->debug.use_ra_cache = "dummy";
+  // Enable table function. Must be done before init.
+  g_enable_table_functions = true;
+
+  int err{0};
+  try {
+    init(config);
+    err = RUN_ALL_TESTS();
+    reset();
+  } catch (const std::exception& e) {
+    LOG(ERROR) << e.what();
+    return -1;
+  }
+
+  return err;
+}


### PR DESCRIPTION
This patch adds a simple version of partitioned aggregation. Only single-step hash partitioning is supported with quite simple heuristics to cover big outputs with many small groups. This can be further improved but need more cases to tune heuristics. 

The current implementation compares the estimated output buffer size with the input size trying to detect big buffers whose reduction wouldn't allow scaling. If the condition is fulfilled, then a replay with partitioning is requrest.

Partitioned aggregation goes in multiple steps.

Step 0 (optional). Materialize data to partition. This is to avoid costly operations executed multiple times on shuffle stages. Again, there is no good heuristics on what operation is simple enough to be included in the shuffle, so for now, I simply execute everything except simple projections.

Step 1. Building histogram for partitions. The goal here is to compute the sizes of future partitions and also to determine offsets to be used by each input fragment in output partitions (so that all kernels could write into the same buffers with no additional sync). This is done using a new node `Shuffle`. The node has group expressions to be used for partitioning and target expressions to be written to output partitions. For this step, it is just `COUNT(*)` expression. On output, we want to get simple arrays with partition sizes, so I force a keyless perfect hash table for memory layout providing exactly that case. There is a special reduction added in `Executor` for such kernel to compute partial sums of obtained partition sizes to be later used as offsets in output buffers. As a result, for `N` input partitions we have `N + 1` output partitions. The output partition with the number K would hold output offsets for the input partition with the same number. I also use some nasty trick to zero-copy transform perfect hashes into projections so that we could zero-copy fetch them later. Probably, it's not performance critical and we could simply create new projection result sets to hold the final data (perfect hash tables are not working because we don't want to skip empty rows)

Step 2. Partitioning. Here we use the same node but use column references in target expressions for all columns we need in the output. Also, we add the result of Step 1 as the second input table. The output is a projection. The biggest trick here is to pre-allocate result sets of the required size for all partitions and generate code that could write to multiple result sets at once. Currently, I pre-allocate all required buffers in Executor (and I'm thinking about moving it to QueryMemoryInitializer), then store for each output partition I store all column pointers in arrays (vectors), then build a new vector with pointers to all built arrays. As a result, I get `int8_t ***` pointer, and using a partition number and then a target number allows me to get the required output column pointer. This pointer is then passed to the kernel instead of the hash table pointer. All kernels get the same pointer but use a proper fragment (with the same number as the processed one) to use their own offsets for output columns. Some changes to code generation were introduced to allow each target to use its own output buffer instead of applying a known offset to a single base value.

Step 3. Aggregation. This is a pretty normal aggregation with slight modifications. First, it has an output entry count hint to avoid new estimation requests and use a sane output buffer size. Second, it allows us to completely avoid a reduction, unless the next operation or config says otherwise. New option to allow multi-fragment execution results (final result, not intermediate) is not disabled by default because such results don't support import to Arrow yet. Also, enabling it by default would most probably break a lot of our tests. I intend to support all public PyHDK API for multi-fragment result set tables and then enable this option by default (leaving it off for testing).

With default parameters, this partitioning would work only for H2O GroupBy Q10 on medium and big data sets. The gain depends on data size and fragment size. For big data size and the default fragment size, the preliminary boost is x5-6. Less for medium data size. Didn't measure on a clean machine yet.

There is still room for improvements. E.g. avoid metadata computation for partitioned data and use different sizes for final aggregation to avoid big partitions affecting all buffer sizes. Popular radix partitioning also assumes using multiple partitioning steps to avoid TLB pressure and get smaller partitions (to have resulting hash table fitting L1/L2 caches).