### PR TITLE
Generalize compile options creation

### DIFF
--- a/omniscidb/CudaMgr/CudaMgr.h
+++ b/omniscidb/CudaMgr/CudaMgr.h
@@ -164,6 +164,8 @@ class CudaMgr : public GpuMgr {
     return getMinNumMPsForAllDevices();
   };
 
+  bool hasFP64Support() const override { return isArchPascalOrLater(); }
+
   bool hasSharedMemoryAtomicsSupport() const override {
     /*
      * From CUDA Toolkit documentation:

--- a/omniscidb/DataMgr/GpuMgr.h
+++ b/omniscidb/DataMgr/GpuMgr.h
@@ -62,5 +62,7 @@ struct GpuMgr {
   virtual uint32_t getGridSize() const = 0;
   virtual uint32_t getMinEUNumForAllDevices() const = 0;
   virtual bool hasSharedMemoryAtomicsSupport() const = 0;
+  // TODO: hasFP64Support implementations do not account for different device capabilities
+  virtual bool hasFP64Support() const { return true; };
   virtual size_t getMinSharedMemoryPerBlockForAllDevices() const = 0;
 };

--- a/omniscidb/L0Mgr/L0Mgr.cpp
+++ b/omniscidb/L0Mgr/L0Mgr.cpp
@@ -451,6 +451,14 @@ bool L0Manager::hasSharedMemoryAtomicsSupport() const {
   return true;
 }
 
+bool L0Manager::hasFP64Support() const {
+  CHECK_GT(drivers_[0]->devices().size(), size_t(0));
+  ze_device_module_properties_t module_props;
+  L0_SAFE_CALL(
+      zeDeviceGetModuleProperties(drivers_[0]->devices()[0]->device(), &module_props));
+  return module_props.fp64flags;
+}
+
 size_t L0Manager::getMinSharedMemoryPerBlockForAllDevices() const {
   auto comp = [](const auto& a, const auto& b) {
     return a->maxSharedLocalMemory() < b->maxSharedLocalMemory();

--- a/omniscidb/L0Mgr/L0Mgr.h
+++ b/omniscidb/L0Mgr/L0Mgr.h
@@ -239,12 +239,13 @@ class L0Manager : public GpuMgr {
   size_t getMaxAllocationSize(const int device_num) const;
   size_t getPageSize(const int device_num) const { return 4096u; }
 
-  virtual uint32_t getMaxBlockSize() const override;
-  virtual int8_t getSubGroupSize() const override;
-  virtual uint32_t getGridSize() const override;
-  virtual uint32_t getMinEUNumForAllDevices() const override;
-  virtual bool hasSharedMemoryAtomicsSupport() const override;
-  virtual size_t getMinSharedMemoryPerBlockForAllDevices() const override;
+  uint32_t getMaxBlockSize() const override;
+  int8_t getSubGroupSize() const override;
+  uint32_t getGridSize() const override;
+  uint32_t getMinEUNumForAllDevices() const override;
+  bool hasSharedMemoryAtomicsSupport() const override;
+  bool hasFP64Support() const override;
+  size_t getMinSharedMemoryPerBlockForAllDevices() const override;
 
   const std::vector<std::shared_ptr<L0Driver>>& drivers() const;
 

--- a/omniscidb/L0Mgr/L0MgrNoL0.cpp
+++ b/omniscidb/L0Mgr/L0MgrNoL0.cpp
@@ -148,7 +148,6 @@ size_t L0Manager::getMinSharedMemoryPerBlockForAllDevices() const {
   return 0u;
 };
 
-
 bool L0Manager::hasFP64Support() const {
   CHECK(false);
   return false;

--- a/omniscidb/L0Mgr/L0MgrNoL0.cpp
+++ b/omniscidb/L0Mgr/L0MgrNoL0.cpp
@@ -148,6 +148,12 @@ size_t L0Manager::getMinSharedMemoryPerBlockForAllDevices() const {
   return 0u;
 };
 
+
+bool L0Manager::hasFP64Support() const {
+  CHECK(false);
+  return false;
+}
+
 const std::vector<std::shared_ptr<L0Driver>>& L0Manager::drivers() const {
   return drivers_;
 }

--- a/omniscidb/QueryEngine/CMakeLists.txt
+++ b/omniscidb/QueryEngine/CMakeLists.txt
@@ -23,6 +23,7 @@ set(query_engine_source_files
     ColumnIR.cpp
     CompareIR.cpp
     CompilationOptions.cpp
+    CompilationOptionsBuilder.cpp
     Compiler/Backend.cpp
     Compiler/HelperFunctions.cpp
     ConstantIR.cpp

--- a/omniscidb/QueryEngine/CompilationOptions.h
+++ b/omniscidb/QueryEngine/CompilationOptions.h
@@ -90,8 +90,8 @@ struct CompilationOptions {
         /*codegen_traits_desc=*/getCgenTraitsDesc(device_type, is_l0)};
   }
 
