### PR TITLE
Add TopK/BottomK aggregate.

### DIFF
--- a/omniscidb/IR/Expr.h
+++ b/omniscidb/IR/Expr.h
@@ -791,7 +791,7 @@ class AggExpr : public Expr {
       : Expr(type, true), agg_type_(a), arg_(arg), is_distinct_(d), arg1_(arg1) {
     if (arg1) {
       if (agg_type_ == AggType::kApproxCountDistinct ||
-          agg_type_ == AggType::kApproxQuantile) {
+          agg_type_ == AggType::kApproxQuantile || agg_type_ == AggType::kTopK) {
         CHECK(arg1_->is<Constant>());
       } else {
         CHECK(agg_type_ == AggType::kCorr);

--- a/omniscidb/IR/OpType.h
+++ b/omniscidb/IR/OpType.h
@@ -87,6 +87,7 @@ enum class AggType {
   kApproxQuantile,
   kSample,
   kSingleValue,
+  kTopK,
   // Compound aggregates
   kStdDevSamp,
   kCorr,
@@ -205,6 +206,8 @@ inline std::string toString(hdk::ir::AggType agg) {
       return "SAMPLE";
     case hdk::ir::AggType::kSingleValue:
       return "SINGLE_VALUE";
+    case hdk::ir::AggType::kTopK:
+      return "TOP_K";
     case hdk::ir::AggType::kStdDevSamp:
       return "STDDEV";
     case hdk::ir::AggType::kCorr:

--- a/omniscidb/QueryBuilder/QueryBuilder.h
+++ b/omniscidb/QueryBuilder/QueryBuilder.h
@@ -76,6 +76,8 @@ class BuilderExpr {
   BuilderExpr approxQuantile(double val) const;
   BuilderExpr sample() const;
   BuilderExpr singleValue() const;
+  BuilderExpr topK(int count) const;
+  BuilderExpr bottomK(int count) const;
   BuilderExpr stdDev() const;
   BuilderExpr corr(const BuilderExpr& arg) const;
 
@@ -84,10 +86,12 @@ class BuilderExpr {
   BuilderExpr firstValue() const;
   BuilderExpr lastValue() const;
 
-  BuilderExpr agg(const std::string& agg_str, const BuilderExpr& arg) const;
+  BuilderExpr agg(const std::string& agg_str, BuilderExpr arg) const;
   BuilderExpr agg(const std::string& agg_str, double val = HUGE_VAL) const;
+  BuilderExpr agg(const std::string& agg_str, int val) const;
   BuilderExpr agg(AggType agg_kind, const BuilderExpr& arg) const;
   BuilderExpr agg(AggType agg_kind, double val) const;
+  BuilderExpr agg(AggType agg_kind, int val) const;
   BuilderExpr agg(AggType agg_kind, bool is_dinstinct, const BuilderExpr& arg) const;
   BuilderExpr agg(AggType agg_kind,
                   bool is_dinstinct = false,

--- a/omniscidb/QueryEngine/Execute.cpp
+++ b/omniscidb/QueryEngine/Execute.cpp
@@ -509,6 +509,10 @@ quantile::TDigest* RowSetMemoryOwner::nullTDigest(double const q) {
       .get();
 }
 
+int8_t* RowSetMemoryOwner::topKBuffer(size_t size) {
+  return allocate(size);
+}
+
 bool Executor::isCPUOnly() const {
   CHECK(data_mgr_);
   return !data_mgr_->getCudaMgr();
@@ -2033,6 +2037,7 @@ void Executor::allocateShuffleBuffers(
       getConfigPtr(),
       query_infos,
       false /*approx_quantile*/,
+      false /*topk_agg*/,
       false /*allow_multifrag*/,
       false /*keyless_hash*/,
       false /*interleaved_bins_on_gpu*/,

--- a/omniscidb/QueryEngine/MemoryLayoutBuilder.cpp
+++ b/omniscidb/QueryEngine/MemoryLayoutBuilder.cpp
@@ -831,6 +831,7 @@ std::unique_ptr<QueryMemoryDescriptor> build_query_memory_descriptor(
         executor->getConfigPtr(),
         query_infos,
         false,
+        false,
         allow_multifrag,
         false,
         false,
@@ -968,10 +969,12 @@ std::unique_ptr<QueryMemoryDescriptor> build_query_memory_descriptor(
 
   auto approx_quantile =
       anyOf(ra_exe_unit.target_exprs, hdk::ir::AggType::kApproxQuantile);
+  auto topk_agg = anyOf(ra_exe_unit.target_exprs, hdk::ir::AggType::kTopK);
   return std::make_unique<QueryMemoryDescriptor>(executor->getDataMgr(),
                                                  executor->getConfigPtr(),
                                                  query_infos,
                                                  approx_quantile,
+                                                 topk_agg,
                                                  allow_multifrag,
                                                  keyless_hash,
                                                  interleaved_bins_on_gpu,

--- a/omniscidb/QueryEngine/NativeCodegen.cpp
+++ b/omniscidb/QueryEngine/NativeCodegen.cpp
@@ -778,6 +778,9 @@ std::vector<std::string> get_agg_fnames(
       case hdk::ir::AggType::kApproxQuantile:
         result.emplace_back("agg_approx_quantile");
         break;
+      case hdk::ir::AggType::kTopK:
+        result.emplace_back("agg_topk");
+        break;
       default:
         CHECK(false);
     }

--- a/omniscidb/QueryEngine/OutputBufferInitialization.cpp
+++ b/omniscidb/QueryEngine/OutputBufferInitialization.cpp
@@ -162,6 +162,7 @@ int64_t get_agg_initial_val(hdk::ir::AggType agg,
     case hdk::ir::AggType::kAvg:
     case hdk::ir::AggType::kCount:
     case hdk::ir::AggType::kApproxCountDistinct:
+    case hdk::ir::AggType::kTopK:
       return 0;
     case hdk::ir::AggType::kApproxQuantile:
       return {};  // Init value is a quantile::TDigest* set elsewhere.

--- a/omniscidb/QueryEngine/QueryMemoryInitializer.h
+++ b/omniscidb/QueryEngine/QueryMemoryInitializer.h
@@ -126,7 +126,9 @@ class QueryMemoryInitializer {
                          int8_t* row_ptr,
                          const std::vector<int64_t>& init_vals,
                          const std::vector<int64_t>& bitmap_sizes,
-                         const std::vector<QuantileParam>& quantile_params);
+                         const std::vector<QuantileParam>& quantile_params,
+                         const std::vector<int>& topk_params,
+                         size_t entry_idx);
 
   void allocateCountDistinctGpuMem(const QueryMemoryDescriptor& query_mem_desc);
 
@@ -142,6 +144,18 @@ class QueryMemoryInitializer {
   std::vector<QuantileParam> allocateTDigests(const QueryMemoryDescriptor& query_mem_desc,
                                               const bool deferred,
                                               const Executor* executor);
+
+  std::vector<int> allocateTopKBuffers(const QueryMemoryDescriptor& query_mem_desc,
+                                       const bool deferred,
+                                       const Executor* executor);
+
+  void allocateAndInitTopKBuffers(const QueryMemoryDescriptor& query_mem_desc,
+                                  const Executor* executor,
+                                  size_t entry_count);
+
+  int8_t* allocateAndInitTopKBuffer(const hdk::ir::Type* elem_type,
+                                    int elem_count,
+                                    size_t entry_count);
 
   GpuGroupByBuffers prepareTopNHeapsDevBuffer(const QueryMemoryDescriptor& query_mem_desc,
                                               const int8_t* init_agg_vals_dev_ptr,
@@ -206,6 +220,8 @@ class QueryMemoryInitializer {
   size_t count_distinct_bitmap_mem_bytes_;
   int8_t* count_distinct_bitmap_crt_ptr_;
   int8_t* count_distinct_bitmap_host_mem_;
+
+  std::vector<int8_t*> topk_buffers_;
 
   DeviceAllocator* device_allocator_{nullptr};
   std::vector<Data_Namespace::AbstractBuffer*> temporary_buffers_;

--- a/omniscidb/QueryEngine/ResultSetReduction.h
+++ b/omniscidb/QueryEngine/ResultSetReduction.h
@@ -105,6 +105,12 @@ class ResultSetReduction {
                                          int8_t* this_ptr1,
                                          const int8_t* that_ptr1,
                                          const size_t target_logical_idx);
+  static void reduceOneTopKSlot(int8_t* this_ptr,
+                                const int8_t* that_ptr,
+                                int elem_size,
+                                bool is_fp,
+                                int topk_param,
+                                bool inline_buffer);
 };
 
 class ResultSetManager {

--- a/omniscidb/QueryEngine/ResultSetReductionCodegen.cpp
+++ b/omniscidb/QueryEngine/ResultSetReductionCodegen.cpp
@@ -403,6 +403,11 @@ void translate_function(const Function* function,
   for (const auto& constant : function->constants()) {
     llvm::Value* constant_llvm{nullptr};
     switch (constant->type()) {
+      case Type::Int1: {
+        constant_llvm =
+            cgen_state->llBool(static_cast<ConstantInt*>(constant.get())->value());
+        break;
+      }
       case Type::Int8: {
         constant_llvm =
             cgen_state->llInt<int8_t>(static_cast<ConstantInt*>(constant.get())->value());

--- a/omniscidb/QueryEngine/ResultSetReductionJIT.h
+++ b/omniscidb/QueryEngine/ResultSetReductionJIT.h
@@ -125,6 +125,13 @@ class ResultSetReductionJIT {
                                    const size_t target_logical_idx,
                                    Function* ir_reduce_one_entry) const;
 
+  void reduceOneTopKSlot(Value* this_ptr1,
+                         Value* that_ptr1,
+                         const hdk::ir::Type* arg_type,
+                         int topk_param,
+                         bool inline_bufer,
+                         Function* ir_reduce_one_entry) const;
+
   void finalizeReductionCode(ReductionCode& reduction_code,
                              const llvm::Function* ir_is_empty,
                              const llvm::Function* ir_reduce_one_entry,
@@ -169,3 +176,10 @@ class GpuReductionHelperJIT : public ResultSetReductionJIT {
  private:
   const QueryMemoryDescriptor& query_mem_desc_;
 };
+
+extern "C" RUNTIME_EXPORT void topk_reduce_jit_rt(const int64_t new_heap_handle,
+                                                  const int64_t old_heap_handle,
+                                                  int elem_size,
+                                                  bool is_fp,
+                                                  int topk_param,
+                                                  bool inline_buffer);

--- a/omniscidb/QueryEngine/TopKAggRuntime.h
+++ b/omniscidb/QueryEngine/TopKAggRuntime.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "ResultSet/TopKAggAccessors.h"
+
+#include <stdint.h>
+
+template <typename T, typename Comp>
+void agg_topk_insert_heapify(T* vals, T value, int pos, int max_size) {
+  Comp comp;
+  if (pos == max_size) {
+    // The heap is full, so maybe replace root and re-heapify top-down.
+    if (comp(vals[0], value)) {
+      int cur_pos = 0;
+      int prev_pos;
+      do {
+        int l = cur_pos * 2 + 1;
+        int r = cur_pos * 2 + 2;
+        prev_pos = cur_pos;
+
+        if (l < max_size) {
+          T l_val = vals[l];
+          if (r < max_size) {
+            T r_val = vals[r];
+            if (comp(l_val, r_val)) {
+              if (comp(l_val, value)) {
+                vals[cur_pos] = l_val;
+                cur_pos = l;
+              }
+            } else {
+              if (comp(r_val, value)) {
+                vals[cur_pos] = r_val;
+                cur_pos = r;
+              }
+            }
+          } else {
+            if (comp(l_val, value)) {
+              vals[cur_pos] = l_val;
+              cur_pos = l;
+            }
+          }
+        }
+      } while (cur_pos != prev_pos);
+      vals[cur_pos] = value;
+    }
+  } else {
+    // Bottom-up insert to the end of the heap.
+    while (pos) {
+      int parent_pos = (pos - 1) / 2;
+      T parent_value = vals[parent_pos];
+      if (comp(value, parent_value)) {
+        vals[pos] = parent_value;
+        pos = parent_pos;
+      } else {
+        break;
+      }
+    }
+    vals[pos] = value;
+  }
+}
+
+template <typename T>
+void agg_topk_impl(int64_t* agg, T val, T empty_val, int k, bool inline_buffer) {
+  T* agg_vals = inline_buffer ? reinterpret_cast<T*>(agg) : reinterpret_cast<T*>(*agg);
+  auto pos = getTopKHeapSize<T>(agg_vals, empty_val, std::abs(k));
+  if (k > 0) {
+    agg_topk_insert_heapify<T, std::less<T>>(agg_vals, val, pos, k);
+  } else {
+    agg_topk_insert_heapify<T, std::greater<T>>(agg_vals, val, pos, -k);
+  }
+}

--- a/omniscidb/QueryEngine/WorkUnitBuilder.cpp
+++ b/omniscidb/QueryEngine/WorkUnitBuilder.cpp
@@ -463,6 +463,10 @@ void WorkUnitBuilder::processAggregate(const ir::Aggregate* agg) {
     auto target_expr = translator.normalize(rewritten_expr.get());
     target_expr = fold_expr(target_expr.get());
     new_target_exprs.emplace_back(target_expr);
+    if (co_.device_type == ExecutorDeviceType::GPU && expr->is<ir::AggExpr>() &&
+        expr->as<ir::AggExpr>()->aggType() == ir::AggType::kTopK) {
+      throw QueryMustRunOnCpu();
+    }
   }
 
   for (size_t i = 0; i < agg->size(); ++i) {

--- a/omniscidb/ResultSet/ArrowResultSetConverter.cpp
+++ b/omniscidb/ResultSet/ArrowResultSetConverter.cpp
@@ -1453,7 +1453,11 @@ std::shared_ptr<arrow::Table> ArrowResultSetConverter::getArrowTable(
 
     size_t row_size_bytes = 0;
     for (size_t i = 0; i < col_count; i++) {
-      row_size_bytes += results_->colType(i)->size();
+      if (results_->colType(i)->isVarLen()) {
+        row_size_bytes += 8;
+      } else {
+        row_size_bytes += results_->colType(i)->size();
+      }
     }
     CHECK_GT(row_size_bytes, (size_t)0);
 

--- a/omniscidb/ResultSet/CMakeLists.txt
+++ b/omniscidb/ResultSet/CMakeLists.txt
@@ -10,6 +10,7 @@ set(result_set_source_files
     RowSetMemoryOwner.cpp
     StreamingTopN.cpp
     TargetValue.cpp
+    TopKAggAccessors.cpp
 )
 
 add_library(ResultSet ${result_set_source_files})

--- a/omniscidb/ResultSet/ColSlotContext.cpp
+++ b/omniscidb/ResultSet/ColSlotContext.cpp
@@ -55,6 +55,12 @@ ColSlotContext::ColSlotContext(const std::vector<const hdk::ir::Expr*>& col_expr
       const auto agg_info = get_target_info(col_expr, bigint_count);
       const auto chosen_type = get_compact_type(agg_info);
 
+      if (agg_info.agg_kind == hdk::ir::AggType::kTopK) {
+        addSlotForColumn(sizeof(int64_t), col_expr_idx);
+        ++col_expr_idx;
+        continue;
+      }
+
       if (chosen_type->isString() || chosen_type->isArray()) {
         addSlotForColumn(sizeof(int64_t), col_expr_idx);
         addSlotForColumn(sizeof(int64_t), col_expr_idx);

--- a/omniscidb/ResultSet/QueryMemoryDescriptor.cpp
+++ b/omniscidb/ResultSet/QueryMemoryDescriptor.cpp
@@ -28,6 +28,7 @@ QueryMemoryDescriptor::QueryMemoryDescriptor(
     ConfigPtr config,
     const std::vector<InputTableInfo>& query_infos,
     const bool approx_quantile,
+    const bool topk_agg,
     const bool allow_multifrag,
     const bool keyless_hash,
     const bool interleaved_bins_on_gpu,
@@ -81,7 +82,7 @@ QueryMemoryDescriptor::QueryMemoryDescriptor(
         output_columnar_ = output_columnar_hint &&
                            QueryMemoryDescriptor::countDescriptorsLogicallyEmpty(
                                count_distinct_descriptors_) &&
-                           !approx_quantile;
+                           !approx_quantile && !topk_agg;
         break;
       default:
         output_columnar_ = false;
@@ -211,7 +212,7 @@ bool QueryMemoryDescriptor::operator==(const QueryMemoryDescriptor& other) const
   if (has_nulls_ != other.has_nulls_) {
     return false;
   }
-  if (count_distinct_descriptors_.size() != count_distinct_descriptors_.size()) {
+  if (count_distinct_descriptors_.size() != other.count_distinct_descriptors_.size()) {
     return false;
   } else {
     // Count distinct descriptors can legitimately differ in device only.

--- a/omniscidb/ResultSet/QueryMemoryDescriptor.h
+++ b/omniscidb/ResultSet/QueryMemoryDescriptor.h
@@ -77,6 +77,7 @@ class QueryMemoryDescriptor {
                         ConfigPtr config,
                         const std::vector<InputTableInfo>& query_infos,
                         const bool approx_quantile,
+                        const bool topk_agg,
                         const bool allow_multifrag,
                         const bool keyless_hash,
                         const bool interleaved_bins_on_gpu,

--- a/omniscidb/ResultSet/ResultSet.h
+++ b/omniscidb/ResultSet/ResultSet.h
@@ -719,6 +719,10 @@ class ResultSet {
                                     const bool translate_strings,
                                     const size_t entry_buff_idx) const;
 
+  TargetValue makeVarlenTargetValueFromTopKHeap(const int8_t* slot_ptr,
+                                                int8_t slot_size,
+                                                const TargetInfo& target_info) const;
+
   struct VarlenTargetPtrPair {
     int8_t* ptr1;
     int8_t compact_sz1;

--- a/omniscidb/ResultSet/RowSetMemoryOwner.h
+++ b/omniscidb/ResultSet/RowSetMemoryOwner.h
@@ -234,6 +234,8 @@ class RowSetMemoryOwner final : public SimpleAllocator, boost::noncopyable {
 
   quantile::TDigest* nullTDigest(double const q);
 
+  int8_t* topKBuffer(size_t size);
+
  private:
   struct CountDistinctBitmapBuffer {
     int8_t* ptr;

--- a/omniscidb/ResultSet/TopKAggAccessors.cpp
+++ b/omniscidb/ResultSet/TopKAggAccessors.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "TopKAggAccessors.h"
+
+#include "IR/Type.h"
+
+int getTopKHeapSize(const int8_t* heap_handle,
+                    const hdk::ir::Type* elem_type,
+                    int max_heap_size) {
+  switch (elem_type->canonicalSize()) {
+    case 1:
+      return getTopKHeapSize(reinterpret_cast<const int8_t*>(heap_handle),
+                             inline_null_value<int8_t>(),
+                             max_heap_size);
+    case 2:
+      return getTopKHeapSize(reinterpret_cast<const int16_t*>(heap_handle),
+                             inline_null_value<int16_t>(),
+                             max_heap_size);
+    case 4:
+      if (elem_type->isFloatingPoint()) {
+        return getTopKHeapSize(reinterpret_cast<const float*>(heap_handle),
+                               inline_null_value<float>(),
+                               max_heap_size);
+      } else {
+        return getTopKHeapSize(reinterpret_cast<const int32_t*>(heap_handle),
+                               inline_null_value<int32_t>(),
+                               max_heap_size);
+      }
+    case 8:
+      if (elem_type->isFloatingPoint()) {
+        return getTopKHeapSize(reinterpret_cast<const double*>(heap_handle),
+                               inline_null_value<double>(),
+                               max_heap_size);
+      } else {
+        return getTopKHeapSize(reinterpret_cast<const int64_t*>(heap_handle),
+                               inline_null_value<int64_t>(),
+                               max_heap_size);
+      }
+    default:
+      CHECK(false);
+  }
+  return 0;
+}

--- a/omniscidb/ResultSet/TopKAggAccessors.h
+++ b/omniscidb/ResultSet/TopKAggAccessors.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+namespace hdk::ir {
+class Type;
+}
+
+#include <stdint.h>
+
+template <typename T>
+int getTopKHeapSize(const T* vals, T empty_value, int max_size) {
+  if (vals[max_size - 1] != empty_value) {
+    return max_size;
+  }
+  int l = 0;
+  int r = max_size - 1;
+  while (l != r) {
+    int cur = (l + r) / 2;
+    if (vals[cur] == empty_value) {
+      r = cur;
+    } else {
+      l = cur + 1;
+    }
+  }
+
+  return l;
+}
+
+int getTopKHeapSize(const int8_t* heap_handle,
+                    const hdk::ir::Type* elem_type,
+                    int max_heap_size);

--- a/omniscidb/Shared/SqlTypesLayout.h
+++ b/omniscidb/Shared/SqlTypesLayout.h
@@ -57,7 +57,8 @@ inline const hdk::ir::Type* get_compact_type(const TargetInfo& target) {
 inline void set_compact_type(TargetInfo& target, const hdk::ir::Type* new_type) {
   if (target.is_agg) {
     const auto agg_type = target.agg_kind;
-    if (agg_type != hdk::ir::AggType::kCount || !target.agg_arg_type) {
+    if ((agg_type != hdk::ir::AggType::kCount && agg_type != hdk::ir::AggType::kTopK) ||
+        !target.agg_arg_type) {
       target.agg_arg_type = new_type;
       return;
     }

--- a/python/pyhdk/_builder.pxd
+++ b/python/pyhdk/_builder.pxd
@@ -40,6 +40,8 @@ cdef extern from "omniscidb/QueryBuilder/QueryBuilder.h":
     CBuilderExpr approxQuantile(double) except +
     CBuilderExpr sample() except +
     CBuilderExpr singleValue() except +
+    CBuilderExpr topK(int) except +
+    CBuilderExpr bottomK(int) except +
     CBuilderExpr stdDev() except +
     CBuilderExpr corr(const CBuilderExpr&) except +
 

--- a/python/pyhdk/_builder.pyx
+++ b/python/pyhdk/_builder.pyx
@@ -96,6 +96,20 @@ cdef class QueryExpr:
     res.c_expr = self.c_expr.singleValue()
     return res
 
+  def top_k(self, count):
+    if not isinstance(count, int) or count == 0:
+      raise TypeError(f"Expected non-zero integer value as count arg. Provided: {type(count)}.")
+    res = QueryExpr()
+    res.c_expr = self.c_expr.topK(count)
+    return res
+
+  def bottom_k(self, count):
+    if not isinstance(count, int) or count == 0:
+      raise TypeError(f"Expected non-zero integer value as count arg. Provided: {type(count)}.")
+    res = QueryExpr()
+    res.c_expr = self.c_expr.bottomK(count)
+    return res
+
   def stddev(self):
     res = QueryExpr();
     res.c_expr = self.c_expr.stdDev()

--- a/python/pyhdk/hdk.py
+++ b/python/pyhdk/hdk.py
@@ -269,6 +269,60 @@ class QueryExprAPI:
         """
         pass
 
+    def top_k(self, count):
+        """
+        Create TOP_K aggregate expression with the current expression as its argument.
+
+        Parameters
+        ----------
+        count : int
+            Maximum number of top elements to collect.
+
+        Returns
+        -------
+        QueryExpr
+
+        Examples
+        --------
+        >>> hdk = pyhdk.init()
+        >>> ht = hdk.import_pydict({"a": [1, 1, 1, 2, 2, 2], "b": [1, 3, 2, 4, 6, 5]})
+        >>> ht.agg(["a"], ht["b"].top_k(2)).run()
+        Schema:
+          a: INT64
+          b_top_2: ARRAY32(INT64)[NN]
+        Data:
+        1|[3,2,]
+        2|[6,5,]
+        """
+        pass
+
+    def bottom_k(self, count):
+        """
+        Create BOTTOM_K aggregate expression with the current expression as its argument.
+
+        Parameters
+        ----------
+        count : int
+            Maximum number of bottom elements to collect.
+
+        Returns
+        -------
+        QueryExpr
+
+        Examples
+        --------
+        >>> hdk = pyhdk.init()
+        >>> ht = hdk.import_pydict({"a": [1, 1, 1, 2, 2, 2], "b": [1, 3, 2, 4, 6, 5]})
+        >>> ht.agg(["a"], ht["b"].bottom_k(2)).run()
+        Schema:
+          a: INT64
+          b_top_2: ARRAY32(INT64)[NN]
+        Data:
+        1|[1,2,]
+        2|[4,5,]
+        """
+        pass
+
     def stddev(self):
         """
         Create sample standard deviation aggregate expression for the current expression.

--- a/python/tests/helpers.py
+++ b/python/tests/helpers.py
@@ -24,5 +24,7 @@ def check_res(res, expected):
         for expected_val, actual_val in zip(expected[col], vals):
             if type(expected_val) is float:
                 assert abs(expected_val - actual_val) < 0.0001
+            elif type(expected_val) is list:
+                assert (expected_val == actual_val).all()
             else:
                 assert expected_val == actual_val

--- a/python/tests/test_pyhdk_api.py
+++ b/python/tests/test_pyhdk_api.py
@@ -1153,6 +1153,16 @@ class TestBuilder(BaseTest):
             },
         )
 
+    def test_top_k(self):
+        hdk = pyhdk.init()
+        ht = hdk.import_pydict({"a": [1, 1, 1, 2, 2, 2], "b": [1, 3, 2, 4, 6, 5]})
+
+        res = ht.agg(["a"], ht["b"].top_k(2)).sort("a").run()
+        check_res(res, {"a": [1, 2], "b_top_2": [[3, 2], [6, 5]]})
+
+        res = ht.agg(["a"], ht["b"].bottom_k(2)).sort("a").run()
+        check_res(res, {"a": [1, 2], "b_bottom_2": [[1, 2], [4, 5]]})
+
 
 class TestSql(BaseTest):
     def test_no_alias(self, exe_cfg):


### PR DESCRIPTION
This patch introduces new aggregates to get top/bottom K elements. The result is a variable-length array. Nulls are excluded, so the resulting array can be empty (but never null).

Initially, I wanted to use our regular layout for variable-length arrays, but then I thought that to get the top 2 integers we would need two 8-byte slots + 8 bytes for array data. That is 3x of the actual stored data and we would need to allocate it for all entries and pay additional initialization costs. So instead of that, I used null-terminated arrays with a known max size. Also, if an array is small enough (<=8 bytes), it is inlined into the slot and we don't pay any additional memory at all. E.g. for the top 2 32-bit integers we would simply have a 8-byte slot and no additional allocations. For the top 3 32-bit integers we would have an 8-byte slot with a pointer to 12-byte array data.

To minimize the number of comparisons and copies, TopK arrays actually hold heaps. We build a min-heap for TopK and a max-heap for BottomK. Therefore insertion is log(N) copies at most. I'm not sure if it is worth the effort, because it has no benefit for a small number of elements. But it still can be beneficial for bigger arrays, so I kept the heaps. This can be revised and adjusted later when we have some real cases to analyze.

It seemed useful to not only have an array with top K elements but also have it sorted in the final. I do this sort on a fetch. We copy data on fetch anyway, so it is a good time to reverse and sort. If we want this sort to be included in execution for more accurate perf measurement, we can make it a part of the reduction. Though it would make reduction necessary even if we have a single fragment and some special reduction would be required in case of the partitioned aggregation with TopK. We can also get rid of heaps and store sorted arrays from the first place (at least for small arrays).

Similar to quantile, TopK disables columnar format. There is no real problem preventing such support, but using the columnar format for aggregations is usually a bad idea overall (at least on CPU), so I decided it doesn't worth the effort.
