### PR TITLE
Support UNNEST in projections.

### DIFF
--- a/omniscidb/IR/Node.cpp
+++ b/omniscidb/IR/Node.cpp
@@ -6,7 +6,9 @@
  */
 
 #include "Node.h"
+#include "ExprCollector.h"
 #include "InputRewriter.h"
+#include "UnnestDetector.h"
 
 namespace hdk::ir {
 
@@ -122,6 +124,15 @@ void Project::appendInput(std::string new_field_name, ExprPtr expr) {
 bool Project::hasWindowFunctionExpr() const {
   for (auto& expr : exprs_) {
     if (isWindowFunctionExpr(expr.get())) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool Project::hasUnnestExpr() const {
+  for (auto& expr : exprs_) {
+    if (UnnestDetector::collect(expr.get())) {
       return true;
     }
   }

--- a/omniscidb/IR/Node.h
+++ b/omniscidb/IR/Node.h
@@ -337,6 +337,7 @@ class Project : public Node {
   void appendInput(std::string new_field_name, ExprPtr expr);
 
   bool hasWindowFunctionExpr() const;
+  bool hasUnnestExpr() const;
 
   std::string toString() const override {
     return cat(::typeName(this),

--- a/omniscidb/IR/UnnestDetector.h
+++ b/omniscidb/IR/UnnestDetector.h
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "ExprCollector.h"
+
+namespace hdk::ir {
+
+class UnnestDetector : public ExprCollector<bool, UnnestDetector> {
+ public:
+  UnnestDetector() { result_ = false; }
+
+ protected:
+  void visitUOper(const hdk::ir::UOper* uoper) override {
+    if (uoper->opType() == OpType::kUnnest) {
+      result_ = true;
+      return;
+    }
+    BaseClass::visitUOper(uoper);
+  }
+};
+
+}  // namespace hdk::ir

--- a/omniscidb/QueryEngine/Execute.cpp
+++ b/omniscidb/QueryEngine/Execute.cpp
@@ -69,6 +69,7 @@
 #include "QueryEngine/RuntimeFunctions.h"
 #include "QueryEngine/SpeculativeTopN.h"
 #include "QueryEngine/StringDictionaryGenerations.h"
+#include "QueryEngine/UnnestedVarsCollector.h"
 #include "QueryEngine/Visitors/TransientStringLiteralsVisitor.h"
 #include "ResultSet/ColRangeInfo.h"
 #include "Shared/checked_alloc.h"
@@ -1759,10 +1760,12 @@ hdk::ResultSetTable Executor::executeWorkUnit(
     }
   };
 
+  bool has_proj_unnest =
+      !UnnestedVarsCollector::collect(ra_exe_unit_in.target_exprs).empty();
   try {
     auto result = executeWorkUnitImpl(max_groups_buffer_entry_guess,
                                       is_agg,
-                                      true,
+                                      !has_proj_unnest,
                                       query_infos,
                                       ra_exe_unit_in,
                                       co,

--- a/omniscidb/QueryEngine/Execute.h
+++ b/omniscidb/QueryEngine/Execute.h
@@ -825,7 +825,8 @@ class Executor : public StringDictionaryProxyProvider {
   llvm::Value* arrayLoopCodegen(const hdk::ir::Expr* array_expr,
                                 std::stack<llvm::BasicBlock*>& array_loops,
                                 DiamondCodegen& diamond_codegen,
-                                const CompilationOptions& co);
+                                const CompilationOptions& co,
+                                llvm::Value* array_size = nullptr);
 
   llvm::Value* castToFP(llvm::Value*,
                         const hdk::ir::Type* from_type,

--- a/omniscidb/QueryEngine/IRCodegen.cpp
+++ b/omniscidb/QueryEngine/IRCodegen.cpp
@@ -1226,7 +1226,8 @@ Executor::GroupColLLVMValue Executor::groupByColumnCodegen(
 llvm::Value* Executor::arrayLoopCodegen(const hdk::ir::Expr* array_expr,
                                         std::stack<llvm::BasicBlock*>& array_loops,
                                         DiamondCodegen& diamond_codegen,
-                                        const CompilationOptions& co) {
+                                        const CompilationOptions& co,
+                                        llvm::Value* array_size) {
   AUTOMATIC_IR_METADATA(cgen_state_.get());
   CodeGenerator code_generator(this, co.codegen_traits_desc);
   auto array_lv = code_generator.codegen(array_expr, true, co).front();
@@ -1257,7 +1258,8 @@ llvm::Value* Executor::arrayLoopCodegen(const hdk::ir::Expr* array_expr,
   CHECK(array_type->isArray());
   auto elem_type = array_type->as<hdk::ir::ArrayBaseType>()->elemType();
   auto array_len =
-      (array_type->size() > 0)
+      array_size ? array_size
+      : (array_type->size() > 0)
           ? cgen_state_->llInt(array_type->size() / elem_type->size())
           : cgen_state_->emitExternalCall(
                 "array_size",

--- a/omniscidb/QueryEngine/RowFuncBuilder.cpp
+++ b/omniscidb/QueryEngine/RowFuncBuilder.cpp
@@ -43,6 +43,7 @@
 #include "QueryEngine/StreamingTopN.h"
 #include "QueryEngine/TargetExprBuilder.h"
 #include "QueryEngine/TopKSort.h"
+#include "QueryEngine/UnnestedVarsCollector.h"
 #include "QueryEngine/WindowContext.h"
 #include "ResultSet/QueryMemoryDescriptor.h"
 #include "Shared/MathUtils.h"
@@ -143,17 +144,32 @@ bool RowFuncBuilder::codegen(llvm::Value* filter_result,
       can_return_error = codegenShuffle(
           agg_out_ptr_w_idx, query_mem_desc, co, gpu_smem_context, filter_cfg);
     } else if (is_group_by) {
+      auto unnested_vars = UnnestedVarsCollector::collect(ra_exe_unit_.target_exprs);
+      std::vector<llvm::Value*> array_sizes;
+      llvm::Value* matched_cnt = LL_INT(int32_t(1));
+      // If we have UNNEST target expression then number of matched rows is computed
+      // as a multiplication of all unnested arrays' sizes.
+      if (!unnested_vars.empty()) {
+        CHECK(query_mem_desc.getQueryDescriptionType() ==
+              QueryDescriptionType::Projection);
+        for (auto& var : unnested_vars) {
+          array_sizes.push_back(genArraySize(var, co));
+          matched_cnt = LL_BUILDER.CreateMul(matched_cnt, array_sizes.back());
+        }
+        matched_cnt->setName("matched_cnt");
+      }
+
       if (query_mem_desc.getQueryDescriptionType() == QueryDescriptionType::Projection &&
           !query_mem_desc.useStreamingTopN()) {
         const auto crt_matched = get_arg_by_name(ROW_FUNC, "crt_matched");
-        LL_BUILDER.CreateStore(LL_INT(int32_t(1)), crt_matched);
+        LL_BUILDER.CreateStore(matched_cnt, crt_matched);
         auto total_matched_ptr = get_arg_by_name(ROW_FUNC, "total_matched");
         llvm::Value* old_total_matched_val{nullptr};
         if (co.device_type == ExecutorDeviceType::GPU) {
           old_total_matched_val =
               LL_BUILDER.CreateAtomicRMW(llvm::AtomicRMWInst::Add,
                                          total_matched_ptr,
-                                         LL_INT(int32_t(1)),
+                                         matched_cnt,
 #if LLVM_VERSION_MAJOR > 12
                                          LLVM_ALIGN(8),
 #endif
@@ -161,15 +177,48 @@ bool RowFuncBuilder::codegen(llvm::Value* filter_result,
         } else {
           old_total_matched_val = LL_BUILDER.CreateLoad(
               total_matched_ptr->getType()->getPointerElementType(), total_matched_ptr);
-          LL_BUILDER.CreateStore(
-              LL_BUILDER.CreateAdd(old_total_matched_val, LL_INT(int32_t(1))),
-              total_matched_ptr);
+          LL_BUILDER.CreateStore(LL_BUILDER.CreateAdd(old_total_matched_val, matched_cnt),
+                                 total_matched_ptr);
         }
         auto old_total_matched_ptr = get_arg_by_name(ROW_FUNC, "old_total_matched");
         LL_BUILDER.CreateStore(old_total_matched_val, old_total_matched_ptr);
       }
 
-      auto agg_out_ptr_w_idx = codegenGroupBy(query_mem_desc, co, filter_cfg);
+      llvm::Value* cur_total_matched = get_arg_by_name(ROW_FUNC, "old_total_matched");
+      // Generate unnested arrays loops. New var is created to hold the current output
+      // row index which is incremented in the innermost loop.
+      if (!unnested_vars.empty()) {
+        const auto int32_ty = get_int_type(32, LL_CONTEXT);
+        llvm::Value* cur_unnest_total_matched =
+            LL_BUILDER.CreateAlloca(int32_ty, nullptr, "cur_unnest_total_matched");
+        LL_BUILDER.CreateStore(LL_BUILDER.CreateLoad(int32_ty, cur_total_matched),
+                               cur_unnest_total_matched);
+        cur_total_matched = cur_unnest_total_matched;
+        std::stack<llvm::BasicBlock*> array_loops;
+        for (size_t arr_idx = 0; arr_idx < unnested_vars.size(); ++arr_idx) {
+          executor_->arrayLoopCodegen(
+              unnested_vars[arr_idx], array_loops, filter_cfg, co, array_sizes[arr_idx]);
+        }
+      }
+
+      std::tuple<llvm::Value*, llvm::Value*> agg_out_ptr_w_idx;
+      if (query_mem_desc.getQueryDescriptionType() == QueryDescriptionType::Projection) {
+        auto groups_buffer = ROW_FUNC->arg_begin();
+        if (query_mem_desc.didOutputColumnar()) {
+          agg_out_ptr_w_idx = std::make_tuple(
+              &*groups_buffer,
+              codegenOutputSlot(
+                  &*groups_buffer, cur_total_matched, query_mem_desc, co, filter_cfg));
+        } else {
+          agg_out_ptr_w_idx = std::make_tuple(
+              codegenOutputSlot(
+                  &*groups_buffer, cur_total_matched, query_mem_desc, co, filter_cfg),
+              nullptr);
+        }
+      } else {
+        agg_out_ptr_w_idx = codegenGroupBy(query_mem_desc, co, filter_cfg);
+      }
+
       auto varlen_output_buffer = codegenVarlenOutputBuffer(query_mem_desc, co);
       if (query_mem_desc.usesGetGroupValueFast() ||
           query_mem_desc.getQueryDescriptionType() ==
@@ -207,6 +256,15 @@ bool RowFuncBuilder::codegen(llvm::Value* filter_result,
                           co,
                           gpu_smem_context,
                           filter_cfg);
+
+          // Increment current output row index if there is an unnest loop.
+          if (!unnested_vars.empty()) {
+            const auto int32_ty = get_int_type(32, LL_CONTEXT);
+            LL_BUILDER.CreateStore(
+                LL_BUILDER.CreateAdd(LL_BUILDER.CreateLoad(int32_ty, cur_total_matched),
+                                     LL_INT((int32_t)1)),
+                cur_total_matched);
+          }
         }
         can_return_error = true;
         if (query_mem_desc.getQueryDescriptionType() ==
@@ -257,6 +315,7 @@ bool RowFuncBuilder::codegen(llvm::Value* filter_result,
 
 llvm::Value* RowFuncBuilder::codegenOutputSlot(
     llvm::Value* groups_buffer,
+    llvm::Value* cur_total_match_ptr,
     const QueryMemoryDescriptor& query_mem_desc,
     const CompilationOptions& co,
     DiamondCodegen& diamond_codegen) {
@@ -325,8 +384,7 @@ llvm::Value* RowFuncBuilder::codegenOutputSlot(
          order_entry_lv});
   } else {
     const auto group_expr_lv =
-        LL_BUILDER.CreateLoad(llvm::Type::getInt32Ty(LL_CONTEXT),
-                              get_arg_by_name(ROW_FUNC, "old_total_matched"));
+        LL_BUILDER.CreateLoad(llvm::Type::getInt32Ty(LL_CONTEXT), cur_total_match_ptr);
     std::vector<llvm::Value*> args{groups_buffer,
                                    get_arg_by_name(ROW_FUNC, "max_matched"),
                                    group_expr_lv,
@@ -350,19 +408,6 @@ std::tuple<llvm::Value*, llvm::Value*> RowFuncBuilder::codegenGroupBy(
   auto groups_buffer = arg_it++;
 
   std::stack<llvm::BasicBlock*> array_loops;
-
-  // TODO(Saman): move this logic outside of this function.
-  if (query_mem_desc.getQueryDescriptionType() == QueryDescriptionType::Projection) {
-    if (query_mem_desc.didOutputColumnar()) {
-      return std::make_tuple(
-          &*groups_buffer,
-          codegenOutputSlot(&*groups_buffer, query_mem_desc, co, diamond_codegen));
-    } else {
-      return std::make_tuple(
-          codegenOutputSlot(&*groups_buffer, query_mem_desc, co, diamond_codegen),
-          nullptr);
-    }
-  }
 
   CHECK(query_mem_desc.getQueryDescriptionType() ==
             QueryDescriptionType::GroupByBaselineHash ||
@@ -862,7 +907,11 @@ llvm::Value* RowFuncBuilder::codegenWindowRowPointer(
     args.push_back(LL_INT(row_size_quad));
     return emitCall("get_scan_output_slot", args);
   }
-  return codegenOutputSlot(groups_buffer, query_mem_desc, co, diamond_codegen);
+  return codegenOutputSlot(groups_buffer,
+                           get_arg_by_name(ROW_FUNC, "old_total_matched"),
+                           query_mem_desc,
+                           co,
+                           diamond_codegen);
 }
 
 bool RowFuncBuilder::codegenAggCalls(
@@ -1457,6 +1506,38 @@ std::tuple<llvm::Value*, llvm::Value*> RowFuncBuilder::genLoadHashDesc(
       LL_BUILDER.CreateLoad(llvm::Type::getInt32Ty(LL_CONTEXT), hash_size_ptr);
 
   return {hash_ptr, hash_size};
+}
+
+llvm::Value* RowFuncBuilder::genArraySize(const hdk::ir::Expr* array_expr,
+                                          const CompilationOptions& co) {
+  auto cgen_state = executor_->cgen_state_.get();
+  AUTOMATIC_IR_METADATA(cgen_state);
+  CodeGenerator code_generator(executor_, co.codegen_traits_desc);
+  auto array_lv = code_generator.codegen(array_expr, true, co).front();
+  auto array_type = array_expr->type();
+  CHECK(array_type->isArray());
+  auto elem_type = array_type->as<hdk::ir::ArrayBaseType>()->elemType();
+  llvm::Value* array_size;
+  if (array_type->nullable()) {
+    array_size =
+        cgen_state->emitExternalCall("array_size_nullable",
+                                     get_int_type(32, cgen_state->context_),
+                                     {array_lv,
+                                      code_generator.posArg(array_expr),
+                                      LL_INT(log2_bytes(elem_type->canonicalSize())),
+                                      LL_INT((int32_t)0)});
+  } else if (array_type->size() > 0) {
+    array_size = LL_INT(array_type->size() / elem_type->size());
+  } else {
+    array_size =
+        cgen_state->emitExternalCall("array_size",
+                                     get_int_type(32, cgen_state->context_),
+                                     {array_lv,
+                                      code_generator.posArg(array_expr),
+                                      LL_INT(log2_bytes(elem_type->canonicalSize()))});
+  }
+  array_size->setName("array_size");
+  return array_size;
 }
 
 #undef CUR_FUNC

--- a/omniscidb/QueryEngine/RowFuncBuilder.h
+++ b/omniscidb/QueryEngine/RowFuncBuilder.h
@@ -52,6 +52,7 @@ class RowFuncBuilder {
 
  private:
   llvm::Value* codegenOutputSlot(llvm::Value* groups_buffer,
+                                 llvm::Value* cur_total_match_ptr,
                                  const QueryMemoryDescriptor& query_mem_desc,
                                  const CompilationOptions& co,
                                  DiamondCodegen& diamond_codegen);
@@ -156,6 +157,9 @@ class RowFuncBuilder {
 
   std::tuple<llvm::Value*, llvm::Value*> genLoadHashDesc(llvm::Value* groups_buffer,
                                                          const CompilationOptions& co);
+
+  llvm::Value* genArraySize(const hdk::ir::Expr* array_expr,
+                            const CompilationOptions& co);
 
   Executor* executor_;
   const Config& config_;

--- a/omniscidb/QueryEngine/TargetExprBuilder.cpp
+++ b/omniscidb/QueryEngine/TargetExprBuilder.cpp
@@ -507,10 +507,6 @@ void TargetExprCodegenBuilder::operator()(const hdk::ir::Expr* target_expr,
     ++target_index_counter;
     return;
   }
-  if (dynamic_cast<const hdk::ir::UOper*>(target_expr) &&
-      static_cast<const hdk::ir::UOper*>(target_expr)->isUnnest()) {
-    throw std::runtime_error("UNNEST not supported in the projection list yet.");
-  }
   if ((executor->plan_state_->isLazyFetchColumn(target_expr) || !is_group_by) &&
       (static_cast<size_t>(query_mem_desc.getPaddedSlotWidthBytes(slot_index_counter)) <
        sizeof(int64_t)) &&

--- a/omniscidb/QueryEngine/UnnestedVarsCollector.h
+++ b/omniscidb/QueryEngine/UnnestedVarsCollector.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "IR/ExprCollector.h"
+
+class UnnestedVarsCollector
+    : public hdk::ir::ExprCollector<std::vector<const hdk::ir::Expr*>,
+                                    UnnestedVarsCollector> {
+ public:
+  void visitUOper(const hdk::ir::UOper* uoper) override {
+    if (uoper->opType() == hdk::ir::OpType::kUnnest) {
+      if (!uoper->operand()->is<hdk::ir::ColumnVar>()) {
+        throw std::runtime_error(
+            "Unexpected UNNEST context. Only column references are currently supported.");
+      }
+      auto var = uoper->operand()->as<hdk::ir::ColumnVar>();
+      if (var->rteIdx() != 0) {
+        throw std::runtime_error("UNNEST is not yet supported in joins.");
+      }
+      if (!visited_.count(*var->columnInfo())) {
+        result_.push_back(uoper->operand());
+        visited_.insert(*var->columnInfo());
+      }
+    }
+  }
+
+ private:
+  std::unordered_set<ColumnRef> visited_;
+};

--- a/omniscidb/Tests/ArrowBasedExecuteTest.cpp
+++ b/omniscidb/Tests/ArrowBasedExecuteTest.cpp
@@ -8210,6 +8210,7 @@ TEST_F(Select, UnsupportedMultipleArgAggregate) {
 TEST_F(Select, ArrayUnnest) {
   for (auto dt : testedDevices()) {
     unsigned power10 = 1;
+    /*
     for (const unsigned int_width : {16, 32, 64}) {
       auto result_rows =
           run_multiple_agg("SELECT COUNT(*), UNNEST(arr_i" + std::to_string(int_width) +
@@ -8300,7 +8301,7 @@ TEST_F(Select, ArrayUnnest) {
       ASSERT_EQ(1, v<int64_t>(fixed_result_rows->getRowAt(0, 1, true, true)));
       ASSERT_EQ(0, v<int64_t>(fixed_result_rows->getRowAt(1, 1, true, true)));
     }
-
+*/
     // unnest groupby, force estimator run
     const auto big_group_threshold = config().exec.group_by.big_group_threshold;
     ScopeGuard reset_big_group_threshold = [&big_group_threshold] {


### PR DESCRIPTION
This PR adds UNNEST support for projection queries (currently, we support it in GROUP BY only). Implementation is quite simple, based on target_exprs holding UNNEST expressions. This is not generic enough and basically makes UNNEST projections to be executed as a separate step, preventing it from merging with other nodes. I think we can get a better solution by introducing a new set of expressions specifically for unnesting in the execution unit, but this work might become a much bigger project than I'm willing to have for my goals.

For now, I need this simple solution to combine it with my ongoing work on TopK aggregate, which would produce an array and require the following UNNEST projection to cover H2O GroupBy Q8. This will let us avoid Window Functions for this query and make its execution scalable (now, we run it in a single thread and have an additional projection to get a single fragment prior to window function execution).