-  //  private:
-  //   CompilationOptions() = default;
+ private:
+  CompilationOptions() = default;
 };
 
 enum class ExecutorType { Native, Extern };

--- a/omniscidb/QueryEngine/CompilationOptions.h
+++ b/omniscidb/QueryEngine/CompilationOptions.h
@@ -89,6 +89,9 @@ struct CompilationOptions {
         /*use_groupby_buffer_desc=*/false,
         /*codegen_traits_desc=*/getCgenTraitsDesc(device_type, is_l0)};
   }
+
+  //  private:
+  //   CompilationOptions() = default;
 };
 
 enum class ExecutorType { Native, Extern };

--- a/omniscidb/QueryEngine/CompilationOptionsBuilder.cpp
+++ b/omniscidb/QueryEngine/CompilationOptionsBuilder.cpp
@@ -37,9 +37,8 @@ void CompilationOptionsBuilder::applyConfigSettings(CompilationOptions& co,
 }
 
 CompilationOptions CompilationOptionsDefaultBuilder::build(const ExecutorDeviceType dt) {
-  CHECK(config_);
   auto co = makeCompilationOptions(dt);
-  applyConfigSettings(co, *config_);
-  setCodegenTraits(co, *platform_);
+  applyConfigSettings(co, config_);
+  setCodegenTraits(co, platform_);
   return co;
 }

--- a/omniscidb/QueryEngine/CompilationOptionsBuilder.cpp
+++ b/omniscidb/QueryEngine/CompilationOptionsBuilder.cpp
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "CompilationOptionsBuilder.h"
+#include "Logger/Logger.h"
+
+CompilationOptions CompilationOptionsBuilder::makeCompilationOptions(
+    const ExecutorDeviceType dt) {
+  return CompilationOptions{dt,
+                            /*hoist_literals=*/true,
+                            /*opt_level=*/ExecutorOptLevel::Default,
+                            /*with_dynamic_watchdog=*/false,
+                            /*allow_lazy_fetch=*/true,
+                            /*filter_on_delted_column=*/true,
+                            /*explain_type=*/ExecutorExplainType::Default,
+                            /*register_intel_jit_listener=*/false,
+                            /*use_groupby_buffer_desc=*/false,
+                            /*codegen_traits_desc=*/compiler::cpu_cgen_traits_desc};
+}
+
+void CompilationOptionsBuilder::setCodegenTraits(
+    CompilationOptions& co,
+    const std::optional<GpuMgrPlatform> platform) {
+  CHECK_EQ(co.device_type, ExecutorDeviceType::GPU);
+  co.codegen_traits_desc = CompilationOptions::getCgenTraitsDesc(
+      co.device_type,
+      (platform.has_value() ? platform.value() == GpuMgrPlatform::L0 : false));
+}
+
+void CompilationOptionsBuilder::applyConfigSettings(CompilationOptions& co,
+                                                    const Config& cfg) {
+  co.hoist_literals = cfg.exec.codegen.hoist_literals;
+  co.device_type = cfg.exec.cpu_only ? ExecutorDeviceType::CPU : co.device_type;
+}
+
+CompilationOptions CompilationOptionsDefaultBuilder::build(const ExecutorDeviceType dt) {
+  CHECK(config_);
+  auto co = makeCompilationOptions(dt);
+  applyConfigSettings(co, *config_);
+  setCodegenTraits(co, *platform_);
+  return co;
+}

--- a/omniscidb/QueryEngine/CompilationOptionsBuilder.h
+++ b/omniscidb/QueryEngine/CompilationOptionsBuilder.h
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "CompilationOptions.h"
+#include "Shared/GpuPlatform.h"
+
+#include <optional>
+
+class CompilationOptionsBuilder {
+ protected:
+  CompilationOptions makeCompilationOptions(const ExecutorDeviceType dt);
+  void setCodegenTraits(CompilationOptions& co, const std::optional<GpuMgrPlatform> p);
+  void applyConfigSettings(CompilationOptions& co, const Config& cfg);
+
+ public:
+  virtual CompilationOptions build(const ExecutorDeviceType) = 0;
+};
+
+class CompilationOptionsDefaultBuilder : public CompilationOptionsBuilder {
+ private:
+  const Config* config_;
+  const std::optional<GpuMgrPlatform>* platform_;
+
+ public:
+  // The default constructor exists to satisfy cython's limitaion for stack allocation
+  CompilationOptionsDefaultBuilder() {}
+  CompilationOptionsDefaultBuilder(const Config& cfg,
+                                   const std::optional<GpuMgrPlatform>& p = std::nullopt)
+      : config_(&cfg), platform_(&p) {}
+  CompilationOptions build(const ExecutorDeviceType dt) override;
+};

