### PR TITLE
[Bench] Reduce input cols number for fetch

### DIFF
--- a/omniscidb/QueryEngine/CMakeLists.txt
+++ b/omniscidb/QueryEngine/CMakeLists.txt
@@ -79,6 +79,7 @@ set(query_engine_source_files
     QueryExecutionSequence.cpp
     QueryMemoryInitializer.cpp
     RelAlgDagBuilder.cpp
+    RelAlgExecutionUnit.cpp
     RelAlgExecutor.cpp
     RelAlgTranslator.cpp
     RelAlgOptimizer.cpp

--- a/omniscidb/QueryEngine/CardinalityEstimator.cpp
+++ b/omniscidb/QueryEngine/CardinalityEstimator.cpp
@@ -100,9 +100,10 @@ RelAlgExecutionUnit create_ndv_execution_unit(const RelAlgExecutionUnit& ra_exe_
 
 RelAlgExecutionUnit create_count_all_execution_unit(
     const RelAlgExecutionUnit& ra_exe_unit,
+    const SchemaProvider* schema_provider,
     hdk::ir::ExprPtr replacement_target) {
   return {ra_exe_unit.input_descs,
-          ra_exe_unit.input_col_descs,
+          schema_provider,
           ra_exe_unit.simple_quals,
           ra_exe_unit.quals,
           ra_exe_unit.join_quals,

--- a/omniscidb/QueryEngine/CardinalityEstimator.h
+++ b/omniscidb/QueryEngine/CardinalityEstimator.h
@@ -66,6 +66,7 @@ RelAlgExecutionUnit create_ndv_execution_unit(const RelAlgExecutionUnit& ra_exe_
 
 RelAlgExecutionUnit create_count_all_execution_unit(
     const RelAlgExecutionUnit& ra_exe_unit,
+    const SchemaProvider* schema_provider,
     hdk::ir::ExprPtr replacement_target);
 
 ResultSetPtr reduce_estimator_results(

--- a/omniscidb/QueryEngine/Descriptors/QueryFragmentDescriptor.cpp
+++ b/omniscidb/QueryEngine/Descriptors/QueryFragmentDescriptor.cpp
@@ -151,7 +151,9 @@ void QueryFragmentDescriptor::buildFragmentPerKernelForTable(
     }
 
     ExecutionKernelDescriptor execution_kernel_desc{
-        device_id, {}, fragment.getNumTuples()};
+        /*device_id*/ device_id,
+        /*fragments*/ {},
+        /*outer_tuple_count*/ fragment.getNumTuples()};
     if (table_desc_offset) {
       const auto frag_ids =
           executor->getTableFragmentIndices(ra_exe_unit,

--- a/omniscidb/QueryEngine/RelAlgExecutionUnit.cpp
+++ b/omniscidb/QueryEngine/RelAlgExecutionUnit.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2023 Intel Corporation
+ * Copyright 2017 MapD Technologies, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "RelAlgExecutionUnit.h"
+#include "Visitors/UsedInputsCollector.h"
+
+void RelAlgExecutionUnit::calcInputColDescs(const SchemaProvider* schema_provider) {
+  // Scan all currently used expressions to determine used columns.
+  UsedInputsCollector collector;
+  for (auto& expr : simple_quals) {
+    collector.visit(expr.get());
+  }
+  for (auto& expr : quals) {
+    collector.visit(expr.get());
+  }
+  for (auto& expr : groupby_exprs) {
+    if (expr) {
+      collector.visit(expr.get());
+    }
+  }
+  for (auto& join_qual : join_quals) {
+    for (auto& expr : join_qual.quals) {
+      collector.visit(expr.get());
+    }
+  }
+
+  for (auto& expr : target_exprs) {
+    collector.visit(expr);
+  }
+
+  if (partition_offsets_col) {
+    collector.visit(partition_offsets_col.get());
+  }
+
+  std::vector<std::shared_ptr<const InputColDescriptor>> col_descs;
+  for (auto& col_var : collector.result()) {
+    col_descs.push_back(std::make_shared<const InputColDescriptor>(col_var.columnInfo(),
+                                                                   col_var.rteIdx()));
+  }
+
+  // For UNION we only have column variables for a single table used
+  // in target expressions but should mark all columns as used.
+  if (union_all && !col_descs.empty()) {
+    CHECK_EQ(col_descs.front()->getNestLevel(), 0);
+    CHECK_EQ(input_descs.size(), (size_t)2);
+    TableRef processed_table_ref(col_descs.front()->getDatabaseId(),
+                                 col_descs.front()->getTableId());
+    for (auto tdesc : input_descs) {
+      if (tdesc.getTableRef() != processed_table_ref) {
+        auto columns = schema_provider->listColumns(tdesc.getTableRef());
+        for (auto& col_info : columns) {
+          if (!col_info->is_rowid) {
+            col_descs.push_back(std::make_shared<InputColDescriptor>(col_info, 0));
+          }
+        }
+      }
+    }
+  }
+
+  std::sort(
+      col_descs.begin(),
+      col_descs.end(),
+      [](std::shared_ptr<const InputColDescriptor> const& lhs,
+         std::shared_ptr<const InputColDescriptor> const& rhs) {
+        return std::make_tuple(lhs->getNestLevel(), lhs->getColId(), lhs->getTableId()) <
+               std::make_tuple(rhs->getNestLevel(), rhs->getColId(), rhs->getTableId());
+      });
+
+  input_col_descs.clear();
+  input_col_descs.insert(input_col_descs.end(), col_descs.begin(), col_descs.end());
+}

--- a/omniscidb/QueryEngine/Visitors/UsedInputsCollector.h
+++ b/omniscidb/QueryEngine/Visitors/UsedInputsCollector.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "IR/ExprCollector.h"
+
+#include <unordered_set>
+
+struct ColumnVarHash {
+  size_t operator()(const hdk::ir::ColumnVar& col_var) const { return col_var.hash(); }
+};
+
+using ColumnVarSet = std::unordered_set<hdk::ir::ColumnVar, ColumnVarHash>;
+
+class UsedInputsCollector
+    : public hdk::ir::ExprCollector<ColumnVarSet, UsedInputsCollector> {
+ protected:
+  void visitColumnRef(const hdk::ir::ColumnRef* col_ref) override { CHECK(false); }
+
+  void visitColumnVar(const hdk::ir::ColumnVar* col_var) override {
+    result_.insert(*col_var);
+  }
+};

--- a/omniscidb/QueryEngine/WorkUnitBuilder.h
+++ b/omniscidb/QueryEngine/WorkUnitBuilder.h
@@ -71,7 +71,7 @@ class WorkUnitBuilder {
   int assignNestLevels(const ir::Node* node, int start_idx = 0);
   void computeJoinTypes(const ir::Node* node, bool allow_join = true);
   void computeInputDescs();
-  void computeInputColDescs();
+  void verifyInputColDescs();
 
   class InputRewriter : public ir::ExprRewriter {
    public:
@@ -122,7 +122,6 @@ class WorkUnitBuilder {
   bool is_agg_ = false;
 
   std::vector<InputDescriptor> input_descs_;
-  std::list<std::shared_ptr<const InputColDescriptor>> input_col_descs_;
   std::list<hdk::ir::ExprPtr> simple_quals_;
   std::list<hdk::ir::ExprPtr> quals_;
   JoinQualsPerNestingLevel join_quals_;


### PR DESCRIPTION
To estimate output size of result query to allocate buffer we are running `count*` before some actual queries. This estimation requires only query body argumnets without `select` arguments, so this commit changes input_cols for `count*` query.

Resolves: #574

Signed-off-by: Dmitrii Makarenko <dmitrii.makarenko@intel.com>