### PR TITLE
Move window function pre-project creation to DAG canonicalization.

### DIFF
--- a/omniscidb/IR/Expr.h
+++ b/omniscidb/IR/Expr.h
@@ -1103,4 +1103,8 @@ class ArrayExpr : public Expr {
 // equal).
 bool exprsEqual(const ExprPtrVector& lhs, const ExprPtrVector& rhs);
 
+// Detect both window function operators and window function operators embedded in case
+// statements (for null handling)
+bool isWindowFunctionExpr(const hdk::ir::Expr* expr);
+
 }  // namespace hdk::ir

--- a/omniscidb/IR/Node.cpp
+++ b/omniscidb/IR/Node.cpp
@@ -119,6 +119,15 @@ void Project::appendInput(std::string new_field_name, ExprPtr expr) {
   exprs_.emplace_back(std::move(expr));
 }
 
+bool Project::hasWindowFunctionExpr() const {
+  for (auto& expr : exprs_) {
+    if (isWindowFunctionExpr(expr.get())) {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool Project::isIdentity() const {
   if (!isSimple()) {
     return false;

--- a/omniscidb/IR/Node.h
+++ b/omniscidb/IR/Node.h
@@ -336,6 +336,8 @@ class Project : public Node {
 
   void appendInput(std::string new_field_name, ExprPtr expr);
 
+  bool hasWindowFunctionExpr() const;
+
   std::string toString() const override {
     return cat(::typeName(this),
                getIdString(),

--- a/omniscidb/QueryEngine/QueryExecutionSequence.cpp
+++ b/omniscidb/QueryEngine/QueryExecutionSequence.cpp
@@ -110,7 +110,7 @@ class QueryExecutionSequenceImpl {
 
     // Due to the current window functions support limitations,
     // both window function result and its input have to be materialized.
-    if (node->is<ir::Project>() && hasWindowFunctionExpr(node->as<ir::Project>())) {
+    if (node->is<ir::Project>() && node->as<ir::Project>()->hasWindowFunctionExpr()) {
       execution_points_.insert(node);
       execution_points_.insert(node->getInput(0));
     }
@@ -175,7 +175,7 @@ class QueryExecutionSequenceImpl {
       CHECK(start != end);
       auto node = graph_[start->m_source];
 
-      if (node->is<ir::Project>() && !hasWindowFunctionExpr(node->as<ir::Project>())) {
+      if (node->is<ir::Project>() && !node->as<ir::Project>()->hasWindowFunctionExpr()) {
         // In case of aggregation we allow only 'simple' projections which
         // don't have complex expressions referencing aggregate exprs.
         bool is_simple = true;

--- a/omniscidb/QueryEngine/RelAlgDagBuilder.h
+++ b/omniscidb/QueryEngine/RelAlgDagBuilder.h
@@ -101,6 +101,4 @@ inline InputColDescriptor column_var_to_descriptor(const hdk::ir::ColumnVar* var
 
 hdk::ir::ExprPtrVector getInputExprsForAgg(const hdk::ir::Node* node);
 
-bool hasWindowFunctionExpr(const hdk::ir::Project* node);
-
 void insert_join_projections(std::vector<hdk::ir::NodePtr>& nodes);

--- a/omniscidb/QueryEngine/RelAlgExecutor.cpp
+++ b/omniscidb/QueryEngine/RelAlgExecutor.cpp
@@ -37,7 +37,7 @@
 #include "QueryEngine/ResultSetSort.h"
 #include "QueryEngine/WindowContext.h"
 #include "QueryEngine/WorkUnitBuilder.h"
-#include "QueryOptimizer/CanonizeQuery.h"
+#include "QueryOptimizer/CanonicalizeQuery.h"
 #include "ResultSet/HyperLogLog.h"
 #include "ResultSetRegistry/ResultSetRegistry.h"
 #include "SchemaMgr/SchemaMgr.h"
@@ -129,7 +129,7 @@ RelAlgExecutor::RelAlgExecutor(Executor* executor,
         mergeProviders(std::vector<SchemaProviderPtr>({schema_provider, rs_registry_}));
   }
 
-  hdk::ir::canonizeQuery(*query_dag_);
+  hdk::ir::canonicalizeQuery(*query_dag_);
 }
 
 RelAlgExecutor::~RelAlgExecutor() {

--- a/omniscidb/QueryEngine/RelAlgExecutor.cpp
+++ b/omniscidb/QueryEngine/RelAlgExecutor.cpp
@@ -331,7 +331,7 @@ inline bool supportsMultifragInput(const hdk::ir::Node* node,
     return true;
   }
   if (node->is<hdk::ir::Project>() &&
-      hasWindowFunctionExpr(node->as<hdk::ir::Project>())) {
+      node->as<hdk::ir::Project>()->hasWindowFunctionExpr()) {
     return false;
   }
   if (node->is<hdk::ir::LogicalUnion>()) {

--- a/omniscidb/QueryOptimizer/CMakeLists.txt
+++ b/omniscidb/QueryOptimizer/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(query_optimizer_source_files
-    CanonizeQuery.cpp
-    CanonizeQuery.h
+    CanonicalizeQuery.cpp
+    CanonicalizeQuery.h
 )
 
 add_library(QueryOptimizer ${query_optimizer_source_files})

--- a/omniscidb/QueryOptimizer/CanonicalizeQuery.cpp
+++ b/omniscidb/QueryOptimizer/CanonicalizeQuery.cpp
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "CanonizeQuery.h"
+#include "CanonicalizeQuery.h"
 
 #include "IR/Expr.h"
 #include "IR/ExprCollector.h"
@@ -469,7 +469,7 @@ void addWindowFunctionPreProject(
 
 }  // namespace
 
-void canonizeQuery(QueryDag& dag) {
+void canonicalizeQuery(QueryDag& dag) {
   expandCompoundAggregates(dag);
   addWindowFunctionPreProject(dag);
 }

--- a/omniscidb/QueryOptimizer/CanonicalizeQuery.h
+++ b/omniscidb/QueryOptimizer/CanonicalizeQuery.h
@@ -10,6 +10,6 @@ namespace hdk::ir {
 
 class QueryDag;
 
-void canonizeQuery(QueryDag& dag);
+void canonicalizeQuery(QueryDag& dag);
 
 }  // namespace hdk::ir

--- a/omniscidb/SchemaMgr/TableInfo.h
+++ b/omniscidb/SchemaMgr/TableInfo.h
@@ -62,7 +62,7 @@ struct TableInfo : public TableRef {
 
   std::string name;
   bool is_view;
-  // For add_window_function_pre_project in RelAlgDagBuilder.
+  // For addWindowFunctionPreProject.
   size_t fragments;
   size_t row_count;
   bool is_stream;

--- a/python/tests/test_pyhdk_api.py
+++ b/python/tests/test_pyhdk_api.py
@@ -1002,6 +1002,14 @@ class TestBuilder(BaseTest):
         res = ht.proj(hdk.row_number().over(ht.ref("a")).order_by(ht.ref("b"))).run()
         check_res(res, {"row_number": [1, 1, 2, 2, 3]})
 
+    def test_row_number_multifrag(self):
+        hdk = pyhdk.init()
+        ht = hdk.import_pydict(
+            {"a": [1, 2, 1, 2, 1], "b": [1, 2, 3, 4, 5]}, fragment_size=2
+        )
+        res = ht.proj(hdk.row_number().over(ht.ref("a")).order_by(ht.ref("b"))).run()
+        check_res(res, {"row_number": [1, 1, 2, 2, 3]})
+
     def test_rank(self):
         hdk = pyhdk.init()
         ht = hdk.import_pydict({"a": [1, 2, 1, 2, 1], "b": [2, 2, 1, 3, 1]})


### PR DESCRIPTION
Move DAG transformation for window functions we use in `RelAlgDagBuilder` to `canonizeQuery` so that it's applied to both Calcite and QueryBuilder generated queries. Some minor functions were moved to the IR module.

Resolves #541
Resolves #543