--- a/omniscidb/QueryEngine/CompilationOptionsBuilder.h
+++ b/omniscidb/QueryEngine/CompilationOptionsBuilder.h
@@ -23,14 +23,12 @@ class CompilationOptionsBuilder {
 
 class CompilationOptionsDefaultBuilder : public CompilationOptionsBuilder {
  private:
-  const Config* config_;
-  const std::optional<GpuMgrPlatform>* platform_;
+  const Config& config_;
+  const std::optional<GpuMgrPlatform> platform_;
 
  public:
-  // The default constructor exists to satisfy cython's limitaion for stack allocation
-  CompilationOptionsDefaultBuilder() {}
   CompilationOptionsDefaultBuilder(const Config& cfg,
-                                   const std::optional<GpuMgrPlatform>& p = std::nullopt)
-      : config_(&cfg), platform_(&p) {}
+                                   const std::optional<GpuMgrPlatform> p = std::nullopt)
+      : config_(cfg), platform_(p) {}
   CompilationOptions build(const ExecutorDeviceType dt) override;
 };

--- a/omniscidb/QueryEngine/Execute.cpp
+++ b/omniscidb/QueryEngine/Execute.cpp
@@ -889,19 +889,9 @@ GpuMgr* Executor::gpuMgr() const {
   return gpu_mgr;
 }
 
-bool Executor::isArchPascalOrLater(const ExecutorDeviceType dt) const {
-  if (dt == ExecutorDeviceType::GPU) {
-    return gpuMgr()->getPlatform() == GpuMgrPlatform::CUDA
-               ? cudaMgr()->isArchPascalOrLater()
-               : false;
-  }
-  return false;
-}
-
 bool Executor::deviceSupportsFP64(const ExecutorDeviceType dt) const {
   if (dt == ExecutorDeviceType::GPU) {
-    return gpuMgr()->getPlatform() == GpuMgrPlatform::CUDA ? isArchPascalOrLater(dt)
-                                                           : true;
+    return gpuMgr()->hasFP64Support();
   }
   return true;
 }

