### PR TITLE
Avoid direct access to ResultSet in PyHDK

### DIFF
--- a/omniscidb/ResultSetRegistry/ResultSetTableToken.cpp
+++ b/omniscidb/ResultSetRegistry/ResultSetTableToken.cpp
@@ -67,6 +67,19 @@ std::shared_ptr<arrow::Table> ResultSetTableToken::toArrow() const {
   return res;
 }
 
+std::vector<TargetValue> ResultSetTableToken::row(size_t row_idx,
+                                                  bool translate_strings,
+                                                  bool decimal_to_double) const {
+  for (size_t rs_idx = 0; rs_idx < resultSetCount(); ++rs_idx) {
+    auto rs = resultSet(rs_idx);
+    if (rs->rowCount() > row_idx) {
+      return rs->getRowAt(row_idx, translate_strings, decimal_to_double);
+    }
+    row_idx -= rs->rowCount();
+  }
+  throw std::runtime_error("Out-of-bound row index.");
+}
+
 std::string ResultSetTableToken::description() const {
   auto first_rs = resultSet(0);
   auto last_rs = resultSet(resultSetCount() - 1);

--- a/omniscidb/ResultSetRegistry/ResultSetTableToken.h
+++ b/omniscidb/ResultSetRegistry/ResultSetTableToken.h
@@ -64,6 +64,10 @@ class ResultSetTableToken : public std::enable_shared_from_this<ResultSetTableTo
            std::to_string(tableId()) + ")";
   }
 
+  std::string description() const;
+  std::string memoryDescription() const;
+  std::string contentToString(bool header) const;
+
  private:
   void reset();
 

--- a/omniscidb/ResultSetRegistry/ResultSetTableToken.h
+++ b/omniscidb/ResultSetRegistry/ResultSetTableToken.h
@@ -59,6 +59,10 @@ class ResultSetTableToken : public std::enable_shared_from_this<ResultSetTableTo
 
   std::shared_ptr<arrow::Table> toArrow() const;
 
+  std::vector<TargetValue> row(size_t row_idx,
+                               bool translate_strings,
+                               bool decimal_to_double) const;
+
   std::string toString() const {
     return "ResultSetTableToken(" + std::to_string(dbId()) + ":" +
            std::to_string(tableId()) + ")";

--- a/python/pyhdk/_sql.pxd
+++ b/python/pyhdk/_sql.pxd
@@ -12,7 +12,7 @@ from pyarrow.lib cimport CTable as CArrowTable
 
 from pyhdk._common cimport CConfig, CType
 from pyhdk._storage cimport CSchemaProvider, CSchemaProviderPtr, CDataProvider, CDataMgr, CBufferProvider
-from pyhdk._execute cimport CExecutor, CResultSetPtr, CCompilationOptions, CExecutionOptions, CTargetMetaInfo
+from pyhdk._execute cimport CExecutor, CResultSetPtr, CCompilationOptions, CExecutionOptions, CTargetMetaInfo, CTargetValue
 
 cdef extern from "omniscidb/QueryEngine/ExtensionFunctionsWhitelist.h":
   cdef cppclass CExtensionFunction "ExtensionFunction":
@@ -60,6 +60,8 @@ cdef extern from "omniscidb/ResultSetRegistry/ResultSetTableToken.h":
     string memoryDescription()
     string contentToString(bool)
 
+    vector[CTargetValue] row(size_t, bool, bool) except +
+
 ctypedef shared_ptr[const CResultSetTableToken] CResultSetTableTokenPtr
 
 cdef extern from "omniscidb/QueryEngine/Descriptors/RelAlgExecutionDescriptor.h":
@@ -68,7 +70,6 @@ cdef extern from "omniscidb/QueryEngine/Descriptors/RelAlgExecutionDescriptor.h"
     CExecutionResult(const CExecutionResult&)
     CExecutionResult(CExecutionResult&&)
 
-    const CResultSetPtr& getRows()
     const vector[CTargetMetaInfo]& getTargetsMeta()
     string getExplanation()
     const string& tableName()

--- a/python/pyhdk/_sql.pxd
+++ b/python/pyhdk/_sql.pxd
@@ -56,6 +56,9 @@ cdef extern from "omniscidb/ResultSetRegistry/ResultSetTableToken.h":
   cdef cppclass CResultSetTableToken "hdk::ResultSetTableToken":
     size_t rowCount()
     shared_ptr[CArrowTable] toArrow() except +
+    string description()
+    string memoryDescription()
+    string contentToString(bool)
 
 ctypedef shared_ptr[const CResultSetTableToken] CResultSetTableTokenPtr
 

--- a/python/pyhdk/_sql.pyx
+++ b/python/pyhdk/_sql.pyx
@@ -87,11 +87,13 @@ cdef class ExecutionResult:
 
   @property
   def desc(self):
-    return self.c_result.getRows().get().summaryToString()
+    cdef CResultSetTableTokenPtr c_token = self.c_result.getToken()
+    return c_token.get().description()
 
   @property
   def memory_desc(self):
-    return self.c_result.getRows().get().toString()
+    cdef CResultSetTableTokenPtr c_token = self.c_result.getToken()
+    return c_token.get().memoryDescription()
 
   @property
   def table_name(self):
@@ -152,7 +154,7 @@ cdef class ExecutionResult:
     for key, type_str in self.schema.items():
       res += f"  {key}: {type_str}\n"
     res += "Data:\n"
-    res += self.c_result.getRows().get().contentToString(False)
+    res += self.c_result.getToken().get().contentToString(False)
     return res
 
   def __repr__(self):

--- a/python/pyhdk/_sql.pyx
+++ b/python/pyhdk/_sql.pyx
@@ -109,7 +109,7 @@ cdef class ExecutionResult:
 
   def row(self, row_id):
     res = []
-    cdef vector[CTargetValue] vals = self.c_result.getRows().get().getRowAt(row_id, True, True)
+    cdef vector[CTargetValue] vals = self.c_result.getToken().get().row(row_id, True, True)
     cdef vector[CTargetValue].const_iterator it = vals.const_begin()
     cdef const CScalarTargetValue *scalar
     cdef const CArrayTargetValue *array


### PR DESCRIPTION
This completely removes ExecutionResult::getRows usage from PyHDK to support all APIs for multi-fragment results we get from the partitioned aggregation.