### PR TITLE
Support debug timers in config builder.

### DIFF
--- a/omniscidb/ConfigBuilder/ConfigBuilder.cpp
+++ b/omniscidb/ConfigBuilder/ConfigBuilder.cpp
@@ -637,6 +637,13 @@ bool ConfigBuilder::parseCommandLineArgs(int argc,
       "time. This option can be used to split data import and execution for performance "
       "measurements.");
 
+  // external
+  opt_desc.add_options()("enable-debug-timer",
+                         po::value<bool>(&g_enable_debug_timer)
+                             ->default_value(g_enable_debug_timer)
+                             ->implicit_value(true),
+                         "Enable debug timers in logger.");
+
   if (allow_gtest_flags) {
     opt_desc.add_options()("gtest_list_tests", "list all test");
     opt_desc.add_options()("gtest_filter", "filters tests, use --help for details");

--- a/python/pyhdk/_common.pyx
+++ b/python/pyhdk/_common.pyx
@@ -184,11 +184,7 @@ cdef class TypeInfo:
   def __repr__(self):
     return self.c_type_info.toString()
 
-def buildConfig(*, enable_debug_timer=None, enable_union=False, log_dir="hdk_log", **kwargs):
-  global g_enable_debug_timer
-  if enable_debug_timer is not None:
-    g_enable_debug_timer = enable_debug_timer
-
+def buildConfig(*, log_dir="hdk_log", **kwargs):
   # Remove legacy params to provide better compatibility with PyOmniSciDbe
   kwargs.pop("enable_union", None)
   kwargs.pop("enable_thrift_logs", None)


### PR DESCRIPTION
This enables debug timers option in unit tests. Also, it allows the removal of special option handling in PyHDK init.