### PR TITLE
Introduce simplified string dictionary 

### DIFF
--- a/omniscidb/StringDictionary/StringDictionary.cpp
+++ b/omniscidb/StringDictionary/StringDictionary.cpp
@@ -50,7 +50,7 @@ namespace {
 
 const int SYSTEM_PAGE_SIZE = omnisci::get_page_size();
 
-uint32_t hash_string(const std::string_view& str) {
+uint32_t hash_string(const std::string_view str) {
   uint32_t str_hash = 1;
   // rely on fact that unsigned overflow is defined and wraps
   for (size_t i = 0; i < str.size(); ++i) {
@@ -77,6 +77,9 @@ struct ThreadInfo {
 }  // namespace
 
 bool g_enable_stringdict_parallel{false};
+
+namespace legacy {
+
 constexpr int32_t StringDictionary::INVALID_STR_ID;
 constexpr size_t StringDictionary::MAX_STRLEN;
 constexpr size_t StringDictionary::MAX_STRCOUNT;
@@ -1256,6 +1259,8 @@ void StringDictionary::mergeSortedCache(std::vector<int32_t>& temp_sorted_cache)
   sorted_cache.swap(updated_cache);
 }
 
+}  // namespace legacy
+
 std::vector<int32_t> StringDictionaryTranslator::buildDictionaryTranslationMap(
     const std::shared_ptr<StringDictionary> source_dict,
     const std::shared_ptr<StringDictionary> dest_dict,
@@ -1368,9 +1373,12 @@ size_t StringDictionaryTranslator::buildDictionaryTranslationMap(
                  ++source_string_id) {
               const std::string_view source_str =
                   source_dict->getStringFromStorageFast(source_string_id);
-              // Get the hash from this/the source dictionary's cache, as the function
-              // will be the same for the dest_dict, sparing us having to recompute it
+          // Get the hash from this/the source dictionary's cache, as the function
+          // will be the same for the dest_dict, sparing us having to recompute it
 
+#ifndef USE_LEGACY_STR_DICT
+              const auto translated_string_id = dest_dict->getIdOfString(source_str);
+#else
               // Todo(todd): Remove option to turn string hash cache off or at least
               // make a constexpr to avoid these branches when we expect it to be always
               // on going forward
@@ -1382,6 +1390,7 @@ size_t StringDictionaryTranslator::buildDictionaryTranslationMap(
               const auto translated_string_id =
                   dest_dict->string_id_uint32_table_[hash_bucket];
               translated_ids[source_string_id] = translated_string_id;
+#endif
 
               if (translated_string_id == StringDictionary::INVALID_STR_ID ||
                   translated_string_id >= num_dest_strings) {
@@ -1407,3 +1416,315 @@ size_t StringDictionaryTranslator::buildDictionaryTranslationMap(
   }
   return total_num_strings_not_translated;
 }
+
+namespace fast {
+
+// Functors passed to eachStringSerially() must derive from StringCallback.
+// Each std::string const& (if isClient()) or std::string_view (if !isClient())
+// plus string_id is passed to the callback functor.
+void StringDictionary::eachStringSerially(int64_t const generation,
+                                          StringCallback& serial_callback) const {
+  // TODO: generation support
+  mapd_shared_lock<mapd_shared_mutex> read_lock(rw_mutex_);
+  for (size_t i = 0; i < numStrings(); i++) {
+    serial_callback(str(i), i);
+  }
+}
+
+int32_t StringDictionary::getOrAdd(const std::string_view& str) noexcept {
+  if (str.size() == 0) {
+    return inline_int_null_value<int32_t>();
+  }
+  CHECK(str.size() <= MAX_STRLEN);
+  const uint32_t hash = hash_string(str);
+
+  mapd_unique_lock<mapd_shared_mutex> rw_lock(rw_mutex_);
+  const int32_t string_id = addString(hash, str);
+  return string_id;
+}
+
+// can't we just do a default argument here?
+template <class T, class String>
+size_t StringDictionary::getBulk(const std::vector<String>& string_vec,
+                                 T* encoded_vec) const {
+  return getBulk(string_vec, encoded_vec, -1L /* generation */);
+}
+
+template size_t StringDictionary::getBulk(const std::vector<std::string>& string_vec,
+                                          uint8_t* encoded_vec) const;
+template size_t StringDictionary::getBulk(const std::vector<std::string>& string_vec,
+                                          uint16_t* encoded_vec) const;
+template size_t StringDictionary::getBulk(const std::vector<std::string>& string_vec,
+                                          int32_t* encoded_vec) const;
+
+template <class T, class String>
+size_t StringDictionary::getBulk(const std::vector<String>& string_vec,
+                                 T* encoded_vec,
+                                 const int64_t generation) const {
+  std::atomic<size_t> num_strings_not_found;
+  tbb::parallel_for(tbb::blocked_range<size_t>(0, string_vec.size()),
+                    [&](const tbb::blocked_range<size_t>& r) {
+                      for (size_t i = r.begin(); i != r.end(); ++i) {
+                        const auto& str = string_vec[i];
+                        if (str.empty()) {
+                          encoded_vec[i] = inline_int_null_value<T>();
+                        } else {
+                          if (str.size() > StringDictionary::MAX_STRLEN) {
+                            legacy::throw_string_too_long_error(str, dict_ref_);
+                          }
+
+                          const auto hash = hash_string(str);
+                          const auto string_id = getIdOfStringImpl(hash, str);
+                          if (string_id == StringDictionary::INVALID_STR_ID ||
+                              string_id > int32_t(strings.size())) {
+                            encoded_vec[i] = StringDictionary::INVALID_STR_ID;
+                            num_strings_not_found++;
+                          }
+                          encoded_vec[i] = string_id;
+                        }
+                      }
+                    });
+
+  return num_strings_not_found.load();
+}
+
+template size_t StringDictionary::getBulk(const std::vector<std::string>& string_vec,
+                                          uint8_t* encoded_vec,
+                                          const int64_t generation) const;
+template size_t StringDictionary::getBulk(const std::vector<std::string>& string_vec,
+                                          uint16_t* encoded_vec,
+                                          const int64_t generation) const;
+template size_t StringDictionary::getBulk(const std::vector<std::string>& string_vec,
+                                          int32_t* encoded_vec,
+                                          const int64_t generation) const;
+
+template <class T, class String>
+void StringDictionary::getOrAddBulk(const std::vector<String>& string_vec,
+                                    T* output_string_ids) {
+  mapd_lock_guard<mapd_shared_mutex> write_lock(rw_mutex_);
+
+  // compute hashes
+  auto hashes = std::make_unique<uint32_t[]>(string_vec.size());
+  tbb::parallel_for(tbb::blocked_range<size_t>(0, string_vec.size()),
+                    [&string_vec, &hashes](const tbb::blocked_range<size_t>& r) {
+                      for (size_t curr_id = r.begin(); curr_id != r.end(); ++curr_id) {
+                        if (string_vec[curr_id].empty()) {
+                          continue;
+                        }
+                        hashes[curr_id] = hash_string(string_vec[curr_id]);
+                      }
+                    });
+
+  for (size_t i = 0; i < string_vec.size(); i++) {
+    const auto& input_string = string_vec[i];
+    if (input_string.empty()) {
+      output_string_ids[i] = inline_int_null_value<T>();
+    } else {
+      // add string to storage and store id
+      const auto& hash = hashes[i];
+      output_string_ids[i] = addString(hash, input_string);
+    }
+  }
+}
+
+template void StringDictionary::getOrAddBulk(const std::vector<std::string>& string_vec,
+                                             uint8_t* encoded_vec);
+template void StringDictionary::getOrAddBulk(const std::vector<std::string>& string_vec,
+                                             uint16_t* encoded_vec);
+template void StringDictionary::getOrAddBulk(const std::vector<std::string>& string_vec,
+                                             int32_t* encoded_vec);
+
+template void StringDictionary::getOrAddBulk(
+    const std::vector<std::string_view>& string_vec,
+    uint8_t* encoded_vec);
+template void StringDictionary::getOrAddBulk(
+    const std::vector<std::string_view>& string_vec,
+    uint16_t* encoded_vec);
+template void StringDictionary::getOrAddBulk(
+    const std::vector<std::string_view>& string_vec,
+    int32_t* encoded_vec);
+
+template <class String>
+int32_t StringDictionary::getIdOfString(const String& str) const {
+  if (str.size() == 0) {
+    return inline_int_null_value<int32_t>();
+  }
+  CHECK(str.size() <= MAX_STRLEN);
+  const uint32_t hash = hash_string(str);
+
+  mapd_shared_lock<mapd_shared_mutex> read_lock(rw_mutex_);
+  return getIdOfStringImpl(hash, str);
+}
+
+template int32_t StringDictionary::getIdOfString(const std::string&) const;
+template int32_t StringDictionary::getIdOfString(const std::string_view&) const;
+
+std::string StringDictionary::getString(int32_t string_id) const {
+  mapd_shared_lock<mapd_shared_mutex> read_lock(rw_mutex_);
+  CHECK_LT(string_id, static_cast<int32_t>(numStrings()));
+  return str(string_id);
+}
+
+std::pair<char*, size_t> StringDictionary::getStringBytes(
+    int32_t string_id) const noexcept {
+  CHECK(false);
+  return std::make_pair(nullptr, 0);
+}
+
+size_t StringDictionary::storageEntryCount() const {
+  mapd_shared_lock<mapd_shared_mutex> read_lock(rw_mutex_);
+  return numStrings();
+}
+
+std::vector<int32_t> StringDictionary::getLike(const std::string& pattern,
+                                               const bool icase,
+                                               const bool is_simple,
+                                               const char escape,
+                                               const size_t generation) const {
+  CHECK(false);
+  return {};
+}
+
+std::vector<int32_t> StringDictionary::getCompare(const std::string& pattern,
+                                                  const std::string& comp_operator,
+                                                  const size_t generation) {
+  CHECK(false);
+  return {};
+}
+
+std::vector<int32_t> StringDictionary::getRegexpLike(const std::string& pattern,
+                                                     const char escape,
+                                                     const size_t generation) const {
+  CHECK(false);
+  return {};
+}
+
+std::vector<std::string> StringDictionary::copyStrings() const {
+  CHECK(false);
+  return {};
+}
+
+int32_t StringDictionary::getUnlocked(const std::string_view sv) const noexcept {
+  const uint32_t hash = hash_string(sv);
+  return getIdOfStringImpl(hash, sv);
+}
+
+std::string_view StringDictionary::getStringFromStorageFast(
+    const int string_id) const noexcept {
+  mapd_shared_lock<mapd_shared_mutex> read_lock(rw_mutex_);
+  return str(string_id);
+}
+
+template <class String>
+int32_t StringDictionary::addString(const uint32_t hash, const String& input_string) {
+  const size_t hash_table_size = hash_to_id_map.size();
+  uint32_t bucket = hash & (hash_table_size - 1);
+  // find an empty slot in the hash map
+  while (true) {
+    const int32_t candidate_string_id = hash_to_id_map[bucket].string_id;
+    if (candidate_string_id == INVALID_STR_ID) {
+      // found an open slot
+      // found an open slot - add the string to the strings payload
+      const auto str_id = addStringToMaps(bucket, hash, input_string);
+      if (2 * str_id > int32_t(size())) {
+        resize(2 * size());
+        VLOG(3) << "Resized to " << size() << " (holds " << numStrings() << ")";
+      }
+
+      return str_id;
+    }
+
+    // slot is full, check for a collision
+    if (hash == hash_to_id_map[bucket].hash) {
+      const auto& existing_string = hash_to_id_map[bucket].string;
+      if (existing_string == input_string) {
+        // found an existing string that matches
+        break;
+      }
+    }
+
+    // wrap around
+    if (++bucket == hash_table_size) {
+      bucket = 0;
+    }
+  }
+  return hash_to_id_map[bucket].string_id;
+}
+
+// on resize we need to re-hash the strings, as the hash is based on the total hash table
+// size
+// NOTE: in taxi this never gets called b/c the dictionaries are so small
+void StringDictionary::resize(const size_t new_size) {
+  CHECK_GT(new_size, size());
+
+  strings.reserve(new_size);
+
+  std::vector<HashMapPayload> new_hash_map(new_size);
+  hash_to_id_map.swap(new_hash_map);
+  const size_t hash_table_size = hash_to_id_map.size();
+
+  for (size_t i = 0; i < numStrings(); i++) {
+    const auto& crt_str = *strings[i].get();
+    const auto hash = hash_string(crt_str);
+    uint32_t bucket = hash & (hash_table_size - 1);
+
+    while (true) {
+      const int32_t candidate_string_id = hash_to_id_map[bucket].string_id;
+      if (candidate_string_id == INVALID_STR_ID) {
+        // found an open slot
+        hash_to_id_map[bucket].set(i, hash, crt_str);
+        break;
+      }
+
+      // slot is full, check for a collision
+      if (hash == hash_to_id_map[bucket].hash) {
+        const auto& existing_string = hash_to_id_map[bucket].string;
+        if (existing_string == crt_str) {
+          // found an existing string that matches
+          LOG(WARNING)
+              << "Found an existing string that matches during str dict hash table "
+                 "resize. Str dict may contain duplicates. Existing string: "
+              << existing_string << ", Input string: " << crt_str;
+          break;
+        }
+      }
+
+      // wrap around
+      if (++bucket == hash_table_size) {
+        bucket = 0;
+      }
+    }
+  }
+}
+
+int32_t StringDictionary::getIdOfStringImpl(const uint32_t hash,
+                                            const std::string_view input_string) const {
+  const size_t hash_table_size = hash_to_id_map.size();
+  uint32_t bucket = hash & (hash_table_size - 1);
+  // find an empty slot in the hash map
+  while (true) {
+    const int32_t candidate_string_id = hash_to_id_map[bucket].string_id;
+    if (candidate_string_id == INVALID_STR_ID) {
+      // found an open slot
+      return candidate_string_id;
+    }
+
+    // slot is full, check for a collision
+    if (hash == hash_to_id_map[bucket].hash) {
+      const auto& existing_string = hash_to_id_map[bucket].string;
+      if (existing_string == input_string) {
+        // found an existing string that matches
+        return candidate_string_id;
+      }
+    }
+
+    // wrap around
+    if (++bucket == hash_table_size) {
+      bucket = 0;
+    }
+  }
+  CHECK(false);
+  return -1;
+}
+
+}  // namespace fast

--- a/omniscidb/StringDictionary/StringDictionary.h
+++ b/omniscidb/StringDictionary/StringDictionary.h
@@ -31,7 +31,29 @@
 
 extern bool g_enable_stringdict_parallel;
 
+class StringDictionary;
+
 using StringLookupCallback = std::function<bool(std::string_view, int32_t string_id)>;
+
+class StringDictionaryTranslator {
+ public:
+  static std::vector<int32_t> buildDictionaryTranslationMap(
+      const std::shared_ptr<StringDictionary> source_dict,
+      const std::shared_ptr<StringDictionary> dest_dict,
+      StringLookupCallback const& dest_transient_lookup_callback);
+
+  static size_t buildDictionaryTranslationMap(
+      const StringDictionary* source_dict,
+      const StringDictionary* dest_dict,
+      int32_t* translated_ids,
+      const int64_t source_generation,
+      const int64_t dest_generation,
+      const bool dest_has_transients,
+      StringLookupCallback const& dest_transient_lookup_callback);
+
+ private:
+  StringDictionaryTranslator() {}
+};
 
 class StringDictionary {
  public:
@@ -88,18 +110,6 @@ class StringDictionary {
                                      const size_t generation) const;
 
   std::vector<std::string> copyStrings() const;
-
-  std::vector<int32_t> buildDictionaryTranslationMap(
-      const std::shared_ptr<StringDictionary> dest_dict,
-      StringLookupCallback const& dest_transient_lookup_callback) const;
-
-  size_t buildDictionaryTranslationMap(
-      const StringDictionary* dest_dict,
-      int32_t* translated_ids,
-      const int64_t source_generation,
-      const int64_t dest_generation,
-      const bool dest_has_transients,
-      StringLookupCallback const& dest_transient_lookup_callback) const;
 
   static constexpr int32_t INVALID_STR_ID = -1;
   static constexpr size_t MAX_STRLEN = (1 << 15) - 1;
@@ -205,6 +215,8 @@ class StringDictionary {
 
   char* CANARY_BUFFER{nullptr};
   size_t canary_buffer_size = 0;
+
+  friend class StringDictionaryTranslator;
 };
 
 int32_t truncate_to_generation(const int32_t id, const size_t generation);

--- a/omniscidb/StringDictionary/StringDictionary.h
+++ b/omniscidb/StringDictionary/StringDictionary.h
@@ -29,9 +29,23 @@
 #include <tuple>
 #include <vector>
 
+#define USE_LEGACY_STR_DICT
+
 extern bool g_enable_stringdict_parallel;
 
+namespace legacy {
 class StringDictionary;
+}
+
+namespace fast {
+class StringDictionary;
+}
+
+#ifdef USE_LEGACY_STR_DICT
+using StringDictionary = legacy::StringDictionary;
+#else
+using StringDictionary = fast::StringDictionary;
+#endif
 
 using StringLookupCallback = std::function<bool(std::string_view, int32_t string_id)>;
 
@@ -55,6 +69,10 @@ class StringDictionaryTranslator {
   StringDictionaryTranslator() {}
 };
 
+class StringLocalCallback;
+
+namespace legacy {
+
 class StringDictionary {
  public:
   StringDictionary(const DictRef& dict_ref,
@@ -76,7 +94,7 @@ class StringDictionary {
   // Each std::string const& (if isClient()) or std::string_view (if !isClient())
   // plus string_id is passed to the callback functor.
   void eachStringSerially(int64_t const generation, StringCallback&) const;
-  friend class StringLocalCallback;
+  friend class ::StringLocalCallback;
 
   int32_t getOrAdd(const std::string_view& str) noexcept;
   template <class T, class String>
@@ -216,9 +234,142 @@ class StringDictionary {
   char* CANARY_BUFFER{nullptr};
   size_t canary_buffer_size = 0;
 
-  friend class StringDictionaryTranslator;
+  friend class ::StringDictionaryTranslator;
 };
 
+}  // namespace legacy
+
 int32_t truncate_to_generation(const int32_t id, const size_t generation);
+
+namespace fast {
+
+class StringDictionary {
+ public:
+  StringDictionary(const DictRef& dict_ref,
+                   const bool materializeHashes = false,
+                   size_t initial_capacity = 256)
+      : dict_ref_(dict_ref), hash_to_id_map(initial_capacity) {
+    strings.reserve(initial_capacity);
+  }
+
+  int32_t getDbId() const noexcept { return dict_ref_.dbId; }
+  int32_t getDictId() const noexcept { return dict_ref_.dictId; }
+
+  class StringCallback {
+   public:
+    virtual ~StringCallback() = default;
+    virtual void operator()(std::string const&, int32_t const string_id) = 0;
+    virtual void operator()(std::string_view const, int32_t const string_id) = 0;
+  };
+
+  // Functors passed to eachStringSerially() must derive from StringCallback.
+  // Each std::string const& (if isClient()) or std::string_view (if !isClient())
+  // plus string_id is passed to the callback functor.
+  void eachStringSerially(int64_t const generation, StringCallback&) const;
+  friend class ::StringLocalCallback;
+
+  int32_t getOrAdd(const std::string_view& str) noexcept;
+  template <class T, class String>
+  size_t getBulk(const std::vector<String>& string_vec, T* encoded_vec) const;
+  template <class T, class String>
+  size_t getBulk(const std::vector<String>& string_vec,
+                 T* encoded_vec,
+                 const int64_t generation) const;
+  template <class T, class String>
+  void getOrAddBulk(const std::vector<String>& string_vec, T* encoded_vec);
+  template <class String>
+  int32_t getIdOfString(const String&) const;
+  std::string getString(int32_t string_id) const;
+  std::pair<char*, size_t> getStringBytes(int32_t string_id) const noexcept;
+  size_t storageEntryCount() const;
+
+  std::vector<int32_t> getLike(const std::string& pattern,
+                               const bool icase,
+                               const bool is_simple,
+                               const char escape,
+                               const size_t generation) const;
+
+  std::vector<int32_t> getCompare(const std::string& pattern,
+                                  const std::string& comp_operator,
+                                  const size_t generation);
+
+  std::vector<int32_t> getRegexpLike(const std::string& pattern,
+                                     const char escape,
+                                     const size_t generation) const;
+
+  std::vector<std::string> copyStrings() const;
+
+  static constexpr int32_t INVALID_STR_ID = -1;
+  static constexpr size_t MAX_STRLEN = (1 << 15) - 1;
+  static constexpr size_t MAX_STRCOUNT = (1U << 31) - 1;
+
+ private:
+  int32_t getUnlocked(const std::string_view sv) const noexcept;
+  std::string_view getStringFromStorageFast(const int string_id) const noexcept;
+  template <class String>
+  uint32_t computeBucket(
+      const uint32_t hash,
+      const String& input_string,
+      const std::vector<int32_t>& string_id_uint32_table) const noexcept;
+
+  template <class String>
+  int32_t addString(const uint32_t hash, const String& input_string);
+
+  const DictRef dict_ref_;
+  size_t str_count_;
+
+  struct HashMapPayload {
+    int32_t string_id;
+    uint32_t hash;
+    std::string_view string;
+
+    void set(const int32_t string_id_in,
+             const uint32_t hash_in,
+             std::string_view string_in) {
+      string_id = string_id_in;
+      hash = hash_in;
+      string = string_in;
+    }
+
+    HashMapPayload() : string_id(INVALID_STR_ID), hash(INVALID_STR_ID) {}
+  };
+
+  std::vector<HashMapPayload> hash_to_id_map;
+  std::vector<std::unique_ptr<std::string>> strings;
+
+  // returns added string ID
+  template <class String>
+  int32_t addStringToMaps(const size_t bucket, const uint32_t hash, const String& str) {
+    strings.emplace_back(std::make_unique<std::string>(str));
+    CHECK_LT(bucket, hash_to_id_map.size());
+    hash_to_id_map[bucket].set(
+        static_cast<int32_t>(numStrings()) - 1, hash, *strings.back());
+    return hash_to_id_map[bucket].string_id;
+  }
+
+  int32_t getIdOfStringImpl(const uint32_t hash, const std::string_view str) const;
+
+  // returns ID for a given bucket
+  int32_t id(const size_t bucket) const { return hash_to_id_map[bucket].string_id; }
+
+  void resize(const size_t new_size);
+
+  // returns string for a given ID
+  const std::string& str(const size_t id) const { return *strings[id].get(); }
+
+  size_t numStrings() const { return strings.size(); }
+
+  size_t size() const { return hash_to_id_map.size(); }
+
+  bool full() const { return strings.size() == hash_to_id_map.size(); }
+
+  mutable mapd_shared_mutex rw_mutex_;
+
+  // TODO: legacy, direct access outside of this class
+  std::vector<uint32_t> hash_cache_;
+  friend class ::StringDictionaryTranslator;
+};
+
+}  // namespace fast
 
 #endif  // STRINGDICTIONARY_STRINGDICTIONARY_H

--- a/omniscidb/StringDictionary/StringDictionary.h
+++ b/omniscidb/StringDictionary/StringDictionary.h
@@ -31,8 +31,6 @@
 
 extern bool g_enable_stringdict_parallel;
 
-using string_dict_hash_t = uint32_t;
-
 using StringLookupCallback = std::function<bool(std::string_view, int32_t string_id)>;
 
 class StringDictionary {
@@ -136,10 +134,10 @@ class StringDictionary {
       const size_t storage_high_water_mark,
       const std::vector<String>& input_strings,
       const std::vector<size_t>& string_memory_ids,
-      const std::vector<string_dict_hash_t>& input_strings_hashes) noexcept;
+      const std::vector<uint32_t>& input_strings_hashes) noexcept;
   template <class String>
   void hashStrings(const std::vector<String>& string_vec,
-                   std::vector<string_dict_hash_t>& hashes) const noexcept;
+                   std::vector<uint32_t>& hashes) const noexcept;
 
   int32_t getUnlocked(const std::string_view sv) const noexcept;
   std::string getStringUnlocked(int32_t string_id) const noexcept;
@@ -147,20 +145,20 @@ class StringDictionary {
   std::pair<char*, size_t> getStringBytesChecked(const int string_id) const noexcept;
   template <class String>
   uint32_t computeBucket(
-      const string_dict_hash_t hash,
+      const uint32_t hash,
       const String& input_string,
-      const std::vector<int32_t>& string_id_string_dict_hash_table) const noexcept;
+      const std::vector<int32_t>& string_id_uint32_table) const noexcept;
   template <class String>
   uint32_t computeBucketFromStorageAndMemory(
-      const string_dict_hash_t input_string_hash,
+      const uint32_t input_string_hash,
       const String& input_string,
-      const std::vector<int32_t>& string_id_string_dict_hash_table,
+      const std::vector<int32_t>& string_id_uint32_table,
       const size_t storage_high_water_mark,
       const std::vector<String>& input_strings,
       const std::vector<size_t>& string_memory_ids) const noexcept;
   uint32_t computeUniqueBucketWithHash(
-      const string_dict_hash_t hash,
-      const std::vector<int32_t>& string_id_string_dict_hash_table) noexcept;
+      const uint32_t hash,
+      const std::vector<int32_t>& string_id_uint32_table) noexcept;
   void checkAndConditionallyIncreasePayloadCapacity(const size_t write_length);
   void checkAndConditionallyIncreaseOffsetCapacity(const size_t write_length);
 
@@ -188,8 +186,8 @@ class StringDictionary {
   const DictRef dict_ref_;
   size_t str_count_;
   size_t collisions_;
-  std::vector<int32_t> string_id_string_dict_hash_table_;
-  std::vector<string_dict_hash_t> hash_cache_;
+  std::vector<int32_t> string_id_uint32_table_;
+  std::vector<uint32_t> hash_cache_;
   std::vector<int32_t> sorted_cache;
   bool materialize_hashes_;
   StringIdxEntry* offset_map_;

--- a/omniscidb/StringDictionary/StringDictionaryProxy.cpp
+++ b/omniscidb/StringDictionary/StringDictionaryProxy.cpp
@@ -234,7 +234,8 @@ StringDictionaryProxy::buildIntersectionTranslationMapToOtherProxyUnlocked(
 
   const size_t num_dest_transients = dest_proxy->transientEntryCountUnlocked();
   const size_t num_persisted_strings_not_translated =
-      generation_ > 0 ? string_dict_->buildDictionaryTranslationMap(
+      generation_ > 0 ? StringDictionaryTranslator::buildDictionaryTranslationMap(
+                            string_dict_.get(),
                             dest_proxy->string_dict_.get(),
                             translation_map_stored_entries_ptr,
                             generation_,

--- a/omniscidb/Tests/StringDictionaryBenchmark.cpp
+++ b/omniscidb/Tests/StringDictionaryBenchmark.cpp
@@ -225,12 +225,13 @@ BENCHMARK_DEFINE_F(StringDictionaryFixture, BulkTranslation_10M_Unique)
   auto dummy_callback = [](const std::string_view& source_string,
                            const int32_t source_string_id) { return true; };
   for (auto _ : state) {
-    source_string_dict->buildDictionaryTranslationMap(dest_string_dict.get(),
-                                                      string_ids.data(),
-                                                      num_source_strings,
-                                                      num_dest_strings,
-                                                      false,
-                                                      dummy_callback);
+    StringDictionaryTranslator::buildDictionaryTranslationMap(source_string_dict.get(),
+                                                              dest_string_dict.get(),
+                                                              string_ids.data(),
+                                                              num_source_strings,
+                                                              num_dest_strings,
+                                                              false,
+                                                              dummy_callback);
   }
 }
 

--- a/omniscidb/Tests/StringDictionaryTest.cpp
+++ b/omniscidb/Tests/StringDictionaryTest.cpp
@@ -885,6 +885,8 @@ int main(int argc, char** argv) {
   po::store(po::command_line_parser(argc, argv).options(desc).run(), vm);
   po::notify(vm);
 
+  logger::init(log_options);
+
   int err{0};
   try {
     err = RUN_ALL_TESTS();

--- a/omniscidb/Tests/StringDictionaryTest.cpp
+++ b/omniscidb/Tests/StringDictionaryTest.cpp
@@ -210,8 +210,8 @@ TEST(StringDictionary, BuildTranslationMap) {
     // First try to translate to empty dictionary.
     // Should get back all INVALID_STR_IDs
 
-    const auto translated_ids = source_string_dict->buildDictionaryTranslationMap(
-        dest_string_dict, dummy_callback);
+    const auto translated_ids = StringDictionaryTranslator::buildDictionaryTranslationMap(
+        source_string_dict, dest_string_dict, dummy_callback);
     const size_t num_ids = translated_ids.size();
     ASSERT_EQ(num_ids, source_string_dict->storageEntryCount());
     for (size_t idx = 0; idx < num_ids; ++idx) {
@@ -233,8 +233,8 @@ TEST(StringDictionary, BuildTranslationMap) {
     }
     dest_string_dict->getOrAddBulk(reversed_strings, reversed_string_ids.data());
     ASSERT_EQ(dest_string_dict->storageEntryCount(), reversed_strings.size());
-    const auto translated_ids = source_string_dict->buildDictionaryTranslationMap(
-        dest_string_dict, dummy_callback);
+    const auto translated_ids = StringDictionaryTranslator::buildDictionaryTranslationMap(
+        source_string_dict, dest_string_dict, dummy_callback);
     const size_t num_ids = translated_ids.size();
     ASSERT_EQ(num_ids, static_cast<size_t>(g_op_count));
     ASSERT_EQ(num_ids,


### PR DESCRIPTION
This PR introduces a drop-in replacement for the `StringDictionary` class using STL containers under the namespace `fast`. The previous string dictionary implementation remains under the namespace `legacy`. The "fast" dictionary has about the same performance of the previous dictionary, but includes options like materialized hashes on by default (materialized hashes give a small performance penalty for small dictionaries in the legacy implementation, because the cost of materializing and storing the hash outweighs the benefit of skipping string comparisons when there are lots of collisions in the hash table). Materialized hashing is essentially free in the fast implementation because we store the hashes directly next to the string ID in the hash table payload, and both are 4 byte values. 

Currently fast dictionary passes all StringDict tests **except** for those involved in dictionary translation. I intend to push the performance boundary of the fast dictionary first, then enable all tests, and finally remove the legacy dictionary and add APIs which should give more performance - e.g. where string ownership remains outside of the dictionary. Also, this PR depends on #613 and #614 which should be merged first.