### PR TITLE
[Join] Zero-copy storage column check.

### DIFF
--- a/omniscidb/ArrowStorage/ArrowStorage.h
+++ b/omniscidb/ArrowStorage/ArrowStorage.h
@@ -70,6 +70,9 @@ class ArrowStorage : public SimpleSchemaProvider, public AbstractDataProvider {
       const ChunkKey& key,
       size_t num_bytes) override;
 
+  std::unique_ptr<Data_Namespace::AbstractDataToken> getZeroCopyColumnData(
+      const ColumnRef& col_ref) override;
+
   TableFragmentsInfo getTableMetadata(int db_id, int table_id) const override;
 
   const DictDescriptor* getDictMetadata(int dict_id, bool load_dict = true) override;

--- a/omniscidb/DataMgr/AbstractBufferMgr.h
+++ b/omniscidb/DataMgr/AbstractBufferMgr.h
@@ -86,6 +86,8 @@ class AbstractBufferMgr {
   virtual AbstractBuffer* getBuffer(const ChunkKey& key, const size_t numBytes = 0) = 0;
   virtual std::unique_ptr<AbstractDataToken> getZeroCopyBufferMemory(const ChunkKey& key,
                                                                      size_t numBytes) = 0;
+  virtual std::unique_ptr<AbstractDataToken> getZeroCopyColumnData(
+      const ColumnRef& col_ref) = 0;
   virtual void fetchBuffer(const ChunkKey& key,
                            AbstractBuffer* destBuffer,
                            const size_t numBytes = 0) = 0;

--- a/omniscidb/DataMgr/AbstractDataProvider.h
+++ b/omniscidb/DataMgr/AbstractDataProvider.h
@@ -45,6 +45,13 @@ class AbstractDataProvider : public Data_Namespace::AbstractBufferMgr {
     return nullptr;
   }
 
+  // TODO(dmitriim) remove this method after enabling
+  // of hashtable, that takes into a count frag_id and offset
+  std::unique_ptr<Data_Namespace::AbstractDataToken> getZeroCopyColumnData(
+      const ColumnRef& col_ref) override {
+    return nullptr;
+  }
+
   void deleteBuffer(const ChunkKey& key, const bool purge = true) override {
     UNREACHABLE();
   }

--- a/omniscidb/DataMgr/BufferMgr/BufferMgr.cpp
+++ b/omniscidb/DataMgr/BufferMgr/BufferMgr.cpp
@@ -865,6 +865,11 @@ std::unique_ptr<AbstractDataToken> BufferMgr::getZeroCopyBufferMemory(const Chun
   return parent_mgr_->getZeroCopyBufferMemory(key, numBytes);
 }
 
+std::unique_ptr<AbstractDataToken> BufferMgr::getZeroCopyColumnData(
+    const ColumnRef& col_ref) {
+  return parent_mgr_->getZeroCopyColumnData(col_ref);
+}
+
 MemoryInfo BufferMgr::getMemoryInfo() {
   std::unique_lock<std::mutex> sized_segs_lock(sized_segs_mutex_);
   MemoryInfo mi;

--- a/omniscidb/DataMgr/BufferMgr/BufferMgr.h
+++ b/omniscidb/DataMgr/BufferMgr/BufferMgr.h
@@ -162,6 +162,9 @@ class BufferMgr : public AbstractBufferMgr {  // implements
   std::unique_ptr<AbstractDataToken> getZeroCopyBufferMemory(const ChunkKey& key,
                                                              size_t numBytes) override;
 
+  std::unique_ptr<AbstractDataToken> getZeroCopyColumnData(
+      const ColumnRef& col_ref) override;
+
   /**
    * @brief Puts the contents of d into the Buffer with ChunkKey key.
    * @param key - Unique identifier for a Chunk.

--- a/omniscidb/DataMgr/DataMgr.cpp
+++ b/omniscidb/DataMgr/DataMgr.cpp
@@ -458,6 +458,13 @@ AbstractBuffer* DataMgr::getChunkBuffer(const ChunkKey& key,
   return bufferMgrs_[level][deviceId]->getBuffer(key, numBytes);
 }
 
+std::unique_ptr<AbstractDataToken> DataMgr::getZeroCopyColumnData(
+    const ColumnRef& col_ref) {
+  const auto level = static_cast<size_t>(Data_Namespace::CPU_LEVEL);
+  CHECK_LT(level, levelSizes_.size());  // make sure we have a legit buffermgr
+  return bufferMgrs_[level][0]->getZeroCopyColumnData(col_ref);
+}
+
 void DataMgr::deleteChunksWithPrefix(const ChunkKey& keyPrefix) {
   int numLevels = bufferMgrs_.size();
   for (int level = numLevels - 1; level >= 0; --level) {

--- a/omniscidb/DataMgr/DataMgr.h
+++ b/omniscidb/DataMgr/DataMgr.h
@@ -167,6 +167,8 @@ class DataMgr {
                                  const MemoryLevel memoryLevel,
                                  const int deviceId = 0,
                                  const size_t numBytes = 0);
+  // TODO(dmitriim) remove this method after enabling of hashtable
+  std::unique_ptr<AbstractDataToken> getZeroCopyColumnData(const ColumnRef& col_ref);
   void deleteChunksWithPrefix(const ChunkKey& keyPrefix);
   void deleteChunksWithPrefix(const ChunkKey& keyPrefix, const MemoryLevel memLevel);
   AbstractBuffer* alloc(const MemoryLevel memoryLevel,

--- a/omniscidb/DataMgr/DataMgrDataProvider.cpp
+++ b/omniscidb/DataMgr/DataMgrDataProvider.cpp
@@ -29,9 +29,16 @@ std::shared_ptr<Chunk_NS::Chunk> DataMgrDataProvider::getChunk(
   return Chunk_NS::Chunk::getChunk(
       col_info, data_mgr_, key, memory_level, device_id, num_bytes, num_elems);
 }
+
+std::unique_ptr<Data_Namespace::AbstractDataToken>
+DataMgrDataProvider::getZeroCopyColumnData(const ColumnRef& col_ref) {
+  return data_mgr_->getZeroCopyColumnData(col_ref);
+}
+
 TableFragmentsInfo DataMgrDataProvider::getTableMetadata(int db_id, int table_id) const {
   return data_mgr_->getTableMetadata(db_id, table_id);
 }
+
 const DictDescriptor* DataMgrDataProvider::getDictMetadata(int dict_id,
                                                            bool load_dict) const {
   return data_mgr_->getDictMetadata(dict_id, load_dict);

--- a/omniscidb/DataMgr/DataMgrDataProvider.h
+++ b/omniscidb/DataMgr/DataMgrDataProvider.h
@@ -35,6 +35,9 @@ class DataMgrDataProvider : public DataProvider {
       const size_t num_bytes,
       const size_t num_elems) override;
 
+  std::unique_ptr<Data_Namespace::AbstractDataToken> getZeroCopyColumnData(
+      const ColumnRef& col_ref) override;
+
   TableFragmentsInfo getTableMetadata(int db_id, int table_id) const override;
 
   const DictDescriptor* getDictMetadata(int dict_id,

--- a/omniscidb/DataMgr/PersistentStorageMgr/PersistentStorageMgr.cpp
+++ b/omniscidb/DataMgr/PersistentStorageMgr/PersistentStorageMgr.cpp
@@ -55,6 +55,11 @@ std::unique_ptr<AbstractDataToken> PersistentStorageMgr::getZeroCopyBufferMemory
   return getStorageMgrForTableKey(key)->getZeroCopyBufferMemory(key, numBytes);
 }
 
+std::unique_ptr<AbstractDataToken> PersistentStorageMgr::getZeroCopyColumnData(
+    const ColumnRef& col_ref) {
+  return getStorageMgr(col_ref.db_id)->getZeroCopyColumnData(col_ref);
+}
+
 void PersistentStorageMgr::fetchBuffer(const ChunkKey& chunk_key,
                                        AbstractBuffer* destination_buffer,
                                        const size_t num_bytes) {

--- a/omniscidb/DataMgr/PersistentStorageMgr/PersistentStorageMgr.h
+++ b/omniscidb/DataMgr/PersistentStorageMgr/PersistentStorageMgr.h
@@ -35,6 +35,8 @@ class PersistentStorageMgr : public AbstractBufferMgr {
   AbstractBuffer* getBuffer(const ChunkKey& chunk_key, const size_t num_bytes) override;
   std::unique_ptr<AbstractDataToken> getZeroCopyBufferMemory(const ChunkKey& key,
                                                              size_t numBytes) override;
+  std::unique_ptr<AbstractDataToken> getZeroCopyColumnData(
+      const ColumnRef& col_ref) override;
   void fetchBuffer(const ChunkKey& chunk_key,
                    AbstractBuffer* destination_buffer,
                    const size_t num_bytes) override;

--- a/omniscidb/DataProvider/DataProvider.h
+++ b/omniscidb/DataProvider/DataProvider.h
@@ -36,6 +36,11 @@ class DataProvider {
       const size_t num_bytes,
       const size_t num_elems) = 0;
 
+  // CPU only
+  // TODO(dmitriim) remove this method after enabling of hashtable
+  virtual std::unique_ptr<Data_Namespace::AbstractDataToken> getZeroCopyColumnData(
+      const ColumnRef& col_ref) = 0;
+
   virtual TableFragmentsInfo getTableMetadata(int db_id, int table_id) const = 0;
 
   virtual const DictDescriptor* getDictMetadata(int dict_id,

--- a/omniscidb/QueryEngine/NativeCodegen.cpp
+++ b/omniscidb/QueryEngine/NativeCodegen.cpp
@@ -711,9 +711,8 @@ std::vector<std::string> get_agg_fnames(
     CHECK(target_expr);
     auto target_type = target_expr->type();
     const auto agg_expr = target_expr->as<hdk::ir::AggExpr>();
-    const bool is_varlen =
-        target_type->isString() ||
-        target_type->isArray();  // TODO: should it use is_varlen_array() ?
+    // Fixed length arrays are also included here.
+    const bool is_varlen = target_type->isString() || target_type->isArray();
     if (!agg_expr || agg_expr->aggType() == hdk::ir::AggType::kSample) {
       result.emplace_back(target_type->isFloatingPoint() ? "agg_id_double" : "agg_id");
       if (is_varlen) {

--- a/omniscidb/ResultSetRegistry/ColumnarResults.cpp
+++ b/omniscidb/ResultSetRegistry/ColumnarResults.cpp
@@ -134,15 +134,32 @@ ColumnarResults::ColumnarResults(std::shared_ptr<RowSetMemoryOwner> row_set_mem_
     , direct_columnar_conversion_(false)
     , thread_idx_(thread_idx) {
   auto timer = DEBUG_TIMER(__func__);
-  const bool is_varlen = target_type->isArray() || target_type->isString();
 
-  if (is_varlen) {
+  if (target_type->isVarLen()) {
     throw ColumnarConversionNotSupported();
   }
   const auto buf_size = num_rows * target_type->size();
   column_buffers_[0] =
       reinterpret_cast<int8_t*>(row_set_mem_owner->allocate(buf_size, thread_idx_));
   memcpy(((void*)column_buffers_[0]), one_col_buffer, buf_size);
+}
+
+ColumnarResults::ColumnarResults(const std::vector<int8_t*> one_col_buffer,
+                                 const size_t num_rows,
+                                 const hdk::ir::Type* target_type,
+                                 const size_t thread_idx)
+    : column_buffers_(1)
+    , num_rows_(num_rows)
+    , target_types_{target_type}
+    , parallel_conversion_(false)
+    , direct_columnar_conversion_(false)
+    , thread_idx_(thread_idx) {
+  auto timer = DEBUG_TIMER(__func__);
+
+  if (target_type->isVarLen()) {
+    throw ColumnarConversionNotSupported();
+  }
+  column_buffers_ = std::move(one_col_buffer);
 }
 
 std::unique_ptr<ColumnarResults> ColumnarResults::mergeResults(

--- a/omniscidb/ResultSetRegistry/ColumnarResults.h
+++ b/omniscidb/ResultSetRegistry/ColumnarResults.h
@@ -73,6 +73,11 @@ class ColumnarResults {
                   const hdk::ir::Type* target_type,
                   const size_t thread_idx);
 
+  ColumnarResults(const std::vector<int8_t*> one_col_buffer,
+                  const size_t num_rows,
+                  const hdk::ir::Type* target_type,
+                  const size_t thread_idx);
+
   static std::unique_ptr<ColumnarResults> mergeResults(
       const std::shared_ptr<RowSetMemoryOwner> row_set_mem_owner,
       const std::vector<std::unique_ptr<ColumnarResults>>& sub_results);


### PR DESCRIPTION
This commit adds check for valid pointer to column buffer to skip copying. Most effective with enabled `enable-non-lazy-data-import` option. Checks number of chunks in storage.

Partially resolves: #574