### PR TITLE
Copy table stats for shuffled data.

### DIFF
--- a/omniscidb/QueryEngine/RelAlgExecutor.h
+++ b/omniscidb/QueryEngine/RelAlgExecutor.h
@@ -131,6 +131,7 @@ class RelAlgExecutor {
                                              const ExecutionOptions& eo,
                                              size_t estimated_buffer_size,
                                              const int64_t queue_time_ms);
+  void maybeCopyTableStatsFromInput(const hdk::ir::Node* node);
   ExecutionResult executeStep(const hdk::ir::Node* step_root,
                               const CompilationOptions& co,
                               const ExecutionOptions& eo,

--- a/omniscidb/ResultSetRegistry/ResultSetRegistry.cpp
+++ b/omniscidb/ResultSetRegistry/ResultSetRegistry.cpp
@@ -176,6 +176,17 @@ void ResultSetRegistry::drop(const ResultSetTableToken& token) {
   SimpleSchemaProvider::dropTable(token.dbId(), token.tableId());
 }
 
+void ResultSetRegistry::setTableStats(const ResultSetTableToken& token,
+                                      TableStats stats) {
+  mapd_shared_lock<mapd_shared_mutex> data_lock(data_mutex_);
+  CHECK(tables_.count(token.tableId()));
+  auto* table = tables_.at(token.tableId()).get();
+  data_lock.unlock();
+
+  mapd_unique_lock<mapd_shared_mutex> table_lock(table->mutex);
+  table->table_stats = std::move(stats);
+}
+
 ResultSetTableTokenPtr ResultSetRegistry::head(const ResultSetTableToken& token,
                                                size_t n) {
   mapd_shared_lock<mapd_shared_mutex> data_lock(data_mutex_);

--- a/omniscidb/ResultSetRegistry/ResultSetRegistry.h
+++ b/omniscidb/ResultSetRegistry/ResultSetRegistry.h
@@ -39,6 +39,8 @@ class ResultSetRegistry : public SimpleSchemaProvider,
   ResultSetPtr get(const ResultSetTableToken& token, size_t frag_id) const;
   void drop(const ResultSetTableToken& token);
 
+  void setTableStats(const ResultSetTableToken& token, TableStats stats);
+
   ResultSetTableTokenPtr head(const ResultSetTableToken& token, size_t n);
   ResultSetTableTokenPtr tail(const ResultSetTableToken& token, size_t n);
 

--- a/omniscidb/ResultSetRegistry/ResultSetTableToken.cpp
+++ b/omniscidb/ResultSetRegistry/ResultSetTableToken.cpp
@@ -38,6 +38,10 @@ void ResultSetTableToken::reset() {
   }
 }
 
+void ResultSetTableToken::setTableStats(TableStats stats) const {
+  registry_->setTableStats(*this, std::move(stats));
+}
+
 ResultSetTableTokenPtr ResultSetTableToken::head(size_t n) const {
   return registry_->head(*this, n);
 }

--- a/omniscidb/ResultSetRegistry/ResultSetTableToken.h
+++ b/omniscidb/ResultSetRegistry/ResultSetTableToken.h
@@ -9,6 +9,7 @@
 #include "ResultSetTable.h"
 
 #include "DataMgr/ChunkMetadata.h"
+#include "DataProvider/TableFragmentsInfo.h"
 #include "SchemaMgr/TableInfo.h"
 
 #include "arrow/api.h"
@@ -53,6 +54,8 @@ class ResultSetTableToken : public std::enable_shared_from_this<ResultSetTableTo
   ResultSetPtr resultSet(size_t idx) const;
 
   const std::string& tableName() const { return tinfo_->name; }
+
+  void setTableStats(TableStats stats) const;
 
   ResultSetTableTokenPtr head(size_t n) const;
   ResultSetTableTokenPtr tail(size_t n) const;


### PR DESCRIPTION
This patch sets table stats for shuffled data. This allows us to avoid metadata computation for the shuffled data.