### PR TITLE
Add database id to TableGenerations.

### DIFF
--- a/omniscidb/QueryEngine/ColumnIR.cpp
+++ b/omniscidb/QueryEngine/ColumnIR.cpp
@@ -254,7 +254,8 @@ llvm::Value* CodeGenerator::codegenRowId(const hdk::ir::ColumnVar* col_var,
   AUTOMATIC_IR_METADATA(cgen_state_);
   const auto offset_lv = cgen_state_->frag_offsets_[adjusted_range_table_index(col_var)];
   llvm::Value* start_rowid_lv{nullptr};
-  const auto& table_generation = executor()->getTableGeneration(col_var->tableId());
+  const auto& table_generation =
+      executor()->getTableGeneration(col_var->dbId(), col_var->tableId());
   if (table_generation.start_rowid > 0) {
     // Handle the multi-node case: each leaf receives a start rowid used
     // to offset the local rowid and generate a cluster-wide unique rowid.

--- a/omniscidb/QueryEngine/Execute.h
+++ b/omniscidb/QueryEngine/Execute.h
@@ -352,7 +352,7 @@ class Executor : public StringDictionaryProxyProvider {
 
   TableFragmentsInfo getTableInfo(const int db_id, const int table_id) const;
 
-  const TableGeneration& getTableGeneration(const int table_id) const;
+  const TableGeneration& getTableGeneration(int db_id, int table_id) const;
 
   ExpressionRange getColRange(const PhysicalInput&) const;
 

--- a/omniscidb/QueryEngine/TableGenerations.cpp
+++ b/omniscidb/QueryEngine/TableGenerations.cpp
@@ -17,19 +17,22 @@
 #include "TableGenerations.h"
 #include "Logger/Logger.h"
 
-void TableGenerations::setGeneration(const uint32_t id,
+void TableGenerations::setGeneration(int db_id,
+                                     int table_id,
                                      const TableGeneration& generation) {
-  const auto it_ok = id_to_generation_.emplace(id, generation);
+  const auto it_ok =
+      id_to_generation_.emplace(std::make_pair(db_id, table_id), generation);
   CHECK(it_ok.second);
 }
 
-const TableGeneration& TableGenerations::getGeneration(const uint32_t id) const {
-  const auto it = id_to_generation_.find(id);
+const TableGeneration& TableGenerations::getGeneration(int db_id, int table_id) const {
+  const auto it = id_to_generation_.find(std::make_pair(db_id, table_id));
   CHECK(it != id_to_generation_.end());
   return it->second;
 }
 
-const std::unordered_map<uint32_t, TableGeneration>& TableGenerations::asMap() const {
+const std::unordered_map<std::pair<int, int>, TableGeneration>& TableGenerations::asMap()
+    const {
   return id_to_generation_;
 }
 

--- a/omniscidb/QueryEngine/TableGenerations.h
+++ b/omniscidb/QueryEngine/TableGenerations.h
@@ -27,16 +27,16 @@ struct TableGeneration {
 
 class TableGenerations {
  public:
-  void setGeneration(const uint32_t id, const TableGeneration& generation);
+  void setGeneration(int db_id, int table_id, const TableGeneration& generation);
 
-  const TableGeneration& getGeneration(const uint32_t id) const;
+  const TableGeneration& getGeneration(int db_id, int table_id) const;
 
-  const std::unordered_map<uint32_t, TableGeneration>& asMap() const;
+  const std::unordered_map<std::pair<int, int>, TableGeneration>& asMap() const;
 
   void clear();
 
  private:
-  std::unordered_map<uint32_t, TableGeneration> id_to_generation_;
+  std::unordered_map<std::pair<int, int>, TableGeneration> id_to_generation_;
 };
 
 #endif  // QUERYENGINE_TABLEGENERATIONS_H


### PR DESCRIPTION
TableGenerations class uses table id as a unique table key which is wrong when multiple storages are involved. Fix it by adding database id.

This fixes the second reproducer in #588.
