### PR TITLE
Add TableStats to TableFragmentsInfo.

### DIFF
--- a/omniscidb/ArrowStorage/ArrowStorage.h
+++ b/omniscidb/ArrowStorage/ArrowStorage.h
@@ -163,6 +163,7 @@ class ArrowStorage : public SimpleSchemaProvider, public AbstractDataProvider {
     std::vector<std::shared_ptr<arrow::ChunkedArray>> col_data;
     std::vector<DataFragment> fragments;
     size_t row_count = 0;
+    TableStats table_stats;
   };
 
   struct DictionaryData {

--- a/omniscidb/DataMgr/ChunkMetadata.h
+++ b/omniscidb/DataMgr/ChunkMetadata.h
@@ -190,6 +190,11 @@ class ChunkMetadata {
     return chunk_stats_;
   }
 
+  // Check if there are pre-computed chunk stats available.
+  // chunkStats can be used in any case but it can trigger
+  // stats computation if there are no pre-computed stats.
+  bool hasComputedChunkStats() const { return !stats_materialize_fn_; }
+
 #ifndef __CUDACC__
   std::string dump() const {
     std::string res = "type: " + type_->toString() +

--- a/omniscidb/QueryEngine/InputMetadata.cpp
+++ b/omniscidb/QueryEngine/InputMetadata.cpp
@@ -22,11 +22,7 @@ InputTableInfoCache::InputTableInfoCache(Executor* executor) : executor_(executo
 namespace {
 
 TableFragmentsInfo copy_table_info(const TableFragmentsInfo& table_info) {
-  TableFragmentsInfo table_info_copy;
-  table_info_copy.chunkKeyPrefix = table_info.chunkKeyPrefix;
-  table_info_copy.fragments = table_info.fragments;
-  table_info_copy.setPhysicalNumTuples(table_info.getPhysicalNumTuples());
-  return table_info_copy;
+  return table_info;
 }
 
 }  // namespace

--- a/omniscidb/ResultSetRegistry/ResultSetRegistry.h
+++ b/omniscidb/ResultSetRegistry/ResultSetRegistry.h
@@ -58,6 +58,8 @@ class ResultSetRegistry : public SimpleSchemaProvider,
 
  private:
   ChunkStats getChunkStats(int table_id, size_t frag_idx, size_t col_idx) const;
+  TableStats getTableStats(int table_id) const;
+  TableStats buildTableStatsNoLock(int table_id) const;
 
   struct DataFragment {
     size_t offset = 0;
@@ -74,6 +76,7 @@ class ResultSetRegistry : public SimpleSchemaProvider,
     size_t row_count;
     bool use_columnar_res;
     bool has_varlen_col;
+    TableStats table_stats;
   };
 
   const int db_id_;

--- a/omniscidb/Tests/TestDataProvider.h
+++ b/omniscidb/Tests/TestDataProvider.h
@@ -86,6 +86,14 @@ class TestTableData {
 
     auto& frag_info = info_.fragments[data_[col_id - 1].size() - 1];
     frag_info.setChunkMetadata(col_id, chunk_meta);
+
+    if (table_stats_.count(col_id)) {
+      mergeStats(
+          table_stats_.at(col_id), chunk_meta->chunkStats(), col_types_.at(col_id));
+    } else {
+      table_stats_.emplace(col_id, chunk_meta->chunkStats());
+    }
+    info_.setTableStats(table_stats_);
   }
 
   void fetchData(int col_id, int frag_id, int8_t* dst, size_t size) {
@@ -102,6 +110,7 @@ class TestTableData {
   TableRef ref_;
   std::vector<std::vector<std::vector<int8_t>>> data_;
   TableFragmentsInfo info_;
+  TableStats table_stats_;
   std::unordered_map<int, const hdk::ir::Type*> col_types_;
 };
 


### PR DESCRIPTION
Chunks metadata is used at every work unit execution and in many cases stats are used. But the main reason for stats usage is range info requests for column references. And to compute the range we simply merge all chunk stats.

This patch introduces TableStats which can be used for column range info computation. While table stats originally are computed using chunk stats, we might avoid it in some cases by propagating input table stats to the resulting table. E. g. simple projection, sort, and shuffle do not modify table stats and therefore stats can be simply assigned to the result. This way we can avoid chunk stats computations that are directly used only to skip fragments during filter execution.

This PR only introduces new stats and doesn't utilize them yet. It also adds checks to ExpressionRange computation to make sure that new stats provide us with the same range as existing ones. There will be another PR to stop using chunk stats in range computations and propagate table stats through shuffling to avoid stats computation for partitioned data.