### PR TITLE
Move to ubuntu 22.04 in docker files and update compute-runtime version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,13 +24,8 @@ RUN apt-get update && apt-get install -y \
 
 # Toolchains
 RUN apt-get update && apt-get install -y \
-    gcc-9 \
-    g++-9 \
     openjdk-11-jdk \
-    -- && \
-    update-alternatives \
-        --install /usr/bin/gcc gcc /usr/bin/gcc-9 800 \
-        --slave /usr/bin/g++ g++ /usr/bin/g++-9
+    --
 
 # LLVM
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update && apt-get install -y \
 
 # Toolchains
 RUN apt-get update && apt-get install -y \
+    g++-12 \
     openjdk-11-jdk \
     --
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
     automake \
     build-essential \
     ccache \
+    cmake \
     curl \
     gdb \
     git \
@@ -20,19 +21,6 @@ RUN apt-get update && apt-get install -y \
     lsb-release \
     software-properties-common \
     --
-
-# cmake
-RUN apt-get update && apt-get install -y \
-    libssl-dev \
-    libcurl4-openssl-dev \
-    --
-
-RUN wget https://github.com/Kitware/CMake/releases/download/v3.24.1/cmake-3.24.1.tar.gz && \
-    tar xzvf cmake-3.24.1.tar.gz && \
-    cd cmake-3.24.1/ && \
-    ./bootstrap && \
-    make -j`nproc` && \
-    make install
 
 # Toolchains
 RUN apt-get update && apt-get install -y \

--- a/docker/Dockerfile.clang
+++ b/docker/Dockerfile.clang
@@ -1,6 +1,6 @@
 # Cuda stack
-RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb && \
-    dpkg -i cuda-keyring_1.0-1_all.deb && \
+RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb && \
+    dpkg -i cuda-keyring_1.1-1_all.deb && \
     apt-get update && \
     apt-get install -y cuda-toolkit-12-0 cuda-drivers-525 libarrow-cuda-dev=11.*
 

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -1,6 +1,6 @@
 # Cuda stack
-RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb && \
-    dpkg -i cuda-keyring_1.0-1_all.deb && \
+RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb && \
+    dpkg -i cuda-keyring_1.1-1_all.deb && \
     apt-get update && \
     apt-get install -y cuda-toolkit-12-0 cuda-drivers-525 libarrow-cuda-dev=11.*
 

--- a/docker/Dockerfile.l0
+++ b/docker/Dockerfile.l0
@@ -1,14 +1,14 @@
 # Intel GPU stack
 RUN mkdir /intel-gpu-drivers && cd /intel-gpu-drivers && \
-    wget https://github.com/oneapi-src/level-zero/releases/download/v1.9.4/level-zero-devel_1.9.4+u18.04_amd64.deb && \
-    wget https://github.com/oneapi-src/level-zero/releases/download/v1.9.4/level-zero_1.9.4+u18.04_amd64.deb && \
-    wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.12812.24/intel-igc-core_1.0.12812.24_amd64.deb && \
-    wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.12812.24/intel-igc-opencl_1.0.12812.24_amd64.deb && \
-    wget https://github.com/intel/compute-runtime/releases/download/22.49.25018.24/intel-level-zero-gpu-dbgsym_1.3.25018.24_amd64.ddeb && \
-    wget https://github.com/intel/compute-runtime/releases/download/22.49.25018.24/intel-level-zero-gpu_1.3.25018.24_amd64.deb && \
-    wget https://github.com/intel/compute-runtime/releases/download/22.49.25018.24/intel-opencl-icd-dbgsym_22.49.25018.24_amd64.ddeb && \
-    wget https://github.com/intel/compute-runtime/releases/download/22.49.25018.24/intel-opencl-icd_22.49.25018.24_amd64.deb && \
-    wget https://github.com/intel/compute-runtime/releases/download/22.49.25018.24/libigdgmm12_22.3.0_amd64.deb
+    wget https://github.com/oneapi-src/level-zero/releases/download/v1.11.0/level-zero-devel_1.11.0+u22.04_amd64.deb && \
+    wget https://github.com/oneapi-src/level-zero/releases/download/v1.11.0/level-zero_1.11.0+u22.04_amd64.deb && \
+    wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.14062.11/intel-igc-core_1.0.14062.11_amd64.deb && \
+    wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.14062.11/intel-igc-opencl_1.0.14062.11_amd64.deb && \
+    wget https://github.com/intel/compute-runtime/releases/download/23.22.26516.18/intel-level-zero-gpu-dbgsym_1.3.26516.18_amd64.ddeb && \
+    wget https://github.com/intel/compute-runtime/releases/download/23.22.26516.18/intel-level-zero-gpu_1.3.26516.18_amd64.deb && \
+    wget https://github.com/intel/compute-runtime/releases/download/23.22.26516.18/intel-opencl-icd-dbgsym_23.22.26516.18_amd64.ddeb && \
+    wget https://github.com/intel/compute-runtime/releases/download/23.22.26516.18/intel-opencl-icd_23.22.26516.18_amd64.deb && \
+    wget https://github.com/intel/compute-runtime/releases/download/23.22.26516.18/libigdgmm12_22.3.0_amd64.deb
 
 RUN cd /intel-gpu-drivers && dpkg -i *.deb
 


### PR DESCRIPTION
p.s. why do we have Dockerfile.clang that is identical to Dockerfile.cuda?