### PR TITLE
Add non-lazy data import.

### DIFF
--- a/omniscidb/ArrowStorage/ArrowStorage.cpp
+++ b/omniscidb/ArrowStorage/ArrowStorage.cpp
@@ -715,7 +715,8 @@ void ArrowStorage::appendArrowTable(std::shared_ptr<arrow::Table> at, int table_
         switch (col_arr->type()->id()) {
           case arrow::Type::STRING:
             // if the dictionary has already been materialized, append indices
-            if (!config_->storage.enable_lazy_dict_materialization ||
+            if (config_->storage.enable_non_lazy_data_import ||
+                !config_->storage.enable_lazy_dict_materialization ||
                 dict_data->is_materialized) {
               col_arr = createDictionaryEncodedColumn(
                   dict_data->dict()->stringDict.get(), col_arr, col_type);
@@ -730,8 +731,11 @@ void ArrowStorage::appendArrowTable(std::shared_ptr<arrow::Table> at, int table_
         }
       } else if (col_type->isString()) {
       } else {
-        col_arr = replaceNullValues(
-            col_arr, col_type, dict_data ? dict_data->dict()->stringDict.get() : nullptr);
+        col_arr =
+            replaceNullValues(col_arr,
+                              col_type,
+                              dict_data ? dict_data->dict()->stringDict.get() : nullptr,
+                              config_->storage.enable_non_lazy_data_import);
       }
 
       col_data[col_idx] = col_arr;

--- a/omniscidb/ArrowStorage/ArrowStorageUtils.h
+++ b/omniscidb/ArrowStorage/ArrowStorageUtils.h
@@ -28,7 +28,8 @@ std::shared_ptr<arrow::DataType> getArrowImportType(hdk::ir::Context& ctx,
 std::shared_ptr<arrow::ChunkedArray> replaceNullValues(
     std::shared_ptr<arrow::ChunkedArray> arr,
     const hdk::ir::Type* type,
-    StringDictionary* dict = nullptr);
+    StringDictionary* dict = nullptr,
+    bool force_single_chunk = false);
 
 std::shared_ptr<arrow::ChunkedArray> convertDecimalToInteger(
     std::shared_ptr<arrow::ChunkedArray> arr,

--- a/omniscidb/ConfigBuilder/ConfigBuilder.cpp
+++ b/omniscidb/ConfigBuilder/ConfigBuilder.cpp
@@ -582,6 +582,15 @@ bool ConfigBuilder::parseCommandLineArgs(int argc,
           ->default_value(config_->storage.enable_lazy_dict_materialization)
           ->implicit_value(true),
       "Enable lazy materialization of string dictionary columns from Arrow Storage.");
+  opt_desc.add_options()(
+      "enable-non-lazy-data-import",
+      po::value<bool>(&config_->storage.enable_non_lazy_data_import)
+          ->default_value(config_->storage.enable_non_lazy_data_import)
+          ->implicit_value(true),
+      "Enable non-lazy data import in Arrow Storage. When enabled, we do as much data "
+      "processing on import as we might require. This might increase overall execution "
+      "time. This option can be used to split data import and execution for performance "
+      "measurements.");
 
   if (allow_gtest_flags) {
     opt_desc.add_options()("gtest_list_tests", "list all test");

--- a/omniscidb/Shared/Config.h
+++ b/omniscidb/Shared/Config.h
@@ -176,6 +176,7 @@ struct DebugConfig {
 
 struct StorageConfig {
   bool enable_lazy_dict_materialization = false;
+  bool enable_non_lazy_data_import = false;
 };
 
 struct Config {


### PR DESCRIPTION
Add a new option that allows to avoid data fetch costs on execution moving it to data import. This option is for benchmarking only when we want to split data import/transformation time and execution time. This can lead to an overall workload execution time increase in the case of unused columns in imported data.