### PR TITLE
Fix arrow dictionary import.

### DIFF
--- a/omniscidb/ArrowStorage/ArrowStorageUtils.h
+++ b/omniscidb/ArrowStorage/ArrowStorageUtils.h
@@ -44,3 +44,6 @@ std::shared_ptr<arrow::ChunkedArray> convertArrowDictionary(
     StringDictionary* dict,
     std::shared_ptr<arrow::ChunkedArray> arr,
     const hdk::ir::Type* type);
+
+std::shared_ptr<arrow::ChunkedArray> decodeArrowDictionary(
+    std::shared_ptr<arrow::ChunkedArray> arr);

--- a/python/tests/test_pyhdk_data_import.py
+++ b/python/tests/test_pyhdk_data_import.py
@@ -9,6 +9,8 @@ import pytest
 import pyhdk
 import pyarrow
 
+from helpers import check_res
+
 
 class TestImport:
     def test_null_schema(self):
@@ -18,4 +20,26 @@ class TestImport:
         opt = pyhdk.storage.TableOptions(2)
         hdk = pyhdk.init()
         ht = hdk.import_arrow(table)
+        hdk.drop_table(ht)
+
+    def test_dict_import(self):
+        hdk = pyhdk.init()
+        ht = hdk.create_table("table1", {"col1": "dict", "col2": "text"})
+
+        col1 = pyarrow.array(["str1", "str2"])
+        at = pyarrow.table([col1, col1], names=["col1", "col2"])
+        hdk.import_arrow(at, ht)
+
+        col1 = pyarrow.DictionaryArray.from_arrays([0, 1, 0, 1], ["str3", "str4"])
+        at = pyarrow.table([col1, col1], names=["col1", "col2"])
+        hdk.import_arrow(at, ht)
+
+        check_res(
+            ht.run(),
+            {
+                "col1": ["str1", "str2", "str3", "str4", "str3", "str4"],
+                "col2": ["str1", "str2", "str3", "str4", "str3", "str4"],
+            },
+        )
+
         hdk.drop_table(ht)


### PR DESCRIPTION
Our dictionary columns are supposed to accept both plain and dictionary-encoded strings on import. But in fact, schema comparison on import forces plain strings usage and doesn't accept arrow dictionaries.

This patch fixes this and allows arrow dictionaries on import for both string and dictionary columns. Also, it adds support for different arrow dictionary indices sizes and NULL values.