--- a/omniscidb/QueryEngine/Execute.h
+++ b/omniscidb/QueryEngine/Execute.h
@@ -431,8 +431,6 @@ class Executor : public StringDictionaryProxyProvider {
 
   GpuMgr* gpuMgr() const;
 
-  bool isArchPascalOrLater(const ExecutorDeviceType dt) const;
-
   bool deviceSupportsFP64(const ExecutorDeviceType dt) const;
 
   bool needFetchAllFragments(const InputColDescriptor& col_desc,

--- a/omniscidb/Tests/ArrowBasedExecuteTest.cpp
+++ b/omniscidb/Tests/ArrowBasedExecuteTest.cpp
@@ -9657,7 +9657,7 @@ TEST_F(Select, Joins_LeftJoinFiltered) {
   auto check_explain_result = [](const std::string& query,
                                  const ExecutorDeviceType dt,
                                  const bool enable_filter_hoisting) {
-    CompilationOptions co;
+    CompilationOptions co = CompilationOptions::defaults(dt);
     co.device_type = dt;
     co.hoist_literals = true;
     ExecutionOptions eo = ExecutionOptions::fromConfig(config());

--- a/omniscidb/Tests/QueryBuilderTest.cpp
+++ b/omniscidb/Tests/QueryBuilderTest.cpp
@@ -61,7 +61,8 @@ class TestSuite : public ::testing::Test {
   ExecutionResult runQuery(std::unique_ptr<QueryDag> dag) {
     auto ra_executor = RelAlgExecutor(getExecutor(), getStorage(), std::move(dag));
     auto eo = ExecutionOptions::fromConfig(config());
-    return ra_executor.executeRelAlgQuery(CompilationOptions::defaults(), eo, false);
+    return ra_executor.executeRelAlgQuery(
+        CompilationOptions::defaults(ExecutorDeviceType::CPU), eo, false);
   }
 };
 

--- a/omniscidb/Tests/QueryBuilderTest.cpp
+++ b/omniscidb/Tests/QueryBuilderTest.cpp
@@ -61,8 +61,10 @@ class TestSuite : public ::testing::Test {
   ExecutionResult runQuery(std::unique_ptr<QueryDag> dag) {
     auto ra_executor = RelAlgExecutor(getExecutor(), getStorage(), std::move(dag));
     auto eo = ExecutionOptions::fromConfig(config());
-    return ra_executor.executeRelAlgQuery(
-        CompilationOptions::defaults(ExecutorDeviceType::CPU), eo, false);
+    auto co = CompilationOptions::defaults(ExecutorDeviceType::CPU);
+    // Work-around for https://github.com/intel-ai/hdk/issues/627
+    co.allow_lazy_fetch = false;
+    return ra_executor.executeRelAlgQuery(co, eo, false);
   }
 };
 

--- a/omniscidb/Tests/QueryBuilderTest.cpp
+++ b/omniscidb/Tests/QueryBuilderTest.cpp
@@ -61,7 +61,7 @@ class TestSuite : public ::testing::Test {
   ExecutionResult runQuery(std::unique_ptr<QueryDag> dag) {
     auto ra_executor = RelAlgExecutor(getExecutor(), getStorage(), std::move(dag));
     auto eo = ExecutionOptions::fromConfig(config());
-    return ra_executor.executeRelAlgQuery(CompilationOptions(), eo, false);
+    return ra_executor.executeRelAlgQuery(CompilationOptions::defaults(), eo, false);
   }
 };
 

--- a/python/pyhdk/_execute.pxd
+++ b/python/pyhdk/_execute.pxd
@@ -97,7 +97,6 @@ cdef extern from "omniscidb/QueryEngine/CompilationOptions.h":
 
 cdef extern from "omniscidb/QueryEngine/CompilationOptionsBuilder.h":
   cdef cppclass CCompilationOptionsDefaultBuilder "CompilationOptionsDefaultBuilder":
-    CCompilationOptionsDefaultBuilder()
     CCompilationOptionsDefaultBuilder(const CConfig, const optional[CGpuMgrPlatform])
     CCompilationOptions build(const CExecutorDeviceType)
 

--- a/python/pyhdk/_execute.pxd
+++ b/python/pyhdk/_execute.pxd
@@ -9,11 +9,12 @@ from libcpp.memory cimport shared_ptr, make_shared, unique_ptr, make_unique
 from libcpp.string cimport string
 from libcpp.vector cimport vector
 from libcpp.utility cimport move
+from libcpp.optional cimport optional
 
 from pyarrow.lib cimport CTable as CArrowTable
 
 from pyhdk._common cimport CType, CConfig
-from pyhdk._storage cimport MemoryLevel, DataMgr, CDataMgr, CBufferProvider, CSchemaProvider, CAbstractDataProvider
+from pyhdk._storage cimport MemoryLevel, DataMgr, CDataMgr, CBufferProvider, CSchemaProvider, CAbstractDataProvider, CGpuMgrPlatform
 
 cdef extern from "omniscidb/QueryEngine/Compiler/CodegenTraitsDescriptor.h" namespace "compiler":
   enum CCallingConvDesc "CallingConvDesc":
@@ -94,6 +95,12 @@ cdef extern from "omniscidb/QueryEngine/CompilationOptions.h":
     @staticmethod
     CExecutionOptions fromConfig(const CConfig)
 
+cdef extern from "omniscidb/QueryEngine/CompilationOptionsBuilder.h":
+  cdef cppclass CCompilationOptionsDefaultBuilder "CompilationOptionsDefaultBuilder":
+    CCompilationOptionsDefaultBuilder()
+    CCompilationOptionsDefaultBuilder(const CConfig, const optional[CGpuMgrPlatform])
+    CCompilationOptions build(const CExecutorDeviceType)
+
 cdef extern from "omniscidb/ResultSet/TargetValue.h":
   cdef cppclass CNullableString "NullableString":
     pass
@@ -153,6 +160,7 @@ cdef extern from "omniscidb/QueryEngine/Execute.h":
     void clearMemory(MemoryLevel, CDataMgr*)
     const CConfig &getConfig()
     shared_ptr[CConfig] getConfigPtr()
+    CDataMgr* getDataMgr()
 
 cdef class Executor:
   cdef shared_ptr[CExecutor] c_executor

--- a/python/pyhdk/_sql.pyx
+++ b/python/pyhdk/_sql.pyx
@@ -196,14 +196,12 @@ cdef class RelAlgExecutor:
     cdef const CConfig *config = self.c_rel_alg_executor.get().getExecutor().getConfigPtr().get()
     cdef optional[CGpuMgrPlatform] platform = self.c_data_mgr.get().getGpuMgr().getPlatform()
     cdef CCompilationOptionsDefaultBuilder builder = CCompilationOptionsDefaultBuilder(dereference(config), platform)
-    cdef CExecutorDeviceType dt
+    cdef CExecutorDeviceType dt = CExecutorDeviceType.CPU
     if kwargs.get("device_type", "auto") == "GPU" and not config.exec.cpu_only:
       dt = CExecutorDeviceType.GPU
-    else:
-      dt = CExecutorDeviceType.CPU
-    cdef CCompilationOptions c_co = builder.build(dt)
-    c_co.allow_lazy_fetch = kwargs.get("enable_lazy_fetch", config.rs.enable_lazy_fetch)
-    c_co.with_dynamic_watchdog = kwargs.get("enable_dynamic_watchdog", config.exec.watchdog.enable_dynamic)
+    cdef unique_ptr[CCompilationOptions] c_co = make_unique[CCompilationOptions](builder.build(dt))
+    c_co.get().allow_lazy_fetch = kwargs.get("enable_lazy_fetch", config.rs.enable_lazy_fetch)
+    c_co.get().with_dynamic_watchdog = kwargs.get("enable_dynamic_watchdog", config.exec.watchdog.enable_dynamic)
     cdef unique_ptr[CExecutionOptions] c_eo = make_unique[CExecutionOptions](CExecutionOptions.fromConfig(dereference(config)))
     c_eo.get().output_columnar_hint = kwargs.get("enable_columnar_output", config.rs.enable_columnar_output)
     c_eo.get().with_watchdog = kwargs.get("enable_watchdog", config.exec.watchdog.enable)
@@ -211,7 +209,7 @@ cdef class RelAlgExecutor:
     c_eo.get().just_explain = kwargs.get("just_explain", False)
     c_eo.get().forced_gpu_proportion = kwargs.get("forced_gpu_proportion", config.exec.heterogeneous.forced_gpu_proportion)
     c_eo.get().forced_cpu_proportion = 100 - c_eo.get().forced_gpu_proportion
-    cdef CExecutionResult c_res = self.c_rel_alg_executor.get().executeRelAlgQuery(c_co, dereference(c_eo.get()), False)
+    cdef CExecutionResult c_res = self.c_rel_alg_executor.get().executeRelAlgQuery(dereference(c_co.get()), dereference(c_eo.get()), False)
     cdef ExecutionResult res = ExecutionResult()
     res.c_result = move(c_res)
     res.c_data_mgr = self.c_data_mgr

--- a/python/pyhdk/_storage.pxd
+++ b/python/pyhdk/_storage.pxd
@@ -157,7 +157,7 @@ cdef extern from "omniscidb/DataMgr/GpuMgr.h":
     L0,
 
   cdef cppclass CGpuMgr "GpuMgr":
-    pass
+    CGpuMgrPlatform getPlatform()
 
 cdef extern from "omniscidb/DataMgr/PersistentStorageMgr/PersistentStorageMgr.h":
   cdef cppclass CPersistentStorageMgr "PersistentStorageMgr"(CAbstractBufferMgr):
@@ -170,6 +170,8 @@ cdef extern from "omniscidb/DataMgr/DataMgr.h" namespace "Data_Namespace":
     CPersistentStorageMgr* getPersistentStorageMgr() except +;
     CBufferProvider* getBufferProvider() except +;
     CDataProvider* getDataProvider() except +;
+
+    CGpuMgr* getGpuMgr()
 
 cdef class DataMgr:
   cdef shared_ptr[CDataMgr] c_data_mgr


### PR DESCRIPTION
This is an attempt to prevent issues like those in https://github.com/intel-ai/hdk/pull/599#pullrequestreview-1550317117. The PR adds CompilationOptionsBuilder and uses it in the python execute API.

This is somewhat similar to what we've done to execution options earlier. The goal would be to move to the new builder everywhere and remove all the direct options modification*, although the config might not be always present. We could use another implementation for such cases. The builder would also be responsible for any validation needed. For example, to check that `device_type` and the `codegen_traits_desc` are compliant.

*For example, things like ` c_co.get().allow_lazy_fetch = kwargs.get("enable_lazy_fetch", config.rs.enable_lazy_fetch)` should modify the config itself and everything else uses the config as a single source of truth.

Thoughts?