### PR TITLE
Support arrow conversion for multi-fragment result set tables [1/N]

### DIFF
--- a/omniscidb/IR/Node.h
+++ b/omniscidb/IR/Node.h
@@ -10,8 +10,8 @@
 #include <atomic>
 #include "Expr.h"
 #include "ExprRewriter.h"
+#include "TargetMetaInfo.h"
 
-#include "QueryEngine/TargetMetaInfo.h"
 #include "SchemaMgr/TableInfo.h"
 #include "Shared/Config.h"
 

--- a/omniscidb/IR/TargetMetaInfo.h
+++ b/omniscidb/IR/TargetMetaInfo.h
@@ -1,26 +1,19 @@
-/*
+/**
  * Copyright 2017 MapD Technologies, Inc.
+ * Copyright (C) 2023 Intel Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef QUERYENGINE_TARGETMETAINFO_H
-#define QUERYENGINE_TARGETMETAINFO_H
+#pragma once
+
+#include "Type.h"
+
+#include "Shared/sqltypes.h"
 
 #include <string>
 
-#include "IR/Type.h"
-#include "Shared/sqltypes.h"
+namespace hdk::ir {
 
 /*
  * @type TargetMetaInfo
@@ -47,4 +40,4 @@ inline std::ostream& operator<<(std::ostream& os, TargetMetaInfo const& tmi) {
             << " type=" << tmi.type()->toString() << ")";
 }
 
-#endif  // QUERYENGINE_TARGETMETAINFO_H
+}  // namespace hdk::ir

--- a/omniscidb/QueryEngine/ArrowResultSet.cpp
+++ b/omniscidb/QueryEngine/ArrowResultSet.cpp
@@ -73,7 +73,7 @@ const hdk::ir::Type* type_from_arrow_field(hdk::ir::Context& ctx,
 }  // namespace
 
 ArrowResultSet::ArrowResultSet(const std::shared_ptr<ResultSet>& rows,
-                               const std::vector<TargetMetaInfo>& targets_meta,
+                               const std::vector<hdk::ir::TargetMetaInfo>& targets_meta,
                                const ExecutorDeviceType device_type)
     : rows_(rows), targets_meta_(targets_meta), crt_row_idx_(0) {
   resultSetArrowLoopback(device_type);
@@ -88,7 +88,7 @@ ArrowResultSet::ArrowResultSet(const std::shared_ptr<ResultSet>& rows,
 
 ArrowResultSet::ArrowResultSet(
     const std::shared_ptr<ResultSet>& rows,
-    const std::vector<TargetMetaInfo>& targets_meta,
+    const std::vector<hdk::ir::TargetMetaInfo>& targets_meta,
     const ExecutorDeviceType device_type,
     const size_t min_result_size_for_bulk_dictionary_fetch,
     const double max_dictionary_to_result_size_ratio_for_bulk_dictionary_fetch)
@@ -357,7 +357,7 @@ std::unique_ptr<ArrowResultSet> result_set_arrow_loopback(
     const ExecutorDeviceType device_type,
     const size_t min_result_size_for_bulk_dictionary_fetch,
     const double max_dictionary_to_result_size_ratio_for_bulk_dictionary_fetch) {
-  std::vector<TargetMetaInfo> dummy_targets_meta;
+  std::vector<hdk::ir::TargetMetaInfo> dummy_targets_meta;
   return results ? std::make_unique<ArrowResultSet>(
                        rows,
                        results->getTargetsMeta(),

--- a/omniscidb/QueryEngine/ArrowResultSet.h
+++ b/omniscidb/QueryEngine/ArrowResultSet.h
@@ -18,9 +18,9 @@
 
 #include "CompilationOptions.h"
 #include "Descriptors/RelAlgExecutionDescriptor.h"
-#include "TargetMetaInfo.h"
 
 #include "DataMgr/DataMgr.h"
+#include "IR/TargetMetaInfo.h"
 #include "ResultSet/ResultSet.h"
 
 #include <type_traits>
@@ -98,12 +98,12 @@ struct ArrowResult {
 class ArrowResultSet {
  public:
   ArrowResultSet(const std::shared_ptr<ResultSet>& rows,
-                 const std::vector<TargetMetaInfo>& targets_meta,
+                 const std::vector<hdk::ir::TargetMetaInfo>& targets_meta,
                  const ExecutorDeviceType device_type = ExecutorDeviceType::CPU);
 
   ArrowResultSet(
       const std::shared_ptr<ResultSet>& rows,
-      const std::vector<TargetMetaInfo>& targets_meta,
+      const std::vector<hdk::ir::TargetMetaInfo>& targets_meta,
       const ExecutorDeviceType device_type,
       const size_t min_result_size_for_bulk_dictionary_fetch,
       const double max_dictionary_to_result_size_ratio_for_bulk_dictionary_fetch);
@@ -168,7 +168,7 @@ class ArrowResultSet {
 
   std::shared_ptr<ArrowResult> results_;
   std::shared_ptr<ResultSet> rows_;
-  std::vector<TargetMetaInfo> targets_meta_;
+  std::vector<hdk::ir::TargetMetaInfo> targets_meta_;
   std::shared_ptr<arrow::RecordBatch> record_batch_;
   arrow::ipc::DictionaryMemo dictionary_memo_;
 
@@ -176,7 +176,7 @@ class ArrowResultSet {
   // temporary, so we cache these for better performance
   std::vector<std::shared_ptr<arrow::Array>> columns_;
   mutable size_t crt_row_idx_;
-  std::vector<TargetMetaInfo> column_metainfo_;
+  std::vector<hdk::ir::TargetMetaInfo> column_metainfo_;
 };
 
 ArrowResultSetRowIterator::value_type ArrowResultSetRowIterator::operator*() const {

--- a/omniscidb/QueryEngine/Descriptors/RelAlgExecutionDescriptor.cpp
+++ b/omniscidb/QueryEngine/Descriptors/RelAlgExecutionDescriptor.cpp
@@ -24,7 +24,7 @@ ExecutionResult::ExecutionResult()
     , type_(QueryResult) {}
 
 ExecutionResult::ExecutionResult(hdk::ResultSetTableTokenPtr token,
-                                 const std::vector<TargetMetaInfo>& targets_meta)
+                                 const std::vector<hdk::ir::TargetMetaInfo>& targets_meta)
     : result_token_(std::move(token))
     , targets_meta_(targets_meta)
     , filter_push_down_enabled_(false)

--- a/omniscidb/QueryEngine/Descriptors/RelAlgExecutionDescriptor.h
+++ b/omniscidb/QueryEngine/Descriptors/RelAlgExecutionDescriptor.h
@@ -30,7 +30,7 @@ class ExecutionResult {
   ExecutionResult();
 
   ExecutionResult(hdk::ResultSetTableTokenPtr token,
-                  const std::vector<TargetMetaInfo>& targets_meta);
+                  const std::vector<hdk::ir::TargetMetaInfo>& targets_meta);
 
   ExecutionResult(const ExecutionResult& that);
 
@@ -66,7 +66,9 @@ class ExecutionResult {
     return {result_token_->tail(n), targets_meta_};
   }
 
-  const std::vector<TargetMetaInfo>& getTargetsMeta() const { return targets_meta_; }
+  const std::vector<hdk::ir::TargetMetaInfo>& getTargetsMeta() const {
+    return targets_meta_;
+  }
 
   const std::vector<PushedDownFilterInfo>& getPushedDownFilterInfo() const;
 
@@ -98,7 +100,7 @@ class ExecutionResult {
 
  private:
   hdk::ResultSetTableTokenPtr result_token_;
-  std::vector<TargetMetaInfo> targets_meta_;
+  std::vector<hdk::ir::TargetMetaInfo> targets_meta_;
   // filters chosen to be pushed down
   std::vector<PushedDownFilterInfo> pushed_down_filter_info_;
   // whether or not it was allowed to look for filters to push down

--- a/omniscidb/QueryEngine/Execute.h
+++ b/omniscidb/QueryEngine/Execute.h
@@ -62,7 +62,6 @@
 #include "QueryEngine/RowFuncBuilder.h"
 #include "QueryEngine/StringDictionaryGenerations.h"
 #include "QueryEngine/TableGenerations.h"
-#include "QueryEngine/TargetMetaInfo.h"
 #include "QueryEngine/WindowContext.h"
 
 #include "DataMgr/Chunk/Chunk.h"

--- a/omniscidb/QueryEngine/ExternalExecutor.cpp
+++ b/omniscidb/QueryEngine/ExternalExecutor.cpp
@@ -61,7 +61,7 @@ int vt_create(sqlite3* db,
   std::transform(p_vt->external_query_table->schema.begin(),
                  p_vt->external_query_table->schema.end(),
                  std::back_inserter(col_defs),
-                 [](const TargetMetaInfo& target_metainfo) {
+                 [](const hdk::ir::TargetMetaInfo& target_metainfo) {
                    return target_metainfo.get_resname() + " " +
                           hdk::ir::sqlTypeName(target_metainfo.type());
                  });
@@ -356,8 +356,8 @@ sqlite3_module omnisci_module = {
     nullptr         // xRollbackto   - function overloading
 };
 
-std::vector<TargetMetaInfo> create_table_schema(const PlanState* plan_state) {
-  std::map<size_t, TargetMetaInfo> schema_map;
+std::vector<hdk::ir::TargetMetaInfo> create_table_schema(const PlanState* plan_state) {
+  std::map<size_t, hdk::ir::TargetMetaInfo> schema_map;
   auto schema_provider = plan_state->executor_->getSchemaProvider();
   for (const auto& kv : plan_state->global_to_local_col_ids_) {
     const int db_id = kv.first.getDatabaseId();
@@ -374,10 +374,10 @@ std::vector<TargetMetaInfo> create_table_schema(const PlanState* plan_state) {
     const auto column_ref =
         serialize_column_ref(db_id, table_id, column_id, schema_provider);
     const auto it_ok =
-        schema_map.emplace(kv.second, TargetMetaInfo(column_ref, column_type));
+        schema_map.emplace(kv.second, hdk::ir::TargetMetaInfo(column_ref, column_type));
     CHECK(it_ok.second);
   }
-  std::vector<TargetMetaInfo> schema;
+  std::vector<hdk::ir::TargetMetaInfo> schema;
   for (const auto& kv : schema_map) {
     schema.push_back(kv.second);
   }

--- a/omniscidb/QueryEngine/ExternalExecutor.h
+++ b/omniscidb/QueryEngine/ExternalExecutor.h
@@ -24,13 +24,14 @@
 #include "QueryEngine/ColumnFetcher.h"
 #include "QueryEngine/PlanState.h"
 #include "QueryEngine/SerializeToSql.h"
-#include "QueryEngine/TargetMetaInfo.h"
+
+#include "IR/TargetMetaInfo.h"
 
 class Executor;
 
 struct ExternalQueryTable {
   FetchResult fetch_result;
-  std::vector<TargetMetaInfo> schema;
+  std::vector<hdk::ir::TargetMetaInfo> schema;
   std::string from_table;
   const Executor* executor;
 };

--- a/omniscidb/QueryEngine/RelAlgDagBuilder.cpp
+++ b/omniscidb/QueryEngine/RelAlgDagBuilder.cpp
@@ -2304,9 +2304,10 @@ class RelAlgDispatcher {
     return ret;
   }
 
-  std::vector<TargetMetaInfo> parseTupleType(const rapidjson::Value& tuple_type_arr) {
+  std::vector<hdk::ir::TargetMetaInfo> parseTupleType(
+      const rapidjson::Value& tuple_type_arr) {
     CHECK(tuple_type_arr.IsArray());
-    std::vector<TargetMetaInfo> tuple_type;
+    std::vector<hdk::ir::TargetMetaInfo> tuple_type;
     for (auto tuple_type_arr_it = tuple_type_arr.Begin();
          tuple_type_arr_it != tuple_type_arr.End();
          ++tuple_type_arr_it) {
@@ -2320,7 +2321,7 @@ class RelAlgDispatcher {
   std::shared_ptr<hdk::ir::LogicalValues> dispatchLogicalValues(
       const rapidjson::Value& logical_values_ra) {
     const auto& tuple_type_arr = field(logical_values_ra, "type");
-    std::vector<TargetMetaInfo> tuple_type = parseTupleType(tuple_type_arr);
+    std::vector<hdk::ir::TargetMetaInfo> tuple_type = parseTupleType(tuple_type_arr);
     const auto& inputs_arr = field(logical_values_ra, "inputs");
     CHECK(inputs_arr.IsArray());
     const auto& tuples_arr = field(logical_values_ra, "tuples");

--- a/omniscidb/QueryEngine/RelAlgExecutor.cpp
+++ b/omniscidb/QueryEngine/RelAlgExecutor.cpp
@@ -549,10 +549,10 @@ const hdk::ir::Type* canonicalTypeForExpr(const hdk::ir::Expr& expr) {
 }
 
 template <class RA>
-std::vector<TargetMetaInfo> get_targets_meta(
+std::vector<hdk::ir::TargetMetaInfo> get_targets_meta(
     const RA* ra_node,
     const std::vector<const hdk::ir::Expr*>& target_exprs) {
-  std::vector<TargetMetaInfo> targets_meta;
+  std::vector<hdk::ir::TargetMetaInfo> targets_meta;
   CHECK_EQ(ra_node->size(), target_exprs.size());
   for (size_t i = 0; i < ra_node->size(); ++i) {
     CHECK(target_exprs[i]);
@@ -564,33 +564,33 @@ std::vector<TargetMetaInfo> get_targets_meta(
 }
 
 template <>
-std::vector<TargetMetaInfo> get_targets_meta(
+std::vector<hdk::ir::TargetMetaInfo> get_targets_meta(
     const hdk::ir::Node* node,
     const std::vector<const hdk::ir::Expr*>& target_exprs);
 
 template <>
-std::vector<TargetMetaInfo> get_targets_meta(
+std::vector<hdk::ir::TargetMetaInfo> get_targets_meta(
     const hdk::ir::Filter* filter,
     const std::vector<const hdk::ir::Expr*>& target_exprs) {
   return get_targets_meta(filter->getInput(0), target_exprs);
 }
 
 template <>
-std::vector<TargetMetaInfo> get_targets_meta(
+std::vector<hdk::ir::TargetMetaInfo> get_targets_meta(
     const hdk::ir::Sort* sort,
     const std::vector<const hdk::ir::Expr*>& target_exprs) {
   return get_targets_meta(sort->getInput(0), target_exprs);
 }
 
 template <>
-std::vector<TargetMetaInfo> get_targets_meta(
+std::vector<hdk::ir::TargetMetaInfo> get_targets_meta(
     const hdk::ir::LogicalUnion* logical_union,
     const std::vector<const hdk::ir::Expr*>& target_exprs) {
   return get_targets_meta(logical_union->getInput(0), target_exprs);
 }
 
 template <>
-std::vector<TargetMetaInfo> get_targets_meta(
+std::vector<hdk::ir::TargetMetaInfo> get_targets_meta(
     const hdk::ir::Node* node,
     const std::vector<const hdk::ir::Expr*>& target_exprs) {
   if (auto proj = node->as<hdk::ir::Project>()) {
@@ -938,8 +938,8 @@ ExecutionResult RelAlgExecutor::executeLogicalValues(
     }
     if (target_meta_info.type()->isNull()) {
       // replace w/ bigint
-      tuple_type[i] = TargetMetaInfo(target_meta_info.get_resname(),
-                                     hdk::ir::Context::defaultCtx().int64());
+      tuple_type[i] = hdk::ir::TargetMetaInfo(target_meta_info.get_resname(),
+                                              hdk::ir::Context::defaultCtx().int64());
     }
     query_mem_desc.addColSlotInfo({std::make_tuple(tuple_type[i].type()->size(), 8)});
   }
@@ -1092,7 +1092,7 @@ RelAlgExecutionUnit decide_approx_count_distinct_implementation(
 
 ExecutionResult RelAlgExecutor::executeWorkUnit(
     const RelAlgExecutor::WorkUnit& work_unit,
-    const std::vector<TargetMetaInfo>& targets_meta,
+    const std::vector<hdk::ir::TargetMetaInfo>& targets_meta,
     const bool is_agg,
     const CompilationOptions& co_in,
     const ExecutionOptions& eo_in,
@@ -1305,7 +1305,7 @@ bool RelAlgExecutor::isRowidLookup(const WorkUnit& work_unit) {
 
 ExecutionResult RelAlgExecutor::handleOutOfMemoryRetry(
     const RelAlgExecutor::WorkUnit& work_unit,
-    const std::vector<TargetMetaInfo>& targets_meta,
+    const std::vector<hdk::ir::TargetMetaInfo>& targets_meta,
     const bool is_agg,
     const CompilationOptions& co,
     const ExecutionOptions& eo,
@@ -1423,7 +1423,7 @@ void RelAlgExecutor::handlePersistentError(const int32_t error_code) {
 
 ExecutionResult RelAlgExecutor::registerResultSetTable(
     hdk::ResultSetTable table,
-    const std::vector<TargetMetaInfo>& targets_meta,
+    const std::vector<hdk::ir::TargetMetaInfo>& targets_meta,
     bool just_explain_result) {
   std::vector<std::string> col_names;
   if (just_explain_result) {

--- a/omniscidb/QueryEngine/RelAlgExecutor.h
+++ b/omniscidb/QueryEngine/RelAlgExecutor.h
@@ -165,7 +165,7 @@ class RelAlgExecutor {
 
   ExecutionResult executeWorkUnit(
       const WorkUnit& work_unit,
-      const std::vector<TargetMetaInfo>& targets_meta,
+      const std::vector<hdk::ir::TargetMetaInfo>& targets_meta,
       const bool is_agg,
       const CompilationOptions& co_in,
       const ExecutionOptions& eo_in,
@@ -195,13 +195,14 @@ class RelAlgExecutor {
 
   bool isRowidLookup(const WorkUnit& work_unit);
 
-  ExecutionResult handleOutOfMemoryRetry(const RelAlgExecutor::WorkUnit& work_unit,
-                                         const std::vector<TargetMetaInfo>& targets_meta,
-                                         const bool is_agg,
-                                         const CompilationOptions& co,
-                                         const ExecutionOptions& eo,
-                                         const bool was_multifrag_kernel_launch,
-                                         const int64_t queue_time_ms);
+  ExecutionResult handleOutOfMemoryRetry(
+      const RelAlgExecutor::WorkUnit& work_unit,
+      const std::vector<hdk::ir::TargetMetaInfo>& targets_meta,
+      const bool is_agg,
+      const CompilationOptions& co,
+      const ExecutionOptions& eo,
+      const bool was_multifrag_kernel_launch,
+      const int64_t queue_time_ms);
 
   // Allows an out of memory error through if CPU retry is enabled. Otherwise, throws an
   // appropriate exception corresponding to the query error code.
@@ -215,9 +216,10 @@ class RelAlgExecutor {
                           const ExecutionOptions& eo,
                           bool allow_speculative_sort);
 
-  ExecutionResult registerResultSetTable(hdk::ResultSetTable table,
-                                         const std::vector<TargetMetaInfo>& targets_meta,
-                                         bool just_explain_result);
+  ExecutionResult registerResultSetTable(
+      hdk::ResultSetTable table,
+      const std::vector<hdk::ir::TargetMetaInfo>& targets_meta,
+      bool just_explain_result);
 
   void addTemporaryTable(const int table_id, const hdk::ResultSetTableTokenPtr& token) {
     CHECK_LT(table_id, 0);

--- a/omniscidb/QueryEngine/ResultSetBuilder.cpp
+++ b/omniscidb/QueryEngine/ResultSetBuilder.cpp
@@ -161,7 +161,7 @@ ResultSet* ResultSetLogicalValuesBuilder::build() {
 
 // static
 ResultSet* ResultSetLogicalValuesBuilder::create(
-    std::vector<TargetMetaInfo>& label_infos,
+    std::vector<hdk::ir::TargetMetaInfo>& label_infos,
     std::vector<hdk::ir::ExprPtrVector> logical_values) {
   // check to see if number of columns matches (at least the first row)
   size_t numCols =

--- a/omniscidb/QueryEngine/ResultSetBuilder.h
+++ b/omniscidb/QueryEngine/ResultSetBuilder.h
@@ -93,7 +93,7 @@ class ResultSetLogicalValuesBuilder : public ResultSetBuilder {
   //     ExecutorDeviceType is "CPU"
   //     QueryMemoryDescriptor is "Projection"
   //     RowSetMemoryOwner is default
-  static ResultSet* create(std::vector<TargetMetaInfo>& label_infos,
+  static ResultSet* create(std::vector<hdk::ir::TargetMetaInfo>& label_infos,
                            std::vector<hdk::ir::ExprPtrVector> logical_values);
 };
 

--- a/python/pyhdk/_execute.pxd
+++ b/python/pyhdk/_execute.pxd
@@ -132,8 +132,8 @@ cdef extern from "omniscidb/ResultSetRegistry/ResultSetRegistry.h":
   cdef cppclass CResultSetRegistry "hdk::ResultSetRegistry"(CSchemaProvider, CAbstractDataProvider):
     CResultSetRegistry(shared_ptr[CConfig]) except +;
 
-cdef extern from "omniscidb/QueryEngine/TargetMetaInfo.h":
-  cdef cppclass CTargetMetaInfo "TargetMetaInfo":
+cdef extern from "omniscidb/IR/TargetMetaInfo.h":
+  cdef cppclass CTargetMetaInfo "hdk::ir::TargetMetaInfo":
     const string& get_resname()
     const CType* type()
 


### PR DESCRIPTION
I want to allow result set tables with multiple fragments to be used not only for intermediate results but also for the final query results. This should enable parallel processing if such results are used in another query. Also, in case of partitioned aggregation, it allows to avoid costly reduction.

The problem with using multi-fragment result is that it doesn't support conversion to Arrow table. So I want to add this functionality. To avoid dependency on QueryEngine in result set tables API I'd like to make some refactoring first, moving related code out from QueryEngine library. 

This first patch moves TargetMetaInfo.h to IR where it's used in nodes anyway.