### PR TITLE
Assign unique id to Node copy.

### DIFF
--- a/omniscidb/IR/Node.cpp
+++ b/omniscidb/IR/Node.cpp
@@ -75,6 +75,12 @@ Node::Node(NodeInputs inputs)
     , context_data_(nullptr)
     , is_nop_(false) {}
 
+Node::Node(const Node& other)
+    : inputs_(other.inputs_)
+    , id_(crt_id_.fetch_add(1))
+    , context_data_(nullptr)
+    , is_nop_(other.is_nop_) {}
+
 void Node::replaceInput(
     NodePtr old_input,
     NodePtr input,

--- a/omniscidb/IR/Node.h
+++ b/omniscidb/IR/Node.h
@@ -72,6 +72,7 @@ using NodeInputs = std::vector<NodePtr>;
 class Node {
  public:
   Node(NodeInputs inputs = {});
+  Node(const Node& other);
 
   virtual ~Node() {}
 

--- a/omniscidb/Tests/PartitionedGroupByTest.cpp
+++ b/omniscidb/Tests/PartitionedGroupByTest.cpp
@@ -150,6 +150,29 @@ TEST_F(PartitionedGroupByTest, ReorderedKeys) {
   compare_res_data(res2, id4_vals, id2_vals, id1_vals, id3_vals, v1_sums, v2_sums);
 }
 
+TEST_F(PartitionedGroupByTest, AggregationWithSort) {
+  auto old_exec = config().exec;
+  ScopeGuard g([&old_exec]() { config().exec = old_exec; });
+
+  config().exec.group_by.default_max_groups_buffer_entry_guess = 1;
+  config().exec.group_by.big_group_threshold = 1;
+  config().exec.group_by.enable_cpu_partitioned_groupby = true;
+  config().exec.group_by.partitioning_buffer_size_threshold = 10;
+  config().exec.group_by.partitioning_group_size_threshold = 1.5;
+  config().exec.group_by.min_partitions = 2;
+  config().exec.group_by.max_partitions = 8;
+  config().exec.group_by.partitioning_buffer_target_size = 612;
+  config().exec.enable_multifrag_execution_result = true;
+
+  QueryBuilder builder(ctx(), getSchemaProvider(), configPtr());
+  auto scan = builder.scan("test1");
+  auto dag1 = scan.agg({"id1"s, "id2"s, "id3"s, "id4"s}, {"sum(v1)"s, "sum(v2)"s})
+                  .sort({0, 1, 2, 3})
+                  .finalize();
+  auto res = runQuery(std::move(dag1));
+  compare_res_data(res, id1_vals, id2_vals, id3_vals, id4_vals, v1_sums, v2_sums);
+}
+
 int main(int argc, char* argv[]) {
   TestHelpers::init_logger_stderr_only(argc, argv);
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
We assume that all nodes in DAG have unique IDs but `Node::deepCopy` method returns a node with the same ID. Fix it by defining a copy ctor for `Node`.

Resolves #617 