### PR TITLE
Support arrow conversion for multi-fragment result set tables [3/3]

### DIFF
--- a/omniscidb/ResultSet/ResultSet.cpp
+++ b/omniscidb/ResultSet/ResultSet.cpp
@@ -468,6 +468,10 @@ bool ResultSet::hasColNames() const {
   return targets_.size() == fields_.size();
 }
 
+const std::vector<std::string>& ResultSet::getColNames() const {
+  return fields_;
+}
+
 std::string ResultSet::colName(size_t col_idx) const {
   if (fields_.empty()) {
     return "col" + std::to_string(col_idx);

--- a/omniscidb/ResultSet/ResultSet.h
+++ b/omniscidb/ResultSet/ResultSet.h
@@ -289,6 +289,7 @@ class ResultSet {
 
   void setColNames(std::vector<std::string> fields);
   bool hasColNames() const;
+  const std::vector<std::string>& getColNames() const;
   std::string colName(size_t col_idx) const;
 
   /**

--- a/omniscidb/ResultSetRegistry/ResultSetRegistry.cpp
+++ b/omniscidb/ResultSetRegistry/ResultSetRegistry.cpp
@@ -212,6 +212,10 @@ ResultSetTableTokenPtr ResultSetRegistry::head(const ResultSetTableToken& token,
     }
   }
 
+  // Copy column names to the resulting table.
+  auto* first_rs = table->fragments.front().rs.get();
+  new_results.front()->setColNames(first_rs->getColNames());
+
   data_lock.unlock();
   table_lock.unlock();
 
@@ -255,6 +259,10 @@ ResultSetTableTokenPtr ResultSetRegistry::tail(const ResultSetTableToken& token,
       }
     }
   }
+
+  // Copy column names to the resulting table.
+  auto* first_rs = table->fragments.front().rs.get();
+  new_results.front()->setColNames(first_rs->getColNames());
 
   data_lock.unlock();
   table_lock.unlock();

--- a/omniscidb/ResultSetRegistry/ResultSetTableToken.cpp
+++ b/omniscidb/ResultSetRegistry/ResultSetTableToken.cpp
@@ -7,6 +7,9 @@
 #include "ResultSetTableToken.h"
 #include "ResultSetRegistry.h"
 
+#include "ResultSet/ArrowResultSet.h"
+#include "Shared/ArrowUtil.h"
+
 namespace hdk {
 
 ResultSetTableToken::ResultSetTableToken(TableInfoPtr tinfo,
@@ -41,6 +44,27 @@ ResultSetTableTokenPtr ResultSetTableToken::head(size_t n) const {
 
 ResultSetTableTokenPtr ResultSetTableToken::tail(size_t n) const {
   return registry_->tail(*this, n);
+}
+
+std::shared_ptr<arrow::Table> ResultSetTableToken::toArrow() const {
+  auto first_rs = resultSet(0);
+  std::vector<std::string> col_names;
+  for (size_t col_idx = 0; col_idx < first_rs->colCount(); ++col_idx) {
+    col_names.push_back(first_rs->colName(col_idx));
+  }
+
+  std::vector<std::shared_ptr<arrow::Table>> converted_tables;
+  for (size_t rs_idx = 0; rs_idx < resultSetCount(); ++rs_idx) {
+    ArrowResultSetConverter converter(resultSet(rs_idx), col_names, -1);
+    converted_tables.push_back(converter.convertToArrowTable());
+  }
+
+  if (converted_tables.size() == (size_t)1) {
+    return converted_tables.front();
+  }
+
+  ARROW_ASSIGN_OR_THROW(auto res, arrow::ConcatenateTables(converted_tables));
+  return res;
 }
 
 }  // namespace hdk

--- a/omniscidb/ResultSetRegistry/ResultSetTableToken.h
+++ b/omniscidb/ResultSetRegistry/ResultSetTableToken.h
@@ -11,6 +11,8 @@
 #include "DataMgr/ChunkMetadata.h"
 #include "SchemaMgr/TableInfo.h"
 
+#include "arrow/api.h"
+
 namespace hdk {
 
 class ResultSetRegistry;
@@ -54,6 +56,8 @@ class ResultSetTableToken : public std::enable_shared_from_this<ResultSetTableTo
 
   ResultSetTableTokenPtr head(size_t n) const;
   ResultSetTableTokenPtr tail(size_t n) const;
+
+  std::shared_ptr<arrow::Table> toArrow() const;
 
   std::string toString() const {
     return "ResultSetTableToken(" + std::to_string(dbId()) + ":" +

--- a/python/pyhdk/_sql.pxd
+++ b/python/pyhdk/_sql.pxd
@@ -8,6 +8,8 @@ from libcpp.memory cimport shared_ptr, unique_ptr
 from libcpp.string cimport string
 from libcpp.vector cimport vector
 
+from pyarrow.lib cimport CTable as CArrowTable
+
 from pyhdk._common cimport CConfig, CType
 from pyhdk._storage cimport CSchemaProvider, CSchemaProviderPtr, CDataProvider, CDataMgr, CBufferProvider
 from pyhdk._execute cimport CExecutor, CResultSetPtr, CCompilationOptions, CExecutionOptions, CTargetMetaInfo
@@ -50,6 +52,13 @@ cdef extern from "omniscidb/QueryEngine/RelAlgDagBuilder.h":
   cdef cppclass CRelAlgDagBuilder "RelAlgDagBuilder"(CQueryDag):
     CRelAlgDagBuilder(const string&, int, CSchemaProviderPtr, shared_ptr[CConfig]) except +
 
+cdef extern from "omniscidb/ResultSetRegistry/ResultSetTableToken.h":
+  cdef cppclass CResultSetTableToken "hdk::ResultSetTableToken":
+    size_t rowCount()
+    shared_ptr[CArrowTable] toArrow() except +
+
+ctypedef shared_ptr[const CResultSetTableToken] CResultSetTableTokenPtr
+
 cdef extern from "omniscidb/QueryEngine/Descriptors/RelAlgExecutionDescriptor.h":
   cdef cppclass CExecutionResult "ExecutionResult":
     CExecutionResult()
@@ -60,6 +69,7 @@ cdef extern from "omniscidb/QueryEngine/Descriptors/RelAlgExecutionDescriptor.h"
     const vector[CTargetMetaInfo]& getTargetsMeta()
     string getExplanation()
     const string& tableName()
+    CResultSetTableTokenPtr getToken()
 
     CExecutionResult head(size_t) except +
     CExecutionResult tail(size_t) except +


### PR DESCRIPTION
Introduce ResultSetTableToken::toArrow and use it in PyHDK.