### PR TITLE
Add ostream operators for compilation options

### DIFF
--- a/omniscidb/QueryEngine/CompilationOptions.cpp
+++ b/omniscidb/QueryEngine/CompilationOptions.cpp
@@ -37,4 +37,59 @@ std::ostream& operator<<(std::ostream& os, const ExecutionOptions& eo) {
      << "preserve_order=" << eo.preserve_order << "\n";
   return os;
 }
+
+std::ostream& operator<<(std::ostream& os, const ExecutorOptLevel& eol) {
+  switch (eol) {
+    case ExecutorOptLevel::Default:
+      return os << "ExecutorOptLevel::Default";
+    case ExecutorOptLevel::ReductionJIT:
+      return os << "ExecutorOptLevel::ReductionJIT";
+    default:
+      return os << "ExecutorOptLevel::UNKNOWN";
+  }
+}
+
+std::ostream& operator<<(std::ostream& os, const ExecutorExplainType& eet) {
+  switch (eet) {
+    case ExecutorExplainType::Default:
+      return os << "ExecutorExplainType::Default";
+    case ExecutorExplainType::Optimized:
+      return os << "ExecutorExplainType::Optimized";
+    default:
+      return os << "ExecutorExplainType::UNKNOWN";
+  }
+}
+
+std::ostream& operator<<(std::ostream& os, const compiler::CallingConvDesc& desc) {
+  switch (desc) {
+    case compiler::CallingConvDesc::C:
+      return os << "CallingConvDesc::C";
+    case compiler::CallingConvDesc::SPIR_FUNC:
+      return os << "CallingConvDesc::SPIR_FUNC";
+    default:
+      return os << "CallingConvDesc::UNKNOWN";
+  }
+}
+
+std::ostream& operator<<(std::ostream& os,
+                         const compiler::CodegenTraitsDescriptor& desc) {
+  os << "{local=" << desc.local_addr_space_ << ",global=" << desc.global_addr_space_
+     << ",shared=" << desc.smem_addr_space_ << ",conv=" << desc.conv_
+     << ",trpile=" << desc.triple_ << "}";
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const CompilationOptions& co) {
+  os << "device_type=" << co.device_type << "\n"
+     << "hoist_literals=" << co.hoist_literals << "\n"
+     << "opt_level=" << co.opt_level << "\n"
+     << "with_dynamic_watchdog=" << co.with_dynamic_watchdog << "\n"
+     << "allow_lazy_fetch=" << co.allow_lazy_fetch << "\n"
+     << "filter_on_deleted_column=" << co.filter_on_deleted_column << "\n"
+     << "explain_type=" << co.explain_type << "\n"
+     << "register_intel_jit_listener=" << co.register_intel_jit_listener << "\n"
+     << "use_groupby_buffer_desc=" << co.use_groupby_buffer_desc << "\n"
+     << "codegen_traits_desc=" << co.codegen_traits_desc << "\n";
+  return os;
+}
 #endif

--- a/omniscidb/QueryEngine/CompilationOptions.h
+++ b/omniscidb/QueryEngine/CompilationOptions.h
@@ -172,6 +172,11 @@ struct ExecutionOptions {
 
 #ifndef __CUDACC__
 std::ostream& operator<<(std::ostream& os, const ExecutionOptions& eo);
+std::ostream& operator<<(std::ostream& os, const ExecutorOptLevel& eol);
+std::ostream& operator<<(std::ostream& os, const compiler::CallingConvDesc& desc);
+std::ostream& operator<<(std::ostream& os, const compiler::CodegenTraitsDescriptor& desc);
+std::ostream& operator<<(std::ostream& os, const ExecutorExplainType& eet);
+std::ostream& operator<<(std::ostream& os, const CompilationOptions& co);
 #endif
 
 #endif  // QUERYENGINE_COMPILATIONOPTIONS_H


### PR DESCRIPTION
These can be useful for tracking down problems with query retries and non-default work units like cardinality estimation kernels.