### PR TITLE
Fixup vectorized bitmap generator and add benchmark

### DIFF
--- a/omniscidb/ResultSet/BitmapGenerators.cpp
+++ b/omniscidb/ResultSet/BitmapGenerators.cpp
@@ -10,9 +10,14 @@
 
 #include <cstring>
 
-#ifdef __AVX512F__
-size_t __attribute__((target("avx512bw", "avx512f"), optimize("no-tree-vectorize")))
-gen_null_bitmap_8(uint8_t* dst, const uint8_t* src, size_t size, const uint8_t null_val) {
+#include <iostream>
+
+#ifndef _WIN32
+size_t __attribute__((target("avx512f", "avx512bw"), optimize("no-tree-vectorize")))
+gen_null_bitmap_8_impl(uint8_t* dst,
+                       const uint8_t* src,
+                       size_t size,
+                       const uint8_t null_val) {
   __m512i nulls_mask = _mm512_set1_epi8(reinterpret_cast<const int8_t&>(null_val));
 
   size_t null_count = 0;
@@ -35,11 +40,11 @@ gen_null_bitmap_8(uint8_t* dst, const uint8_t* src, size_t size, const uint8_t n
   return null_count;
 }
 
-size_t __attribute__((target("avx512bw", "avx512f"), optimize("no-tree-vectorize")))
-gen_null_bitmap_16(uint8_t* dst,
-                   const uint16_t* src,
-                   size_t size,
-                   const uint16_t null_val) {
+size_t __attribute__((target("avx512f", "avx512bw"), optimize("no-tree-vectorize")))
+gen_null_bitmap_16_impl(uint8_t* dst,
+                        const uint16_t* src,
+                        size_t size,
+                        const uint16_t null_val) {
   __m512i nulls_mask = _mm512_set1_epi16(reinterpret_cast<const int16_t&>(null_val));
 
   size_t null_count = 0;
@@ -62,11 +67,11 @@ gen_null_bitmap_16(uint8_t* dst,
   return null_count;
 }
 
-size_t __attribute__((target("avx512bw", "avx512f"), optimize("no-tree-vectorize")))
-gen_null_bitmap_32(uint8_t* dst,
-                   const uint32_t* src,
-                   size_t size,
-                   const uint32_t null_val) {
+size_t __attribute__((target("avx512f", "avx512bw"), optimize("no-tree-vectorize")))
+gen_null_bitmap_32_impl(uint8_t* dst,
+                        const uint32_t* src,
+                        size_t size,
+                        const uint32_t null_val) {
   __m512i nulls_mask = _mm512_set1_epi32(reinterpret_cast<const int32_t&>(null_val));
 
   size_t null_count = 0;
@@ -88,11 +93,11 @@ gen_null_bitmap_32(uint8_t* dst,
   return null_count;
 }
 
-size_t __attribute__((target("avx512bw", "avx512f"), optimize("no-tree-vectorize")))
-gen_null_bitmap_64(uint8_t* dst,
-                   const uint64_t* src,
-                   size_t size,
-                   const uint64_t null_val) {
+size_t __attribute__((target("avx512f", "avx512bw"), optimize("no-tree-vectorize")))
+gen_null_bitmap_64_impl(uint8_t* dst,
+                        const uint64_t* src,
+                        size_t size,
+                        const uint64_t null_val) {
   __m512i nulls_mask = _mm512_set1_epi64(reinterpret_cast<const int64_t&>(null_val));
 
   size_t null_count = 0;
@@ -142,35 +147,65 @@ size_t gen_null_bitmap_default(uint8_t* dst,
 }
 
 #if defined(_MSC_VER)
-#define DEFAULT_TARGET_ATTRIBUTE
+#define BITMAP_GEN_TARGET_ATTRS
 #else
-#define DEFAULT_TARGET_ATTRIBUTE __attribute__((target("default")))
+#define BITMAP_GEN_TARGET_ATTRS __attribute__((target("default")))
 #endif
 
-size_t DEFAULT_TARGET_ATTRIBUTE gen_null_bitmap_8(uint8_t* dst,
-                                                  const uint8_t* src,
-                                                  size_t size,
-                                                  const uint8_t null_val) {
+size_t BITMAP_GEN_TARGET_ATTRS gen_null_bitmap_8_impl(uint8_t* dst,
+                                                      const uint8_t* src,
+                                                      size_t size,
+                                                      const uint8_t null_val) {
+  // std::cout << "Using default impl " << std::endl;
   return gen_null_bitmap_default<uint8_t>(dst, src, size, null_val);
 }
 
-size_t DEFAULT_TARGET_ATTRIBUTE gen_null_bitmap_16(uint8_t* dst,
-                                                   const uint16_t* src,
-                                                   size_t size,
-                                                   const uint16_t null_val) {
+size_t BITMAP_GEN_TARGET_ATTRS gen_null_bitmap_16_impl(uint8_t* dst,
+                                                       const uint16_t* src,
+                                                       size_t size,
+                                                       const uint16_t null_val) {
   return gen_null_bitmap_default<uint16_t>(dst, src, size, null_val);
 }
 
-size_t DEFAULT_TARGET_ATTRIBUTE gen_null_bitmap_32(uint8_t* dst,
-                                                   const uint32_t* src,
-                                                   size_t size,
-                                                   const uint32_t null_val) {
+size_t BITMAP_GEN_TARGET_ATTRS gen_null_bitmap_32_impl(uint8_t* dst,
+                                                       const uint32_t* src,
+                                                       size_t size,
+                                                       const uint32_t null_val) {
   return gen_null_bitmap_default<uint32_t>(dst, src, size, null_val);
 }
 
-size_t DEFAULT_TARGET_ATTRIBUTE gen_null_bitmap_64(uint8_t* dst,
-                                                   const uint64_t* src,
-                                                   size_t size,
-                                                   const uint64_t null_val) {
+size_t BITMAP_GEN_TARGET_ATTRS gen_null_bitmap_64_impl(uint8_t* dst,
+                                                       const uint64_t* src,
+                                                       size_t size,
+                                                       const uint64_t null_val) {
   return gen_null_bitmap_default<uint64_t>(dst, src, size, null_val);
+}
+
+// dispatchers
+size_t gen_null_bitmap_8(uint8_t* dst,
+                         const uint8_t* src,
+                         size_t size,
+                         const uint8_t null_val) {
+  return gen_null_bitmap_8_impl(dst, src, size, null_val);
+}
+
+size_t gen_null_bitmap_16(uint8_t* dst,
+                          const uint16_t* src,
+                          size_t size,
+                          const uint16_t null_val) {
+  return gen_null_bitmap_16_impl(dst, src, size, null_val);
+}
+
+size_t gen_null_bitmap_32(uint8_t* dst,
+                          const uint32_t* src,
+                          size_t size,
+                          const uint32_t null_val) {
+  return gen_null_bitmap_32_impl(dst, src, size, null_val);
+}
+
+size_t gen_null_bitmap_64(uint8_t* dst,
+                          const uint64_t* src,
+                          size_t size,
+                          const uint64_t null_val) {
+  return gen_null_bitmap_64_impl(dst, src, size, null_val);
 }

--- a/omniscidb/ResultSet/BitmapGenerators.cpp
+++ b/omniscidb/ResultSet/BitmapGenerators.cpp
@@ -10,10 +10,15 @@
 
 #include <cstring>
 
-#include <iostream>
-
 #ifndef _WIN32
-size_t __attribute__((target("avx512f", "avx512bw"), optimize("no-tree-vectorize")))
+
+#if defined(__clang__)
+#define AVX512_TARGET target("avx512bw")
+#else
+#define AVX512_TARGET target("avx512f", "avx512bw")
+#endif
+
+size_t __attribute__((AVX512_TARGET, optimize("no-tree-vectorize")))
 gen_null_bitmap_8_impl(uint8_t* dst,
                        const uint8_t* src,
                        size_t size,
@@ -40,7 +45,7 @@ gen_null_bitmap_8_impl(uint8_t* dst,
   return null_count;
 }
 
-size_t __attribute__((target("avx512f", "avx512bw"), optimize("no-tree-vectorize")))
+size_t __attribute__((AVX512_TARGET, optimize("no-tree-vectorize")))
 gen_null_bitmap_16_impl(uint8_t* dst,
                         const uint16_t* src,
                         size_t size,
@@ -67,7 +72,7 @@ gen_null_bitmap_16_impl(uint8_t* dst,
   return null_count;
 }
 
-size_t __attribute__((target("avx512f", "avx512bw"), optimize("no-tree-vectorize")))
+size_t __attribute__((AVX512_TARGET, optimize("no-tree-vectorize")))
 gen_null_bitmap_32_impl(uint8_t* dst,
                         const uint32_t* src,
                         size_t size,
@@ -93,7 +98,7 @@ gen_null_bitmap_32_impl(uint8_t* dst,
   return null_count;
 }
 
-size_t __attribute__((target("avx512f", "avx512bw"), optimize("no-tree-vectorize")))
+size_t __attribute__((AVX512_TARGET, optimize("no-tree-vectorize")))
 gen_null_bitmap_64_impl(uint8_t* dst,
                         const uint64_t* src,
                         size_t size,
@@ -120,11 +125,15 @@ gen_null_bitmap_64_impl(uint8_t* dst,
 }
 #endif
 
+#if defined(_MSC_VER) || defined(__clang__)
+#define BITMAP_GEN_DEFAULT_TARGET_ATTRS
+#else
+#define BITMAP_GEN_DEFAULT_TARGET_ATTRS __attribute__((target_clones("bmi2", "default")))
+#endif
+
 template <typename TYPE>
-size_t gen_null_bitmap_default(uint8_t* dst,
-                               const TYPE* src,
-                               size_t size,
-                               const TYPE null_val) {
+size_t BITMAP_GEN_DEFAULT_TARGET_ATTRS
+gen_null_bitmap_default(uint8_t* dst, const TYPE* src, size_t size, const TYPE null_val) {
   size_t null_count = 0;
   TYPE loaded_data[8];
 
@@ -156,7 +165,6 @@ size_t BITMAP_GEN_TARGET_ATTRS gen_null_bitmap_8_impl(uint8_t* dst,
                                                       const uint8_t* src,
                                                       size_t size,
                                                       const uint8_t null_val) {
-  // std::cout << "Using default impl " << std::endl;
   return gen_null_bitmap_default<uint8_t>(dst, src, size, null_val);
 }
 

--- a/omniscidb/Tests/BitmapGeneratorBenchmark.cpp
+++ b/omniscidb/Tests/BitmapGeneratorBenchmark.cpp
@@ -45,8 +45,6 @@ static std::unique_ptr<T[]> gen_data(size_t size, const T null_val, float percen
   return data_buf;
 }
 
-#include <iostream>
-
 static auto alloc_bitmap(size_t input_sz) {
   // allocate extra space to ensure we can align
   size_t crt_sz = input_sz;
@@ -61,7 +59,6 @@ static auto alloc_bitmap(size_t input_sz) {
   return bitmap_buf_owned;
 }
 
-// TODO: get null count and verify
 static void null_bitmap_8(benchmark::State& state) {
   // generate a 4096 element buffer with 25% nulls (+ a few more since the null sentinel
   // will match the max size in the buffer)

--- a/omniscidb/Tests/BitmapGeneratorBenchmark.cpp
+++ b/omniscidb/Tests/BitmapGeneratorBenchmark.cpp
@@ -1,0 +1,165 @@
+/**
+ * Copyright 2023 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <benchmark/benchmark.h>
+#include <cstdlib>
+#include <memory>
+#include <random>
+#include <stdexcept>
+
+#include "Logger/Logger.h"
+#include "ResultSet/BitmapGenerators.h"
+
+size_t g_rand_seed = 42;
+
+// percent_nulls is the percentage of time the distribution returns true, expressed in
+// decimal form (e.g. / 100)
+template <typename T>
+static std::unique_ptr<T[]> gen_data(size_t size, const T null_val, float percent_nulls) {
+  auto data_buf = std::make_unique<T[]>(size);
+  auto data_buf_ptr = data_buf.get();
+
+  std::mt19937 rand_gen(g_rand_seed);
+  std::bernoulli_distribution dist(percent_nulls);
+  for (size_t i = 0; i < size; i++) {
+    if (dist(rand_gen)) {
+      data_buf_ptr[i] = null_val;
+    } else {
+      data_buf_ptr[i] = i % std::numeric_limits<T>::max();
+    }
+  }
+
+  return data_buf;
+}
+
+#include <iostream>
+
+static auto alloc_bitmap(size_t input_sz) {
+  // allocate extra space to ensure we can align
+  size_t crt_sz = input_sz;
+  constexpr size_t alignment = 64;
+  if (crt_sz % alignment != 0) {
+    crt_sz += (alignment - (crt_sz % alignment));
+  }
+
+  void* bitmap_buf_ptr = std::aligned_alloc(alignment, crt_sz);
+  auto bitmap_buf_owned = std::unique_ptr<char[], void (*)(char*)>(
+      reinterpret_cast<char*>(bitmap_buf_ptr), [](char* ptr) { std::free(ptr); });
+  return bitmap_buf_owned;
+}
+
+// TODO: get null count and verify
+static void null_bitmap_8(benchmark::State& state) {
+  // generate a 4096 element buffer with 25% nulls (+ a few more since the null sentinel
+  // will match the max size in the buffer)
+  const size_t num_elems = 4096;
+  auto data_buf = gen_data<uint8_t>(num_elems, std::numeric_limits<uint8_t>::max(), 0.25);
+  auto bitmap_ptr_owned = alloc_bitmap(ceil(num_elems / 8.));
+
+  auto initial_null_count =
+      gen_null_bitmap_8(reinterpret_cast<uint8_t*>(bitmap_ptr_owned.get()),
+                        data_buf.get(),
+                        num_elems,
+                        std::numeric_limits<uint8_t>::max());
+
+  for (auto _ : state) {
+    auto null_count =
+        gen_null_bitmap_8(reinterpret_cast<uint8_t*>(bitmap_ptr_owned.get()),
+                          data_buf.get(),
+                          num_elems,
+                          /*null_value=*/std::numeric_limits<uint8_t>::max());
+    CHECK_EQ(null_count, initial_null_count);  // ensure null counts match
+  }
+}
+
+static void null_bitmap_16(benchmark::State& state) {
+  // generate a 4096 element buffer with 25% nulls (+ a few more since the null sentinel
+  // will match the max size in the buffer)
+  const size_t num_elems = 4096;
+  auto data_buf =
+      gen_data<uint16_t>(num_elems, std::numeric_limits<uint16_t>::max(), 0.25);
+  auto bitmap_ptr_owned = alloc_bitmap(ceil(num_elems / 8.));
+
+  auto initial_null_count =
+      gen_null_bitmap_16(reinterpret_cast<uint8_t*>(bitmap_ptr_owned.get()),
+                         data_buf.get(),
+                         num_elems,
+                         /*null_value=*/std::numeric_limits<uint16_t>::max());
+
+  for (auto _ : state) {
+    auto null_count =
+        gen_null_bitmap_16(reinterpret_cast<uint8_t*>(bitmap_ptr_owned.get()),
+                           data_buf.get(),
+                           num_elems,
+                           /*null_value=*/std::numeric_limits<uint16_t>::max());
+    CHECK_EQ(null_count, initial_null_count);  // ensure null counts match
+  }
+}
+
+static void null_bitmap_32(benchmark::State& state) {
+  // generate a 4096 element buffer with 25% nulls (+ a few more since the null sentinel
+  // will match the max size in the buffer)
+  const size_t num_elems = 4096;
+  auto data_buf =
+      gen_data<uint32_t>(num_elems, std::numeric_limits<uint32_t>::max(), 0.25);
+  auto bitmap_ptr_owned = alloc_bitmap(ceil(num_elems / 8.));
+
+  auto initial_null_count =
+      gen_null_bitmap_32(reinterpret_cast<uint8_t*>(bitmap_ptr_owned.get()),
+                         data_buf.get(),
+                         num_elems,
+                         /*null_value=*/std::numeric_limits<uint32_t>::max());
+
+  for (auto _ : state) {
+    auto null_count =
+        gen_null_bitmap_32(reinterpret_cast<uint8_t*>(bitmap_ptr_owned.get()),
+                           data_buf.get(),
+                           num_elems,
+                           /*null_value=*/std::numeric_limits<uint32_t>::max());
+    CHECK_EQ(null_count, initial_null_count);  // ensure null counts match
+  }
+}
+
+static void null_bitmap_64(benchmark::State& state) {
+  // generate a 4096 element buffer with 25% nulls (+ a few more since the null sentinel
+  // will match the max size in the buffer)
+  const size_t num_elems = 4096;
+  auto data_buf =
+      gen_data<uint64_t>(num_elems, std::numeric_limits<uint64_t>::max(), 0.25);
+  auto bitmap_ptr_owned = alloc_bitmap(ceil(num_elems / 8.));
+
+  auto initial_null_count =
+      gen_null_bitmap_64(reinterpret_cast<uint8_t*>(bitmap_ptr_owned.get()),
+                         data_buf.get(),
+                         num_elems,
+                         /*null_value=*/std::numeric_limits<uint64_t>::max());
+
+  for (auto _ : state) {
+    auto null_count =
+        gen_null_bitmap_64(reinterpret_cast<uint8_t*>(bitmap_ptr_owned.get()),
+                           data_buf.get(),
+                           num_elems,
+                           /*null_value=*/std::numeric_limits<uint64_t>::max());
+    CHECK_EQ(null_count, initial_null_count);  // ensure null counts match
+  }
+}
+
+BENCHMARK(null_bitmap_8);
+BENCHMARK(null_bitmap_16);
+BENCHMARK(null_bitmap_32);
+BENCHMARK(null_bitmap_64);
+
+BENCHMARK_MAIN();

--- a/omniscidb/Tests/CMakeLists.txt
+++ b/omniscidb/Tests/CMakeLists.txt
@@ -58,6 +58,7 @@ endif()
 
 # Tests + Microbenchmarks
 add_executable(StringDictionaryBenchmark StringDictionaryBenchmark.cpp)
+add_executable(BitmapGeneratorBenchmark BitmapGeneratorBenchmark.cpp ../ResultSet/BitmapGenerators.cpp)
 
 if(ENABLE_L0)
   add_executable(L0MgrExecuteTest L0MgrExecuteTest.cpp)
@@ -133,6 +134,8 @@ if(ENABLE_FOLLY)
 else()
   target_link_libraries(StringDictionaryBenchmark benchmark gtest StringDictionary Logger Utils $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:stdc++fs> ${CMAKE_DL_LIBS} ${Boost_LIBRARIES} ${ZLIB_LIBRARIES})
 endif()
+
+target_link_libraries(BitmapGeneratorBenchmark benchmark)
 
 if(ENABLE_CUDA)
   target_link_libraries(GpuSharedMemoryTest gtest Logger QueryEngine)

--- a/omniscidb/Tests/CMakeLists.txt
+++ b/omniscidb/Tests/CMakeLists.txt
@@ -58,7 +58,8 @@ endif()
 
 # Tests + Microbenchmarks
 add_executable(StringDictionaryBenchmark StringDictionaryBenchmark.cpp)
-add_executable(BitmapGeneratorBenchmark BitmapGeneratorBenchmark.cpp ../ResultSet/BitmapGenerators.cpp)
+add_executable(BitmapGeneratorBenchmark BitmapGeneratorBenchmark.cpp)
+target_link_libraries(BitmapGeneratorBenchmark ResultSet)
 
 if(ENABLE_L0)
   add_executable(L0MgrExecuteTest L0MgrExecuteTest.cpp)

--- a/omniscidb/Tests/CMakeLists.txt
+++ b/omniscidb/Tests/CMakeLists.txt
@@ -58,8 +58,11 @@ endif()
 
 # Tests + Microbenchmarks
 add_executable(StringDictionaryBenchmark StringDictionaryBenchmark.cpp)
-add_executable(BitmapGeneratorBenchmark BitmapGeneratorBenchmark.cpp)
-target_link_libraries(BitmapGeneratorBenchmark ResultSet)
+if (NOT WIN32)
+  # aligned_alloc is missing on windows 
+  add_executable(BitmapGeneratorBenchmark BitmapGeneratorBenchmark.cpp)
+  target_link_libraries(BitmapGeneratorBenchmark ResultSet benchmark)
+endif()
 
 if(ENABLE_L0)
   add_executable(L0MgrExecuteTest L0MgrExecuteTest.cpp)
@@ -135,8 +138,6 @@ if(ENABLE_FOLLY)
 else()
   target_link_libraries(StringDictionaryBenchmark benchmark gtest StringDictionary Logger Utils $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:stdc++fs> ${CMAKE_DL_LIBS} ${Boost_LIBRARIES} ${ZLIB_LIBRARIES})
 endif()
-
-target_link_libraries(BitmapGeneratorBenchmark benchmark)
 
 if(ENABLE_CUDA)
   target_link_libraries(GpuSharedMemoryTest gtest Logger QueryEngine)


### PR DESCRIPTION
A few fixes necessary: 
- added required compiler flags to generate code for AVX-512 extensions to CMake
- moved the implementation of the bitmap generators into local functions, facilitating appropriate dispatch (avx512 vs non-avx512)
- removed unnecessary `avx512f` target - `avx512bw` is required to support `_mm512_cmpneq_epi8_mask`.
- added a small microbenchmark 

Closes #549 