### PR TITLE
Add common GPU runtime

### DIFF
--- a/omniscidb/DataMgr/DataMgr.cpp
+++ b/omniscidb/DataMgr/DataMgr.cpp
@@ -505,15 +505,6 @@ void DataMgr::copy(AbstractBuffer* destBuffer, AbstractBuffer* srcBuffer) {
 // size_t numBytes, const size_t destOffset, const size_t srcOffset) {
 //} /
 
-void DataMgr::setTableEpoch(const int db_id, const int tb_id, const int start_epoch) {
-  UNREACHABLE();
-}
-
-size_t DataMgr::getTableEpoch(const int db_id, const int tb_id) {
-  UNREACHABLE();
-  return 0;
-}
-
 std::ostream& operator<<(std::ostream& os, const DataMgr::SystemMemoryUsage& mem_info) {
   os << "jsonlog ";
   os << "{";
@@ -531,11 +522,6 @@ std::ostream& operator<<(std::ostream& os, const DataMgr::SystemMemoryUsage& mem
 
 PersistentStorageMgr* DataMgr::getPersistentStorageMgr() const {
   return dynamic_cast<PersistentStorageMgr*>(bufferMgrs_[MemoryLevel::DISK_LEVEL][0]);
-}
-
-Buffer_Namespace::CpuBufferMgr* DataMgr::getCpuBufferMgr() const {
-  return dynamic_cast<Buffer_Namespace::CpuBufferMgr*>(
-      bufferMgrs_[MemoryLevel::CPU_LEVEL][0]);
 }
 
 const DictDescriptor* DataMgr::getDictMetadata(int dict_id, bool load_dict) const {

--- a/omniscidb/DataMgr/DataMgr.h
+++ b/omniscidb/DataMgr/DataMgr.h
@@ -196,8 +196,6 @@ class DataMgr {
   void getChunkMetadataVecForKeyPrefix(ChunkMetadataVector& chunkMetadataVec,
                                        const ChunkKey& keyPrefix);
   inline bool gpusPresent() const { return has_gpus_; }
-  void setTableEpoch(const int db_id, const int tb_id, const int start_epoch);
-  size_t getTableEpoch(const int db_id, const int tb_id);
 
   void setGpuMgrContext(GpuMgrPlatform name);
 
@@ -221,9 +219,6 @@ class DataMgr {
   static size_t getTotalSystemMemory();
 
   PersistentStorageMgr* getPersistentStorageMgr() const;
-
-  // Used for testing.
-  Buffer_Namespace::CpuBufferMgr* getCpuBufferMgr() const;
 
   const DictDescriptor* getDictMetadata(int dict_id, bool load_dict = true) const;
 

--- a/omniscidb/QueryEngine/CMakeLists.txt
+++ b/omniscidb/QueryEngine/CMakeLists.txt
@@ -172,7 +172,7 @@ add_dependencies(QueryEngine QueryEngineFunctionsTargets)
 
 set(cpu_runtime_function_sources RuntimeFunctions.cpp DateAdd.cpp DateTruncate.cpp)
 set(intel_gpu_runtime_function_sources l0_mapd_rt.cpp DateAdd.cpp DateTruncate.cpp)
-set(intel_gpu_helpers_sources genx.cpp)
+set(intel_gpu_helpers_sources Compiler/genx.cpp)
 
 
 set(hdk_default_runtime_functions_module_dependencies
@@ -250,13 +250,13 @@ link_runtime_module(${cpu_module_name} "${cpu_precompiled_module_list}")
 # SPIRV helper functions & intrinsics
 set(spirv_helper_functions_module genx_impl.bc)
 add_custom_command(
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Compiler/genx.ll
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${intel_gpu_helpers_sources} ${CMAKE_CURRENT_SOURCE_DIR}/Compiler/genx.ll Compiler/CommonGpuRuntime.cpp
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${spirv_helper_functions_module}
     COMMAND ${llvm_as_cmd} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/Compiler/genx.ll -o ${CMAKE_CURRENT_BINARY_DIR}/${spirv_helper_functions_module}
 )
 
 set(spirv_runtime_module genx.bc)
-precompile_modules("genx_mod_lst" ${intel_gpu_module_internal_suffix} ${precompile_intel_gpu_module_cmd} Compiler/genx.cpp)
+precompile_modules("genx_mod_lst" ${intel_gpu_module_internal_suffix} ${precompile_intel_gpu_module_cmd} ${intel_gpu_helpers_sources})
 list(APPEND genx_mod_lst ${spirv_helper_functions_module})
 link_runtime_module(${spirv_runtime_module} "${genx_mod_lst}")
 
@@ -335,6 +335,7 @@ add_custom_command(
             TopKRuntime.cpp 
             StringFunctions.cpp
             RegexpFunctions.cpp
+            Compiler/CommonGpuRuntime.cpp
             ../Utils/ChunkIter.cpp
             ../Utils/StringLike.cpp
             ../Utils/Regexp.cpp

--- a/omniscidb/QueryEngine/Compiler/CommonGpuRuntime.cpp
+++ b/omniscidb/QueryEngine/Compiler/CommonGpuRuntime.cpp
@@ -1,0 +1,67 @@
+/**
+ * Copyright (C) 2023 Intel Corporation
+ * Copyright 2017 MapD Technologies, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <cstdint>
+
+#include "Shared/funcannotations.h"
+
+extern "C" {
+#define DEF_AGG_ID_INT_SHARED(n)                                         \
+  DEVICE void agg_id_int##n##_shared(GENERIC_ADDR_SPACE int##n##_t* agg, \
+                                     const int##n##_t val) {             \
+    *agg = val;                                                          \
+  }
+
+DEF_AGG_ID_INT_SHARED(32)
+DEF_AGG_ID_INT_SHARED(16)
+DEF_AGG_ID_INT_SHARED(8)
+
+#undef DEF_AGG_ID_INT_SHARED
+
+DEVICE void agg_id_shared(GENERIC_ADDR_SPACE int64_t* agg, const int64_t val) {
+  *agg = val;
+}
+
+DEVICE GENERIC_ADDR_SPACE int8_t* agg_id_varlen_shared(
+    GENERIC_ADDR_SPACE int8_t* varlen_buffer,
+    const int64_t offset,
+    const GENERIC_ADDR_SPACE int8_t* value,
+    const int64_t size_bytes) {
+  for (auto i = 0; i < size_bytes; i++) {
+    varlen_buffer[offset + i] = value[i];
+  }
+  return &varlen_buffer[offset];
+}
+
+DEVICE void agg_count_distinct_bitmap_gpu(GENERIC_ADDR_SPACE int64_t* agg,
+                                          const int64_t val,
+                                          const int64_t min_val,
+                                          const int64_t base_dev_addr,
+                                          const int64_t base_host_addr,
+                                          const uint64_t sub_bitmap_count,
+                                          const uint64_t bitmap_bytes);
+
+DEVICE void agg_count_distinct_bitmap_skip_val_gpu(GENERIC_ADDR_SPACE int64_t* agg,
+                                                   const int64_t val,
+                                                   const int64_t min_val,
+                                                   const int64_t skip_val,
+                                                   const int64_t base_dev_addr,
+                                                   const int64_t base_host_addr,
+                                                   const uint64_t sub_bitmap_count,
+                                                   const uint64_t bitmap_bytes) {
+  if (val != skip_val) {
+    agg_count_distinct_bitmap_gpu(
+        agg, val, min_val, base_dev_addr, base_host_addr, sub_bitmap_count, bitmap_bytes);
+  }
+}
+
+DEVICE const GENERIC_ADDR_SPACE int64_t* init_shared_mem_nop(
+    const GENERIC_ADDR_SPACE int64_t* groups_buffer,
+    const int32_t groups_buffer_size) {
+  return groups_buffer;
+}
+}

--- a/omniscidb/QueryEngine/Compiler/genx.cpp
+++ b/omniscidb/QueryEngine/Compiler/genx.cpp
@@ -10,6 +10,8 @@
 #include "Shared/funcannotations.h"
 
 extern "C" {
+int64_t get_thread_index();
+
 int64_t atomic_cas_int_64(GENERIC_ADDR_SPACE int64_t*, int64_t, int64_t);
 int32_t atomic_cas_int_32(GENERIC_ADDR_SPACE int32_t*, int32_t, int32_t);
 int64_t atomic_xchg_int_64(GENERIC_ADDR_SPACE int64_t*, int64_t);
@@ -41,6 +43,10 @@ DEF_AGG_ID_INT_SHARED(16)
 DEF_AGG_ID_INT_SHARED(8)
 
 #undef DEF_AGG_ID_INT_SHARED
+
+void agg_id_shared(GENERIC_ADDR_SPACE int64_t* agg, const int64_t val) {
+  *agg = val;
+}
 
 void agg_id_float_shared(GENERIC_ADDR_SPACE int32_t* agg, const float val) {
   *reinterpret_cast<GENERIC_ADDR_SPACE float*>(agg) = val;

--- a/omniscidb/QueryEngine/Compiler/genx.cpp
+++ b/omniscidb/QueryEngine/Compiler/genx.cpp
@@ -10,8 +10,6 @@
 #include "Shared/funcannotations.h"
 
 extern "C" {
-int64_t get_thread_index();
-
 int64_t atomic_cas_int_64(GENERIC_ADDR_SPACE int64_t*, int64_t, int64_t);
 int32_t atomic_cas_int_32(GENERIC_ADDR_SPACE int32_t*, int32_t, int32_t);
 int64_t atomic_xchg_int_64(GENERIC_ADDR_SPACE int64_t*, int64_t);
@@ -25,28 +23,7 @@ void agg_max_shared(GENERIC_ADDR_SPACE int64_t* agg, const int64_t val);
 int64_t agg_count_shared(GENERIC_ADDR_SPACE int64_t* agg, const int64_t val);
 uint32_t agg_count_int32_shared(GENERIC_ADDR_SPACE uint32_t* agg, const int32_t val);
 
-const GENERIC_ADDR_SPACE int64_t* init_shared_mem_nop(
-    const GENERIC_ADDR_SPACE int64_t* groups_buffer,
-    const int32_t groups_buffer_size) {
-  return groups_buffer;
-}
-
-// TODO: these are almost the same in cuda, move to a single source
-#define DEF_AGG_ID_INT_SHARED(n)                                             \
-  extern "C" void agg_id_int##n##_shared(GENERIC_ADDR_SPACE int##n##_t* agg, \
-                                         const int##n##_t val) {             \
-    *agg = val;                                                              \
-  }
-
-DEF_AGG_ID_INT_SHARED(32)
-DEF_AGG_ID_INT_SHARED(16)
-DEF_AGG_ID_INT_SHARED(8)
-
-#undef DEF_AGG_ID_INT_SHARED
-
-void agg_id_shared(GENERIC_ADDR_SPACE int64_t* agg, const int64_t val) {
-  *agg = val;
-}
+#include "CommonGpuRuntime.cpp"
 
 void agg_id_float_shared(GENERIC_ADDR_SPACE int32_t* agg, const float val) {
   *reinterpret_cast<GENERIC_ADDR_SPACE float*>(agg) = val;

--- a/omniscidb/QueryEngine/Compiler/genx.ll
+++ b/omniscidb/QueryEngine/Compiler/genx.ll
@@ -25,7 +25,7 @@ define void @sync_threadblock() {
     ret void
 }
 
-define i32 @pos_start_impl(i32* %0)  readnone nounwind alwaysinline {
+define i32 @pos_start_impl(i32 addrspace(4)* %0)  readnone nounwind alwaysinline {
     %gid = call i64 @__spirv_BuiltInWorkgroupId(i32 0)
     %gsize = call i64 @__spirv_BuiltInWorkgroupSize(i32 0)
     %tid = call i64 @__spirv_BuiltInLocalInvocationId(i32 0)
@@ -161,24 +161,18 @@ define void @agg_sum_double_skip_val_shared(i64 addrspace(4)* %agg, double nound
     ret void
 }
 
-
-define i64 @agg_sum_skip_val_shared(i64* %agg, i64 noundef %val, i64 noundef %skip_val) {
+define i64 @agg_sum_skip_val_shared(i64 addrspace(4)* %agg, i64 noundef %val, i64 noundef %skip_val) {
     %no_skip = icmp ne i64 %val, %skip_val
     br i1 %no_skip, label %.noskip, label %.skip
 .noskip:
-    %old = atomicrmw xchg i64* %agg, i64 0 monotonic
+    %old = atomicrmw xchg i64 addrspace(4)* %agg, i64 0 monotonic
     %isempty = icmp eq i64 %old, -9223372036854775808
     %sel = select i1 %isempty, i64 0, i64 %old
     %new_val = add nsw i64 %val, %sel
-    %old2 = atomicrmw add i64* %agg, i64 %new_val monotonic
+    %old2 = atomicrmw add i64 addrspace(4)* %agg, i64 %new_val monotonic
     ret i64 %old2
 .skip:
     ret i64 0
-}
-
-define void @agg_id_shared(i64* %agg, i64 noundef %val) {
-    store i64 %val, i64* %agg
-    ret void
 }
 
 define void @atomic_or(i32 addrspace(4)* %addr, i32 noundef %val) {
@@ -275,7 +269,7 @@ define double @atomic_max_double(double addrspace(4)* %addr, double noundef %val
 }
 
 
-define void @agg_count_distinct_bitmap_gpu(i64* %agg, i64 noundef %val, i64 noundef %min_val, i64 noundef %base_dev_addr, i64 noundef %base_host_addr, i64 noundef %sub_bitmap_count, i64 noundef %bitmap_bytes) {
+define void @agg_count_distinct_bitmap_gpu(i64 addrspace(4)* %agg, i64 noundef %val, i64 noundef %min_val, i64 noundef %base_dev_addr, i64 noundef %base_host_addr, i64 noundef %sub_bitmap_count, i64 noundef %bitmap_bytes) {
     %bitmap_idx = sub nsw i64 %val, %min_val
     %bitmap_idx.i32 = trunc i64 %bitmap_idx to i32
     %byte_idx.i64 = lshr i64 %bitmap_idx, 3
@@ -283,7 +277,7 @@ define void @agg_count_distinct_bitmap_gpu(i64* %agg, i64 noundef %val, i64 noun
     %word_idx = lshr i32 %byte_idx, 2
     %word_idx.i64 = zext i32 %word_idx to i64
     %byte_word_idx = and i32 %byte_idx, 3
-    %host_addr = load i64, i64* %agg
+    %host_addr = load i64, i64 addrspace(4)* %agg
     %sub_bm_m1 = sub i64 %sub_bitmap_count, 1
     %tid = call i64 @get_thread_index()
     %sub_tid = and i64 %sub_bm_m1, %tid
@@ -366,11 +360,11 @@ define void @write_back_non_grouped_agg(i64 addrspace(4)* %input_buffer, i64 add
     ret void
 }
 
-define void @agg_count_distinct_bitmap_skip_val_gpu(i64* %agg, i64 noundef %val, i64 noundef %min_val, i64 noundef %skip_val, i64 noundef %base_dev_addr, i64 noundef %base_host_addr, i64 noundef %sub_bitmap_count, i64 noundef %bitmap_bytes) {
+define void @agg_count_distinct_bitmap_skip_val_gpu(i64 addrspace(4)* %agg, i64 noundef %val, i64 noundef %min_val, i64 noundef %skip_val, i64 noundef %base_dev_addr, i64 noundef %base_host_addr, i64 noundef %sub_bitmap_count, i64 noundef %bitmap_bytes) {
  %no_skip = icmp ne i64 %val, %skip_val
     br i1 %no_skip, label %.noskip, label %.skip
 .noskip:
-    call void @agg_count_distinct_bitmap_gpu(i64* %agg, i64 noundef %val, i64 noundef %min_val, i64 noundef %base_dev_addr, i64 noundef %base_host_addr, i64 noundef %sub_bitmap_count, i64 noundef %bitmap_bytes)
+    call void @agg_count_distinct_bitmap_gpu(i64 addrspace(4)* %agg, i64 noundef %val, i64 noundef %min_val, i64 noundef %base_dev_addr, i64 noundef %base_host_addr, i64 noundef %sub_bitmap_count, i64 noundef %bitmap_bytes)
     br label %.skip
 .skip:
     ret void
@@ -414,8 +408,8 @@ define void @agg_max_skip_val_shared(i64 addrspace(4)* %agg, i64 noundef %val, i
     ret void
 }
 
-define void @agg_min_shared(i64* %agg, i64 noundef %val) {
-    %old = atomicrmw min i64* %agg, i64 %val acq_rel
+define void @agg_min_shared(i64 addrspace(4)* %agg, i64 noundef %val) {
+    %old = atomicrmw min i64 addrspace(4)* %agg, i64 %val acq_rel
     ret void
 }
 

--- a/omniscidb/QueryEngine/Compiler/genx.ll
+++ b/omniscidb/QueryEngine/Compiler/genx.ll
@@ -360,17 +360,6 @@ define void @write_back_non_grouped_agg(i64 addrspace(4)* %input_buffer, i64 add
     ret void
 }
 
-define void @agg_count_distinct_bitmap_skip_val_gpu(i64 addrspace(4)* %agg, i64 noundef %val, i64 noundef %min_val, i64 noundef %skip_val, i64 noundef %base_dev_addr, i64 noundef %base_host_addr, i64 noundef %sub_bitmap_count, i64 noundef %bitmap_bytes) {
- %no_skip = icmp ne i64 %val, %skip_val
-    br i1 %no_skip, label %.noskip, label %.skip
-.noskip:
-    call void @agg_count_distinct_bitmap_gpu(i64 addrspace(4)* %agg, i64 noundef %val, i64 noundef %min_val, i64 noundef %base_dev_addr, i64 noundef %base_host_addr, i64 noundef %sub_bitmap_count, i64 noundef %bitmap_bytes)
-    br label %.skip
-.skip:
-    ret void
-}
-
-
 define i64 @atomic_cas_int_64(i64 addrspace(4)* %p, i64 %cmp, i64 %val) {
     %val_success = cmpxchg i64 addrspace(4)* %p, i64 %cmp, i64 %val acq_rel monotonic
     %old = extractvalue {i64, i1} %val_success, 0

--- a/omniscidb/QueryEngine/cuda_mapd_rt.cu
+++ b/omniscidb/QueryEngine/cuda_mapd_rt.cu
@@ -40,12 +40,6 @@ extern "C" __device__ int8_t thread_warp_idx(const int8_t warp_sz) {
   return threadIdx.x % warp_sz;
 }
 
-extern "C" __device__ const int64_t* init_shared_mem_nop(
-    const int64_t* groups_buffer,
-    const int32_t groups_buffer_size) {
-  return groups_buffer;
-}
-
 extern "C" __device__ void write_back_nop(int64_t* dest, int64_t* src, const int32_t sz) {
 }
 
@@ -673,20 +667,6 @@ extern "C" __device__ void agg_min_float_shared(int32_t* agg, const float val) {
   atomicMin(reinterpret_cast<float*>(agg), val);
 }
 
-extern "C" __device__ void agg_id_shared(int64_t* agg, const int64_t val) {
-  *agg = val;
-}
-
-extern "C" __device__ int8_t* agg_id_varlen_shared(int8_t* varlen_buffer,
-                                                   const int64_t offset,
-                                                   const int8_t* value,
-                                                   const int64_t size_bytes) {
-  for (auto i = 0; i < size_bytes; i++) {
-    varlen_buffer[offset + i] = value[i];
-  }
-  return &varlen_buffer[offset];
-}
-
 extern "C" __device__ int32_t checked_single_agg_id_shared(int64_t* agg,
                                                            const int64_t val,
                                                            const int64_t null_val) {
@@ -714,17 +694,7 @@ extern "C" __device__ int32_t checked_single_agg_id_shared(int64_t* agg,
   return 0;
 }
 
-#define DEF_AGG_ID_INT_SHARED(n)                                            \
-  extern "C" __device__ void agg_id_int##n##_shared(int##n##_t* agg,        \
-                                                    const int##n##_t val) { \
-    *agg = val;                                                             \
-  }
-
-DEF_AGG_ID_INT_SHARED(32)
-DEF_AGG_ID_INT_SHARED(16)
-DEF_AGG_ID_INT_SHARED(8)
-
-#undef DEF_AGG_ID_INT_SHARED
+#include "Compiler/CommonGpuRuntime.cpp"
 
 extern "C" __device__ void agg_id_double_shared(int64_t* agg, const double val) {
   *agg = *(reinterpret_cast<const int64_t*>(&val));
@@ -1246,21 +1216,6 @@ extern "C" __device__ void agg_count_distinct_bitmap_gpu(int64_t* agg,
       break;
     default:
       break;
-  }
-}
-
-extern "C" __device__ void agg_count_distinct_bitmap_skip_val_gpu(
-    int64_t* agg,
-    const int64_t val,
-    const int64_t min_val,
-    const int64_t skip_val,
-    const int64_t base_dev_addr,
-    const int64_t base_host_addr,
-    const uint64_t sub_bitmap_count,
-    const uint64_t bitmap_bytes) {
-  if (val != skip_val) {
-    agg_count_distinct_bitmap_gpu(
-        agg, val, min_val, base_dev_addr, base_host_addr, sub_bitmap_count, bitmap_bytes);
   }
 }
 


### PR DESCRIPTION
Some of the GPU runtime functions are almost identical. This adds the common GPU runtime that is included in both CUDA and L0 to avoid duplication. More functions are expected to migrate to the common runtime over time. The patch also does some minor cleanup.