### PR TITLE
Add support for GPerftools to taxi benchmark

### DIFF
--- a/omniscidb/Benchmarks/taxi/CMakeLists.txt
+++ b/omniscidb/Benchmarks/taxi/CMakeLists.txt
@@ -4,4 +4,5 @@ add_executable(${bench_name} taxi_reduced_bench.cpp)
 target_link_libraries(${bench_name} ${EXECUTE_TEST_LIBS} benchmark)
 
 add_executable(taxi_full taxi_full_bench.cpp)
-target_link_libraries(taxi_full ${EXECUTE_TEST_LIBS} benchmark)
+target_link_options(taxi_full PUBLIC "LINKER:--no-as-needed")
+target_link_libraries(taxi_full ${PROFILER_LIBS} ${EXECUTE_TEST_LIBS} benchmark)

--- a/omniscidb/CMakeLists.txt
+++ b/omniscidb/CMakeLists.txt
@@ -31,6 +31,17 @@ string(TOLOWER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_LOWER)
 # Force -O0 optimization level for debug builds.
 set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
 
+set(PROFILER_LIBS "")
+option(ENABLE_PROFILER "Enable Gperftools linking" OFF)
+if(ENABLE_PROFILER)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer  -fPIC")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-omit-frame-pointer -fPIC")
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")
+  find_package(Gperftools REQUIRED COMPONENTS TCMALLOC PROFILER)
+  set(PROFILER_LIBS ${Gperftools_TCMALLOC} ${Gperftools_PROFILER})
+  add_definitions("-DHAVE_PROFILER")
+endif()
+
 if("${CMAKE_VERSION}" VERSION_GREATER 3.11.999)
   cmake_policy(SET CMP0074 NEW)
 endif()
@@ -608,14 +619,6 @@ if(TIME_LIMITED_BUILD)
   set(MAPD_PACKAGE_FLAGS "${MAPD_PACKAGE_FLAGS}-${TIME_LIMITED_NUMBER_OF_DAYS}d")
 endif()
 
-option(ENABLE_PROFILER "Enable google perftools" OFF)
-if(ENABLE_PROFILER)
-  find_package(Gperftools REQUIRED COMPONENTS TCMALLOC PROFILER)
-  set(PROFILER_LIBS ${Gperftools_TCMALLOC} ${Gperftools_PROFILER})
-  add_definitions("-DHAVE_PROFILER")
-else()
-  set(PROFILER_LIBS "")
-endif()
 
 add_subdirectory(SqliteConnector)
 


### PR DESCRIPTION
Modifies the existing code to ensure gperftools isn't removed by the linker (probably due to dynamic linking in conda env) and add some compiler flags to improve readability of stack traces, particularly under other profiling tools like `perf`.