### PR TITLE
Add support for LLVM 16

### DIFF
--- a/omniscidb/QueryEngine/ArrayIR.cpp
+++ b/omniscidb/QueryEngine/ArrayIR.cpp
@@ -143,7 +143,7 @@ std::vector<llvm::Value*> CodeGenerator::codegenArrayExpr(
       allocated_target_buffer = ir_builder.CreateAddrSpaceCast(
           allocated_target_buffer,
           llvm::PointerType::get(
-              allocated_target_buffer->getType()->getPointerElementType(),
+              cgen_state_->context_,
               co.codegen_traits_desc.local_addr_space_),
           "allocated.target.buffer.cast");
     }

--- a/omniscidb/QueryEngine/CgenState.cpp
+++ b/omniscidb/QueryEngine/CgenState.cpp
@@ -299,8 +299,7 @@ std::vector<std::string> CgenState::gpuFunctionsToReplace(llvm::Function* fn) {
   CHECK(!fn->isDeclaration());
 
   for (auto& basic_block : *fn) {
-    auto& inst_list = basic_block.getInstList();
-    for (auto inst_itr = inst_list.begin(); inst_itr != inst_list.end(); ++inst_itr) {
+    for (auto inst_itr = basic_block.begin(); inst_itr != basic_block.end(); ++inst_itr) {
       if (auto call_inst = llvm::dyn_cast<llvm::CallInst>(inst_itr)) {
         auto called_fcn = call_inst->getCalledFunction();
         CHECK(called_fcn);
@@ -332,8 +331,7 @@ void CgenState::replaceFunctionForGpu(const std::string& fcn_to_replace,
           << " for parent function " << fn->getName().str();
 
   for (auto& basic_block : *fn) {
-    auto& inst_list = basic_block.getInstList();
-    for (auto inst_itr = inst_list.begin(); inst_itr != inst_list.end(); ++inst_itr) {
+    for (auto inst_itr = basic_block.begin(); inst_itr != basic_block.end(); ++inst_itr) {
       if (auto call_inst = llvm::dyn_cast<llvm::CallInst>(inst_itr)) {
         auto called_fcn = call_inst->getCalledFunction();
         CHECK(called_fcn);

--- a/omniscidb/QueryEngine/Compiler/Backend.h
+++ b/omniscidb/QueryEngine/Compiler/Backend.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <llvm/IR/Value.h>
+#include <llvm/Transforms/IPO/PassManagerBuilder.h>
 #include <memory>
 
 #include "QueryEngine/ExtensionModules.h"

--- a/omniscidb/QueryEngine/Compiler/HelperFunctions.cpp
+++ b/omniscidb/QueryEngine/Compiler/HelperFunctions.cpp
@@ -134,7 +134,11 @@ void optimize_ir(llvm::Function* query_func,
   CGPM.addPass(AnnotateInternalFunctionsPass());
   MPM.addPass(createModuleToPostOrderCGSCCPassAdaptor(std::move(CGPM)));
 
+#if LLVM_VERSION_MAJOR > 15
+  FPM.addPass(llvm::SROAPass(llvm::SROAOptions::PreserveCFG));
+#else
   FPM.addPass(llvm::SROAPass());
+#endif
   // mem ssa drops unused load and store instructions, e.g. passing variables directly
   // where possible
   FPM.addPass(llvm::EarlyCSEPass(/*enable_mem_ssa=*/true));  // Catch trivial redundancies
@@ -152,7 +156,11 @@ void optimize_ir(llvm::Function* query_func,
   FPM.addPass(llvm::GVNPass());
 
   FPM.addPass(llvm::DSEPass());  // DeadStoreEliminationPass
+#if LLVM_VERSION_MAJOR > 14
+  LPM.addPass(llvm::LICMPass(llvm::LICMOptions()));
+#else
   LPM.addPass(llvm::LICMPass());
+#endif
   FPM.addPass(createFunctionToLoopPassAdaptor(std::move(LPM), /*UseMemorySSA=*/true));
 
   FPM.addPass(llvm::InstCombinePass());

--- a/omniscidb/QueryEngine/ConstantIR.cpp
+++ b/omniscidb/QueryEngine/ConstantIR.cpp
@@ -230,15 +230,13 @@ std::vector<llvm::Value*> CodeGenerator::codegenHoistedConstantsPlaceholders(
     auto* int_to_ptr0 =
         cgen_state_->ir_builder_.CreateIntToPtr(cgen_state_->llInt(0), placeholder0_type);
     auto placeholder0 = cgen_state_->ir_builder_.CreateLoad(
-        int_to_ptr0->getType()->getPointerElementType(),
-        int_to_ptr0,
-        "__placeholder__" + literal_name + "_start");
+        var_start->getType(), int_to_ptr0, "__placeholder__" + literal_name + "_start");
     llvm::PointerType* placeholder1_type =
         cgen_traits.localPointerType(var_start_address->getType());
     auto* int_to_ptr1 =
         cgen_state_->ir_builder_.CreateIntToPtr(cgen_state_->llInt(0), placeholder1_type);
     auto placeholder1 = cgen_state_->ir_builder_.CreateLoad(
-        int_to_ptr1->getType()->getPointerElementType(),
+        placeholder1_type,
         int_to_ptr1,
         "__placeholder__" + literal_name + "_start_address");
     llvm::PointerType* placeholder2_type =
@@ -246,9 +244,7 @@ std::vector<llvm::Value*> CodeGenerator::codegenHoistedConstantsPlaceholders(
     auto* int_to_ptr2 =
         cgen_state_->ir_builder_.CreateIntToPtr(cgen_state_->llInt(0), placeholder2_type);
     auto placeholder2 = cgen_state_->ir_builder_.CreateLoad(
-        int_to_ptr2->getType()->getPointerElementType(),
-        int_to_ptr2,
-        "__placeholder__" + literal_name + "_length");
+        placeholder2_type, int_to_ptr2, "__placeholder__" + literal_name + "_length");
 
     cgen_state_->row_func_hoisted_literals_[placeholder0] = {lit_off, 0};
     cgen_state_->row_func_hoisted_literals_[placeholder1] = {lit_off, 1};
@@ -268,7 +264,7 @@ std::vector<llvm::Value*> CodeGenerator::codegenHoistedConstantsPlaceholders(
     auto* int_to_ptr0 =
         cgen_state_->ir_builder_.CreateIntToPtr(cgen_state_->llInt(0), placeholder0_type);
     auto placeholder0 = cgen_state_->ir_builder_.CreateLoad(
-        int_to_ptr0->getType()->getPointerElementType(),
+        var_start_address->getType(),
         int_to_ptr0,
         "__placeholder__" + literal_name + "_start_address");
     llvm::PointerType* placeholder1_type =
@@ -276,9 +272,7 @@ std::vector<llvm::Value*> CodeGenerator::codegenHoistedConstantsPlaceholders(
     auto* int_to_ptr1 =
         cgen_state_->ir_builder_.CreateIntToPtr(cgen_state_->llInt(0), placeholder1_type);
     auto placeholder1 = cgen_state_->ir_builder_.CreateLoad(
-        int_to_ptr1->getType()->getPointerElementType(),
-        int_to_ptr1,
-        "__placeholder__" + literal_name + "_length");
+        var_length->getType(), int_to_ptr1, "__placeholder__" + literal_name + "_length");
 
     cgen_state_->row_func_hoisted_literals_[placeholder0] = {lit_off, 0};
     cgen_state_->row_func_hoisted_literals_[placeholder1] = {lit_off, 1};

--- a/omniscidb/QueryEngine/ConstantIR.cpp
+++ b/omniscidb/QueryEngine/ConstantIR.cpp
@@ -125,7 +125,7 @@ std::vector<llvm::Value*> CodeGenerator::codegenHoistedConstantsLoads(
   std::string literal_name = "literal_" + std::to_string(lit_off);
   auto lit_buff_query_func_lv = get_arg_by_name(cgen_state_->query_func_, "literals");
   const auto lit_buf_start = cgen_state_->query_func_entry_ir_builder_.CreateGEP(
-      llvm::PointerType::get(cgen_state_->context_, 0),
+      get_int_type(8, cgen_state_->context_),
       lit_buff_query_func_lv,
       cgen_state_->llInt(lit_off));
   if (type->isString() && !use_dict_encoding) {

--- a/omniscidb/QueryEngine/ConstantIR.cpp
+++ b/omniscidb/QueryEngine/ConstantIR.cpp
@@ -291,11 +291,8 @@ std::vector<llvm::Value*> CodeGenerator::codegenHoistedConstantsPlaceholders(
 
   auto* int_to_ptr = cgen_state_->ir_builder_.CreateIntToPtr(
       cgen_state_->llInt(0), cgen_traits.localPointerType(to_return_lv->getType()));
-  // TODO(llvm16): address space
-  auto placeholder0 =
-      cgen_state_->ir_builder_.CreateLoad(get_int_type(32, cgen_state_->context_),
-                                          int_to_ptr,
-                                          "__placeholder__" + literal_name);
+  auto placeholder0 = cgen_state_->ir_builder_.CreateLoad(
+      to_return_lv->getType(), int_to_ptr, "__placeholder__" + literal_name);
 
   cgen_state_->row_func_hoisted_literals_[placeholder0] = {lit_off, 0};
 
@@ -325,21 +322,8 @@ std::vector<llvm::Value*> CodeGenerator::codegenHoistedConstants(
       }
     }
   } catch (const std::range_error& e) {
-    // detect
-    // literal
-    // buffer
-    // overflow
-    // when
-    // trying to
-    // assign
-    // literal
-    // buf offset
-    // which is
-    // not in a
-    // valid
-    // range to
-    // checked_type
-    // variable
+    // detect literal buffer overflow when trying to assign literal buf offset which is
+    // not in a valid range to checked_type variable
     throw TooManyLiterals();
   }
   std::vector<llvm::Value*> hoisted_literal_loads;

--- a/omniscidb/QueryEngine/Execute.cpp
+++ b/omniscidb/QueryEngine/Execute.cpp
@@ -3804,7 +3804,7 @@ void Executor::preloadFragOffsets(const std::vector<InputDescriptor>& input_desc
     } else {
       if (frag_count > 1) {
         cgen_state_->frag_offsets_.push_back(cgen_state_->ir_builder_.CreateLoad(
-            frag_off_ptr->getType()->getPointerElementType(), frag_off_ptr));
+            get_int_type(64, cgen_state_->context_), frag_off_ptr));
       } else {
         cgen_state_->frag_offsets_.push_back(nullptr);
       }

--- a/omniscidb/QueryEngine/Execute.cpp
+++ b/omniscidb/QueryEngine/Execute.cpp
@@ -3919,33 +3919,6 @@ llvm::Value* Executor::castToFP(llvm::Value* value,
   return value;
 }
 
-llvm::Value* Executor::castToIntPtrTyIn(llvm::Value* val, const size_t bitWidth) {
-  AUTOMATIC_IR_METADATA(cgen_state_.get());
-  CHECK(val->getType()->isPointerTy());
-
-  const auto val_ptr_type = static_cast<llvm::PointerType*>(val->getType());
-  const auto val_type = val_ptr_type->getPointerElementType();
-  size_t val_width = 0;
-  if (val_type->isIntegerTy()) {
-    val_width = val_type->getIntegerBitWidth();
-  } else {
-    if (val_type->isFloatTy()) {
-      val_width = 32;
-    } else {
-      CHECK(val_type->isDoubleTy());
-      val_width = 64;
-    }
-  }
-  CHECK_LT(size_t(0), val_width);
-  if (bitWidth == val_width) {
-    return val;
-  }
-  return cgen_state_->ir_builder_.CreateBitCast(
-      val,
-      llvm::PointerType::get(get_int_type(bitWidth, cgen_state_->context_),
-                             val->getType()->getPointerAddressSpace()));
-}
-
 #define EXECUTE_INCLUDE
 #include "ArrayOps.cpp"
 #include "DateAdd.cpp"

--- a/omniscidb/QueryEngine/Execute.h
+++ b/omniscidb/QueryEngine/Execute.h
@@ -831,7 +831,6 @@ class Executor : public StringDictionaryProxyProvider {
   llvm::Value* castToFP(llvm::Value*,
                         const hdk::ir::Type* from_type,
                         const hdk::ir::Type* to_type);
-  llvm::Value* castToIntPtrTyIn(llvm::Value* val, const size_t bit_width);
 
   FragmentSkipStatus canSkipFragmentForFpQual(const hdk::ir::BinOper* comp_expr,
                                               const hdk::ir::ColumnVar* lhs_col,

--- a/omniscidb/QueryEngine/ExecutionEngineWrapper.h
+++ b/omniscidb/QueryEngine/ExecutionEngineWrapper.h
@@ -74,9 +74,7 @@ class ORCJITExecutionEngineWrapper {
             data_layout_->getGlobalPrefix())));
   }
 
-  ~ORCJITExecutionEngineWrapper() {
-    llvm::cantFail(execution_session_->endSession());
-  }
+  ~ORCJITExecutionEngineWrapper() { llvm::cantFail(execution_session_->endSession()); }
 
   ORCJITExecutionEngineWrapper(const ORCJITExecutionEngineWrapper& other) = delete;
   ORCJITExecutionEngineWrapper(ORCJITExecutionEngineWrapper&& other) = delete;
@@ -102,9 +100,7 @@ class ORCJITExecutionEngineWrapper {
     return reinterpret_cast<void*>(symbol->getAddress());
   }
 
-  bool exists() const {
-    return !(execution_session_ == nullptr);
-  }
+  bool exists() const { return !(execution_session_ == nullptr); }
 
   void removeModule(llvm::Module* module) {
     // Do nothing here. Module is deleted by ORC after materialization.

--- a/omniscidb/QueryEngine/ExtensionsIR.cpp
+++ b/omniscidb/QueryEngine/ExtensionsIR.cpp
@@ -346,7 +346,7 @@ llvm::Value* CodeGenerator::codegenFunctionOper(
         codegen_traits_desc.local_addr_space_) {
       buffer_ret = cgen_state_->ir_builder_.CreateAddrSpaceCast(
           buffer_ret,
-          llvm::PointerType::get(buffer_ret->getType()->getPointerElementType(),
+          llvm::PointerType::get(cgen_state_->context_,
                                  codegen_traits_desc.local_addr_space_),
           "buffer.ret.cast");
     }
@@ -411,7 +411,7 @@ CodeGenerator::beginArgsNullcheck(const hdk::ir::FunctionOper* function_oper,
           codegen_traits_desc.local_addr_space_) {
         null_array_alloca = cgen_state_->ir_builder_.CreateAddrSpaceCast(
             null_array_alloca,
-            llvm::PointerType::get(null_array_alloca->getType()->getPointerElementType(),
+            llvm::PointerType::get(cgen_state_->context_,
                                    codegen_traits_desc.local_addr_space_),
             "null.array.alloca.cast");
       }
@@ -627,7 +627,7 @@ void CodeGenerator::codegenBufferArgs(const std::string& ext_func_name,
       codegen_traits_desc.local_addr_space_) {
     alloc_mem = cgen_state_->ir_builder_.CreateAddrSpaceCast(
         alloc_mem,
-        llvm::PointerType::get(alloc_mem->getType()->getPointerElementType(),
+        llvm::PointerType::get(cgen_state_->context_,
                                codegen_traits_desc.local_addr_space_),
         "alloc.mem.cast");
   }

--- a/omniscidb/QueryEngine/IRCodegen.cpp
+++ b/omniscidb/QueryEngine/IRCodegen.cpp
@@ -1252,7 +1252,7 @@ llvm::Value* Executor::arrayLoopCodegen(const hdk::ir::Expr* array_expr,
       co.codegen_traits_desc.local_addr_space_) {
     array_idx_ptr = cgen_state_->ir_builder_.CreateAddrSpaceCast(
         array_idx_ptr,
-        llvm::PointerType::get(array_idx_ptr->getType()->getPointerElementType(),
+        llvm::PointerType::get(cgen_state_->context_,
                                co.codegen_traits_desc.local_addr_space_),
         "array.idx.ptrcast");
   }

--- a/omniscidb/QueryEngine/IRCodegen.cpp
+++ b/omniscidb/QueryEngine/IRCodegen.cpp
@@ -1048,6 +1048,7 @@ void Executor::codegenJoinLoops(const std::vector<JoinLoop>& join_loops,
           JoinLoopDomain domain{{0}};
           domain.element_count = element_count;
           domain.values_buffer = values;
+          domain.values_buffer_is_array_of_arrays = true;
           return domain;
         },
         nullptr,

--- a/omniscidb/QueryEngine/IRCodegen.cpp
+++ b/omniscidb/QueryEngine/IRCodegen.cpp
@@ -659,11 +659,11 @@ std::vector<JoinLoop> Executor::buildJoinLoops(
             JoinLoopDomain domain{{0}};
             auto* arg = get_arg_by_name(cgen_state_->row_func_, "num_rows_per_scan");
             const auto rows_per_scan_ptr = cgen_state_->ir_builder_.CreateGEP(
-                arg->getType()->getScalarType()->getPointerElementType(),
+                get_int_type(64, cgen_state_->context_),
                 arg,
                 cgen_state_->llInt(int32_t(level_idx + 1)));
             domain.upper_bound = cgen_state_->ir_builder_.CreateLoad(
-                rows_per_scan_ptr->getType()->getPointerElementType(),
+                get_int_type(64, cgen_state_->context_),
                 rows_per_scan_ptr,
                 "num_rows_per_scan");
             return domain;
@@ -1276,7 +1276,7 @@ llvm::Value* Executor::arrayLoopCodegen(const hdk::ir::Expr* array_expr,
   cgen_state_->ir_builder_.SetInsertPoint(array_loop_head);
   CHECK(array_len);
   auto array_idx = cgen_state_->ir_builder_.CreateLoad(
-      array_idx_ptr->getType()->getPointerElementType(), array_idx_ptr);
+      get_int_type(32, cgen_state_->context_), array_idx_ptr);
   auto bound_check =
       cgen_state_->ir_builder_.CreateICmp(llvm::ICmpInst::ICMP_SLT, array_idx, array_len);
   auto array_loop_body = llvm::BasicBlock::Create(

--- a/omniscidb/QueryEngine/IRCodegen.cpp
+++ b/omniscidb/QueryEngine/IRCodegen.cpp
@@ -934,8 +934,12 @@ void Executor::redeclareFilterFunction() {
   // copy the filter_func function body over
   // see
   // https://stackoverflow.com/questions/12864106/move-function-body-avoiding-full-cloning/18751365
+#if LLVM_VERSION_MAJOR > 15
+  filter_func2->splice(filter_func2->begin(), cgen_state_->filter_func_);
+#else
   filter_func2->getBasicBlockList().splice(
       filter_func2->begin(), cgen_state_->filter_func_->getBasicBlockList());
+#endif
 
   if (cgen_state_->current_func_ == cgen_state_->filter_func_) {
     cgen_state_->current_func_ = filter_func2;

--- a/omniscidb/QueryEngine/JoinHashTable/BaselineJoinHashTable.cpp
+++ b/omniscidb/QueryEngine/JoinHashTable/BaselineJoinHashTable.cpp
@@ -883,8 +883,7 @@ llvm::Value* BaselineJoinHashTable::codegenKey(const CompilationOptions& co) {
       co.codegen_traits_desc.local_addr_space_) {
     key_buff_lv = LL_BUILDER.CreateAddrSpaceCast(
         key_buff_lv,
-        llvm::PointerType::get(key_buff_lv->getType()->getPointerElementType(),
-                               co.codegen_traits_desc.local_addr_space_),
+        llvm::PointerType::get(LL_CONTEXT, co.codegen_traits_desc.local_addr_space_),
         "key.buff.lv.cast");
   }
 

--- a/omniscidb/QueryEngine/JoinHashTable/HashJoin.cpp
+++ b/omniscidb/QueryEngine/JoinHashTable/HashJoin.cpp
@@ -191,8 +191,10 @@ HashJoinMatchingSet HashJoin::codegenMatchingSet(
       llvm::Type::getInt32PtrTy(executor->cgen_state_->context_,
                                 cgen_traits.getLocalAddrSpace()));
 
+  // TODO(llvm16): this is probably wrong
   auto rowid_ptr_i32 = executor->cgen_state_->ir_builder_.CreateGEP(
-      rowid_base_i32->getType()->getScalarType()->getPointerElementType(),
+      llvm::PointerType::get(executor->cgen_state_->context_,
+                             cgen_traits.getLocalAddrSpace()),
       rowid_base_i32,
       slot_lv);
   return {rowid_ptr_i32, row_count_lv, slot_lv};

--- a/omniscidb/QueryEngine/LoopControlFlow/JoinLoop.cpp
+++ b/omniscidb/QueryEngine/LoopControlFlow/JoinLoop.cpp
@@ -95,9 +95,7 @@ llvm::BasicBlock* JoinLoop::codegen(
             co.codegen_traits_desc.local_addr_space_) {
           iteration_counter_ptr = builder.CreateAddrSpaceCast(
               iteration_counter_ptr,
-              llvm::PointerType::get(
-                  iteration_counter_ptr->getType()->getPointerElementType(),
-                  co.codegen_traits_desc.local_addr_space_),
+              llvm::PointerType::get(context, co.codegen_traits_desc.local_addr_space_),
               "iteration.counter.ptr.cast");
         }
         llvm::Value* found_an_outer_match_ptr{nullptr};
@@ -109,9 +107,7 @@ llvm::BasicBlock* JoinLoop::codegen(
               co.codegen_traits_desc.local_addr_space_) {
             found_an_outer_match_ptr = builder.CreateAddrSpaceCast(
                 found_an_outer_match_ptr,
-                llvm::PointerType::get(
-                    found_an_outer_match_ptr->getType()->getPointerElementType(),
-                    co.codegen_traits_desc.local_addr_space_),
+                llvm::PointerType::get(context, co.codegen_traits_desc.local_addr_space_),
                 "found.an.outer.match.ptr.cast");
           }
           builder.CreateStore(ll_bool(false, context), found_an_outer_match_ptr);
@@ -121,9 +117,7 @@ llvm::BasicBlock* JoinLoop::codegen(
               co.codegen_traits_desc.local_addr_space_) {
             current_condition_match_ptr = builder.CreateAddrSpaceCast(
                 current_condition_match_ptr,
-                llvm::PointerType::get(
-                    current_condition_match_ptr->getType()->getPointerElementType(),
-                    co.codegen_traits_desc.local_addr_space_),
+                llvm::PointerType::get(context, co.codegen_traits_desc.local_addr_space_),
                 "current.condition.match.ptr.cast");
           }
         }
@@ -241,9 +235,7 @@ llvm::BasicBlock* JoinLoop::codegen(
             co.codegen_traits_desc.local_addr_space_) {
           remaining_cond_match = builder.CreateAddrSpaceCast(
               remaining_cond_match,
-              llvm::PointerType::get(
-                  remaining_cond_match->getType()->getPointerElementType(),
-                  co.codegen_traits_desc.local_addr_space_),
+              llvm::PointerType::get(context, co.codegen_traits_desc.local_addr_space_),
               "remaining.cond.match.cast");
         }
 

--- a/omniscidb/QueryEngine/LoopControlFlow/JoinLoop.cpp
+++ b/omniscidb/QueryEngine/LoopControlFlow/JoinLoop.cpp
@@ -128,7 +128,7 @@ llvm::BasicBlock* JoinLoop::codegen(
         builder.CreateBr(head_bb);
         builder.SetInsertPoint(head_bb);
         llvm::Value* iteration_counter =
-            builder.CreateLoad(iteration_counter_ptr->getType()->getPointerElementType(),
+            builder.CreateLoad(get_int_type(64, context),
                                iteration_counter_ptr,
                                "ub_iter_counter_val_" + join_loop.name_);
         auto iteration_val = iteration_counter;
@@ -138,9 +138,7 @@ llvm::BasicBlock* JoinLoop::codegen(
         if (join_loop.kind_ == JoinLoopKind::Set ||
             join_loop.kind_ == JoinLoopKind::MultiSet) {
           CHECK(iteration_domain.values_buffer->getType()->isPointerTy());
-          const auto ptr_type =
-              static_cast<llvm::PointerType*>(iteration_domain.values_buffer->getType());
-          if (ptr_type->getPointerElementType()->isArrayTy()) {
+          if (iteration_domain.values_buffer_is_array_of_arrays) {
             iteration_val = builder.CreateGEP(
                 iteration_domain.values_buffer->getType()
                     ->getScalarType()
@@ -151,9 +149,7 @@ llvm::BasicBlock* JoinLoop::codegen(
                     iteration_counter},
                 "ub_iter_counter_" + join_loop.name_);
           } else {
-            iteration_val = builder.CreateGEP(iteration_domain.values_buffer->getType()
-                                                  ->getScalarType()
-                                                  ->getPointerElementType(),
+            iteration_val = builder.CreateGEP(get_int_type(32, context),
                                               iteration_domain.values_buffer,
                                               iteration_counter,
                                               "ub_iter_counter_" + join_loop.name_);

--- a/omniscidb/QueryEngine/LoopControlFlow/JoinLoop.h
+++ b/omniscidb/QueryEngine/LoopControlFlow/JoinLoop.h
@@ -46,7 +46,8 @@ struct JoinLoopDomain {
     llvm::Value* element_count;       // for Set
     llvm::Value* slot_lookup_result;  // for Singleton
   };
-  llvm::Value* values_buffer;  // used for Set
+  llvm::Value* values_buffer;                    // used for Set
+  bool values_buffer_is_array_of_arrays{false};  // TODO: this will take some work
 };
 
 // Any join is logically a loop. Hash joins just limit the domain of iteration,

--- a/omniscidb/QueryEngine/NativeCodegen.cpp
+++ b/omniscidb/QueryEngine/NativeCodegen.cpp
@@ -1096,7 +1096,7 @@ void Executor::createErrorCheckControlFlow(
           error_code_arg_val = ir_builder.CreateAddrSpaceCast(
               error_code_arg,
               llvm::PointerType::get(
-                  error_code_arg->getType()->getPointerElementType(),
+                  cgen_state_->context_,
                   record_error_code_func->getArg(1)->getType()->getPointerAddressSpace()),
               "checkflow.error.cast");
         }
@@ -1938,7 +1938,7 @@ bool Executor::compileBody(const RelAlgExecutionUnit& ra_exe_unit,
           co.codegen_traits_desc.local_addr_space_) {
         loop_done = cgen_state_->ir_builder_.CreateAddrSpaceCast(
             loop_done,
-            llvm::PointerType::get(loop_done->getType()->getPointerElementType(),
+            llvm::PointerType::get(cgen_state_->context_,
                                    co.codegen_traits_desc.local_addr_space_),
             "loop.done.cast");
       }

--- a/omniscidb/QueryEngine/NativeCodegen.cpp
+++ b/omniscidb/QueryEngine/NativeCodegen.cpp
@@ -1926,14 +1926,15 @@ bool Executor::compileBody(const RelAlgExecutionUnit& ra_exe_unit,
   // remapped into filter function arguments by redeclareFilterFunction().
   cgen_state_->row_func_bb_ = cgen_state_->ir_builder_.GetInsertBlock();
   llvm::Value* loop_done{nullptr};
+  auto loop_done_type = get_int_type(1, cgen_state_->context_);
   std::unique_ptr<Executor::FetchCacheAnchor> fetch_cache_anchor;
   if (cgen_state_->filter_func_) {
     if (cgen_state_->row_func_bb_->getName() == "loop_body") {
       auto row_func_entry_bb = &cgen_state_->row_func_->getEntryBlock();
       cgen_state_->ir_builder_.SetInsertPoint(row_func_entry_bb,
                                               row_func_entry_bb->begin());
-      loop_done = cgen_state_->ir_builder_.CreateAlloca(
-          get_int_type(1, cgen_state_->context_), nullptr, "loop_done");
+      loop_done =
+          cgen_state_->ir_builder_.CreateAlloca(loop_done_type, nullptr, "loop_done");
       if (loop_done->getType()->getPointerAddressSpace() !=
           co.codegen_traits_desc.local_addr_space_) {
         loop_done = cgen_state_->ir_builder_.CreateAddrSpaceCast(
@@ -2013,8 +2014,8 @@ bool Executor::compileBody(const RelAlgExecutionUnit& ra_exe_unit,
           cgen_state_->context_, "loop_done_true", cgen_state_->row_func_);
       auto loop_done_false = llvm::BasicBlock::Create(
           cgen_state_->context_, "loop_done_false", cgen_state_->row_func_);
-      auto loop_done_flag = cgen_state_->ir_builder_.CreateLoad(
-          loop_done->getType()->getPointerElementType(), loop_done);
+      auto loop_done_flag =
+          cgen_state_->ir_builder_.CreateLoad(loop_done_type, loop_done);
       cgen_state_->ir_builder_.CreateCondBr(
           loop_done_flag, loop_done_true, loop_done_false);
       cgen_state_->ir_builder_.SetInsertPoint(loop_done_true);
@@ -2036,12 +2037,12 @@ std::vector<llvm::Value*> generate_column_heads_load(const int num_columns,
 
   std::vector<llvm::Value*> col_heads;
   for (int col_id = 0; col_id <= max_col_local_id; ++col_id) {
-    auto* gep = ir_builder.CreateGEP(
-        byte_stream_arg->getType()->getScalarType()->getPointerElementType(),
+    auto gep = llvm::dyn_cast<llvm::GEPOperator>(ir_builder.CreateGEP(
+        get_int_type(8, ctx),
         byte_stream_arg,
-        llvm::ConstantInt::get(llvm::Type::getInt32Ty(ctx), col_id));
-    col_heads.emplace_back(
-        ir_builder.CreateLoad(gep->getType()->getPointerElementType(), gep));
+        llvm::ConstantInt::get(llvm::Type::getInt32Ty(ctx), col_id)));
+    CHECK(gep);
+    col_heads.emplace_back(ir_builder.CreateLoad(gep->getSourceElementType(), gep));
   }
   return col_heads;
 }

--- a/omniscidb/QueryEngine/NativeCodegen.cpp
+++ b/omniscidb/QueryEngine/NativeCodegen.cpp
@@ -2038,7 +2038,7 @@ std::vector<llvm::Value*> generate_column_heads_load(const int num_columns,
   std::vector<llvm::Value*> col_heads;
   for (int col_id = 0; col_id <= max_col_local_id; ++col_id) {
     auto gep = llvm::dyn_cast<llvm::GEPOperator>(ir_builder.CreateGEP(
-        get_int_type(8, ctx),
+        llvm::PointerType::get(ctx, 0),
         byte_stream_arg,
         llvm::ConstantInt::get(llvm::Type::getInt32Ty(ctx), col_id)));
     CHECK(gep);

--- a/omniscidb/QueryEngine/QueryTemplateGenerator.cpp
+++ b/omniscidb/QueryEngine/QueryTemplateGenerator.cpp
@@ -601,6 +601,7 @@ class GroupByQueryTemplateGenerator : public QueryTemplateGenerator {
     if (query_mem_desc.hasVarlenOutput()) {
       // make the varlen buffer the _first_ 8 byte value in the group by buffers double
       // ptr, and offset the group by buffers index by 8 bytes
+      // TODO(llvm16): should this be 32?
       auto varlen_output_buffer_gep = llvm::GetElementPtrInst::Create(
           get_int_type(64, mod->getContext()),
           output_buffers,
@@ -924,11 +925,8 @@ class NonGroupedQueryTemplateGenerator : public QueryTemplateGenerator {
     row_process_params.insert(
         row_process_params.end(), result_ptr_vec.begin(), result_ptr_vec.end());
     if (is_estimate_query) {
-      row_process_params.push_back(new llvm::LoadInst(get_int_type(64, mod->getContext()),
-                                                      output_buffers,
-                                                      "max_matched",
-                                                      false,
-                                                      bb_forbody));
+      row_process_params.push_back(new llvm::LoadInst(
+          output_buffers->getType(), output_buffers, "max_matched", false, bb_forbody));
     }
     row_process_params.push_back(agg_init_val);
     row_process_params.push_back(pos);

--- a/omniscidb/QueryEngine/QueryTemplateGenerator.cpp
+++ b/omniscidb/QueryEngine/QueryTemplateGenerator.cpp
@@ -32,15 +32,6 @@
 
 namespace {
 
-inline llvm::Type* get_pointer_element_type(llvm::Value* value) {
-  CHECK(value);
-  auto type = value->getType();
-  CHECK(type && type->isPointerTy());
-  auto pointer_type = llvm::dyn_cast<llvm::PointerType>(type);
-  CHECK(pointer_type);
-  return pointer_type->getPointerElementType();
-}
-
 template <class Attributes>
 llvm::Function* default_func_builder(llvm::Module* mod, const std::string& name) {
   using namespace llvm;
@@ -372,29 +363,29 @@ class QueryTemplateGenerator {
     query_func_ptr->setAttributes(query_func_pal);
 
     llvm::Function::arg_iterator query_arg_it = query_func_ptr->arg_begin();
-    byte_stream = &*query_arg_it;
+    byte_stream = &*query_arg_it;  // i8**
     byte_stream->setName("byte_stream");
     if (hoist_literals) {
-      literals = &*(++query_arg_it);
+      literals = &*(++query_arg_it);  // i8*
       literals->setName("literals");
     }
-    row_count_ptr = &*(++query_arg_it);
+    row_count_ptr = &*(++query_arg_it);  // i64*
     row_count_ptr->setName("row_count_ptr");
-    frag_row_off_ptr = &*(++query_arg_it);
+    frag_row_off_ptr = &*(++query_arg_it);  // i64*
     frag_row_off_ptr->setName("frag_row_off_ptr");
-    max_matched_ptr = &*(++query_arg_it);
+    max_matched_ptr = &*(++query_arg_it);  // i32*
     max_matched_ptr->setName("max_matched_ptr");
-    agg_init_val = &*(++query_arg_it);
+    agg_init_val = &*(++query_arg_it);  // i64*
     agg_init_val->setName("agg_init_val");
-    output_buffers = &*(++query_arg_it);
+    output_buffers = &*(++query_arg_it);  // i64**
     output_buffers->setName("result_buffers");
-    frag_idx = &*(++query_arg_it);
+    frag_idx = &*(++query_arg_it);  // i32
     frag_idx->setName("frag_idx");
-    join_hash_tables = &*(++query_arg_it);
+    join_hash_tables = &*(++query_arg_it);  // i64*
     join_hash_tables->setName("join_hash_tables");
-    total_matched = &*(++query_arg_it);
+    total_matched = &*(++query_arg_it);  // i32*
     total_matched->setName("total_matched");
-    error_code = &*(++query_arg_it);
+    error_code = &*(++query_arg_it);  // i32*
     error_code->setName("error_code");
 
     bb_entry = llvm::BasicBlock::Create(mod->getContext(), ".entry", query_func_ptr, 0);
@@ -409,7 +400,7 @@ class QueryTemplateGenerator {
 
   virtual void generateEntryBlock() {
     CHECK(!row_count);
-    row_count = new llvm::LoadInst(get_pointer_element_type(row_count_ptr),
+    row_count = new llvm::LoadInst(get_int_type(64, mod->getContext()),
                                    row_count_ptr,
                                    "row_count",
                                    false,
@@ -551,7 +542,7 @@ class GroupByQueryTemplateGenerator : public QueryTemplateGenerator {
 
     CHECK(row_func_call_args && !row_func_call_args->max_matched);
     row_func_call_args->max_matched =
-        new llvm::LoadInst(get_pointer_element_type(max_matched_ptr),
+        new llvm::LoadInst(get_int_type(32, mod->getContext()),
                            max_matched_ptr,
                            "max_matched",
                            false,
@@ -561,6 +552,7 @@ class GroupByQueryTemplateGenerator : public QueryTemplateGenerator {
     auto crt_matched_uncasted_ptr =
         new llvm::AllocaInst(i32_type, 0, "crt_matched", bb_entry);
     if (crt_matched_uncasted_ptr->getType() != pi32_type) {
+      // can this ever happen?
       crt_matched_ptr = new llvm::AddrSpaceCastInst(
           crt_matched_uncasted_ptr, pi32_type, "crt_matched.casted", bb_entry);
     } else {
@@ -605,22 +597,18 @@ class GroupByQueryTemplateGenerator : public QueryTemplateGenerator {
     group_buff_idx_call->setAttributes(group_buff_idx_pal);
     llvm::Value* group_buff_idx = group_buff_idx_call;
 
-    const llvm::PointerType* Ty =
-        llvm::dyn_cast<llvm::PointerType>(output_buffers->getType());
-    CHECK(Ty);
-
     CHECK(row_func_call_args && !row_func_call_args->varlen_output_buffer);
     if (query_mem_desc.hasVarlenOutput()) {
       // make the varlen buffer the _first_ 8 byte value in the group by buffers double
       // ptr, and offset the group by buffers index by 8 bytes
       auto varlen_output_buffer_gep = llvm::GetElementPtrInst::Create(
-          Ty->getPointerElementType(),
+          get_int_type(64, mod->getContext()),
           output_buffers,
           llvm::ConstantInt::get(llvm::Type::getInt32Ty(mod->getContext()), 0),
           "",
           bb_entry);
       row_func_call_args->varlen_output_buffer =
-          new llvm::LoadInst(get_pointer_element_type(varlen_output_buffer_gep),
+          new llvm::LoadInst(varlen_output_buffer_gep->getSourceElementType(),
                              varlen_output_buffer_gep,
                              "varlen_output_buffer",
                              false,
@@ -640,9 +628,13 @@ class GroupByQueryTemplateGenerator : public QueryTemplateGenerator {
 
     CHECK(!pos_start_i64);
     pos_start_i64 = new llvm::SExtInst(pos_start, i64_type, "pos_start_i64", bb_entry);
-    llvm::GetElementPtrInst* group_by_buffers_gep = llvm::GetElementPtrInst::Create(
-        Ty->getPointerElementType(), output_buffers, group_buff_idx, "", bb_entry);
-    col_buffer = new llvm::LoadInst(get_pointer_element_type(group_by_buffers_gep),
+    llvm::GetElementPtrInst* group_by_buffers_gep =
+        llvm::GetElementPtrInst::Create(get_int_type(64, mod->getContext()),
+                                        output_buffers,
+                                        group_buff_idx,
+                                        "",
+                                        bb_entry);
+    col_buffer = new llvm::LoadInst(group_by_buffers_gep->getSourceElementType(),
                                     group_by_buffers_gep,
                                     "col_buffer",
                                     false,
@@ -719,7 +711,7 @@ class GroupByQueryTemplateGenerator : public QueryTemplateGenerator {
     llvm::ICmpInst* loop_or_exit = new llvm::ICmpInst(
         *bb_forbody, llvm::ICmpInst::ICMP_SLT, pos_inc, row_count, "loop_or_exit");
     if (check_scan_limit) {
-      auto crt_matched = new llvm::LoadInst(get_pointer_element_type(crt_matched_ptr),
+      auto crt_matched = new llvm::LoadInst(get_int_type(32, mod->getContext()),
                                             crt_matched_ptr,
                                             "crt_matched",
                                             false,
@@ -727,12 +719,12 @@ class GroupByQueryTemplateGenerator : public QueryTemplateGenerator {
       auto filter_match = llvm::BasicBlock::Create(
           mod->getContext(), "filter_match", query_func_ptr, bb_crit_edge);
       CHECK(row_func_call_args && row_func_call_args->old_total_matched_ptr);
-      llvm::Value* new_total_matched = new llvm::LoadInst(
-          get_pointer_element_type(row_func_call_args->old_total_matched_ptr),
-          row_func_call_args->old_total_matched_ptr,
-          "old_total_matched",
-          false,
-          filter_match);
+      llvm::Value* new_total_matched =
+          new llvm::LoadInst(get_int_type(32, mod->getContext()),
+                             row_func_call_args->old_total_matched_ptr,
+                             "old_total_matched",
+                             false,
+                             filter_match);
       new_total_matched = llvm::BinaryOperator::CreateAdd(
           new_total_matched, crt_matched, "new_total_matched", filter_match);
       CHECK(new_total_matched);
@@ -870,14 +862,14 @@ class NonGroupedQueryTemplateGenerator : public QueryTemplateGenerator {
 
       for (size_t i = 0; i < aggr_col_count; ++i) {
         auto idx_lv = llvm::ConstantInt::get(i32_type, i);
-        auto agg_init_gep = llvm::GetElementPtrInst::CreateInBounds(
-            agg_init_val->getType()->getPointerElementType(),
-            agg_init_val,
-            idx_lv,
-            "agg_init_val_" + std::to_string(i),
-            bb_entry);
+        auto agg_init_gep =
+            llvm::GetElementPtrInst::CreateInBounds(get_int_type(64, mod->getContext()),
+                                                    agg_init_val,
+                                                    idx_lv,
+                                                    "agg_init_val_" + std::to_string(i),
+                                                    bb_entry);
         auto agg_init_val = new llvm::LoadInst(
-            get_pointer_element_type(agg_init_gep), agg_init_gep, "", false, bb_entry);
+            agg_init_gep->getSourceElementType(), agg_init_gep, "", false, bb_entry);
         agg_init_val->setAlignment(LLVM_ALIGN(8));
         agg_init_val_vec.push_back(agg_init_val);
         auto init_val_st =
@@ -930,12 +922,11 @@ class NonGroupedQueryTemplateGenerator : public QueryTemplateGenerator {
     row_process_params.insert(
         row_process_params.end(), result_ptr_vec.begin(), result_ptr_vec.end());
     if (is_estimate_query) {
-      row_process_params.push_back(
-          new llvm::LoadInst(get_pointer_element_type(output_buffers),
-                             output_buffers,
-                             "max_matched",
-                             false,
-                             bb_forbody));
+      row_process_params.push_back(new llvm::LoadInst(get_int_type(64, mod->getContext()),
+                                                      output_buffers,
+                                                      "max_matched",
+                                                      false,
+                                                      bb_forbody));
     }
     row_process_params.push_back(agg_init_val);
     row_process_params.push_back(pos);
@@ -966,7 +957,8 @@ class NonGroupedQueryTemplateGenerator : public QueryTemplateGenerator {
   virtual void generateCriticalEdgeBlock() override {
     if (!is_estimate_query) {
       for (size_t i = 0; i < aggr_col_count; ++i) {
-        auto result = new llvm::LoadInst(get_pointer_element_type(result_ptr_vec[i]),
+        // stores agg_init_val result, so 64 bits
+        auto result = new llvm::LoadInst(get_int_type(64, mod->getContext()),
                                          result_ptr_vec[i],
                                          ".pre.result",
                                          false,
@@ -1005,7 +997,7 @@ class NonGroupedQueryTemplateGenerator : public QueryTemplateGenerator {
         auto col_idx = llvm::ConstantInt::get(i32_type, i);
         if (gpu_smem_context.isSharedMemoryUsed()) {
           auto target_addr = llvm::GetElementPtrInst::CreateInBounds(
-              smem_output_buffer->getType()->getPointerElementType(),
+              smem_output_buffer->getFunctionType(),
               smem_output_buffer,
               col_idx,
               "",
@@ -1019,14 +1011,17 @@ class NonGroupedQueryTemplateGenerator : public QueryTemplateGenerator {
                                  "",
                                  bb_exit);
         } else {
+          // TODO(adb): (1) need to set address space on this opaque pointer properly
+          //            (2) need to make sure this sequence is correct w/r/t opague
+          //            pointer types
           auto out_gep = llvm::GetElementPtrInst::CreateInBounds(
-              output_buffers->getType()->getPointerElementType(),
-              output_buffers,
-              col_idx,
-              "",
-              bb_exit);
+              get_int_type(64, mod->getContext()), output_buffers, col_idx, "", bb_exit);
           auto col_buffer = new llvm::LoadInst(
-              get_pointer_element_type(out_gep), out_gep, "", false, bb_exit);
+              llvm::PointerType::get(mod->getContext(), /*AddressSpace=*/0),
+              out_gep,
+              "",
+              false,
+              bb_exit);
           col_buffer->setAlignment(LLVM_ALIGN(8));
           auto slot_idx = llvm::BinaryOperator::CreateAdd(
               group_buff_idx,
@@ -1034,11 +1029,7 @@ class NonGroupedQueryTemplateGenerator : public QueryTemplateGenerator {
               "",
               bb_exit);
           auto target_addr = llvm::GetElementPtrInst::CreateInBounds(
-              col_buffer->getType()->getPointerElementType(),
-              col_buffer,
-              slot_idx,
-              "",
-              bb_exit);
+              col_buffer->getType(), col_buffer, slot_idx, "", bb_exit);
           llvm::StoreInst* result_st =
               new llvm::StoreInst(result_vec[i], target_addr, false, bb_exit);
           result_st->setAlignment(LLVM_ALIGN(8));
@@ -1056,14 +1047,14 @@ class NonGroupedQueryTemplateGenerator : public QueryTemplateGenerator {
         // If there are more targets than threads we do not currently use shared memory
         // optimization. This can be relaxed if necessary
         for (size_t i = 0; i < aggr_col_count; i++) {
-          auto out_gep = llvm::GetElementPtrInst::CreateInBounds(
-              output_buffers->getType()->getPointerElementType(),
-              output_buffers,
-              llvm::ConstantInt::get(i32_type, i),
-              "",
-              bb_exit);
+          auto out_gep =
+              llvm::GetElementPtrInst::CreateInBounds(get_int_type(64, mod->getContext()),
+                                                      output_buffers,
+                                                      llvm::ConstantInt::get(i32_type, i),
+                                                      "",
+                                                      bb_exit);
           auto gmem_output_buffer =
-              new llvm::LoadInst(get_pointer_element_type(out_gep),
+              new llvm::LoadInst(out_gep->getSourceElementType(),
                                  out_gep,
                                  "gmem_output_buffer_" + std::to_string(i),
                                  false,

--- a/omniscidb/QueryEngine/QueryTemplateGenerator.cpp
+++ b/omniscidb/QueryEngine/QueryTemplateGenerator.cpp
@@ -634,7 +634,9 @@ class GroupByQueryTemplateGenerator : public QueryTemplateGenerator {
                                         group_buff_idx,
                                         "",
                                         bb_entry);
-    col_buffer = new llvm::LoadInst(group_by_buffers_gep->getSourceElementType(),
+    // TODO(adb): use central constant for address space for load
+    // NOTE: address spaces must match for function arguments (no surprise)
+    col_buffer = new llvm::LoadInst(llvm::PointerType::get(mod->getContext(), 0),
                                     group_by_buffers_gep,
                                     "col_buffer",
                                     false,
@@ -646,6 +648,8 @@ class GroupByQueryTemplateGenerator : public QueryTemplateGenerator {
         llvm::ConstantInt::get(i32_type, gpu_smem_context.getSharedMemorySize());
     // TODO(Saman): change this further, normal path should not go through this
     // TODO(adb): this could be directly assigned in row func args?
+    auto fcn_arg = func_init_shared_mem->getArg(0);
+    fcn_arg->print(llvm::errs(), true);
     result_buffer =
         llvm::CallInst::Create(func_init_shared_mem,
                                std::vector<llvm::Value*>{col_buffer, shared_mem_bytes_lv},

--- a/omniscidb/QueryEngine/QueryTemplateGenerator.cpp
+++ b/omniscidb/QueryEngine/QueryTemplateGenerator.cpp
@@ -649,7 +649,6 @@ class GroupByQueryTemplateGenerator : public QueryTemplateGenerator {
     // TODO(Saman): change this further, normal path should not go through this
     // TODO(adb): this could be directly assigned in row func args?
     auto fcn_arg = func_init_shared_mem->getArg(0);
-    fcn_arg->print(llvm::errs(), true);
     result_buffer =
         llvm::CallInst::Create(func_init_shared_mem,
                                std::vector<llvm::Value*>{col_buffer, shared_mem_bytes_lv},

--- a/omniscidb/QueryEngine/ResultSetReductionCodegen.cpp
+++ b/omniscidb/QueryEngine/ResultSetReductionCodegen.cpp
@@ -279,7 +279,7 @@ void translate_body(const std::vector<std::unique_ptr<Instruction>>& body,
           co.codegen_traits_desc.local_addr_space_) {
         translated = cgen_state->ir_builder_.CreateAddrSpaceCast(
             translated,
-            llvm::PointerType::get(translated->getType()->getPointerElementType(),
+            llvm::PointerType::get(cgen_state->context_,
                                    co.codegen_traits_desc.local_addr_space_),
             "translated.cast");
       }

--- a/omniscidb/QueryEngine/RowFuncBuilder.cpp
+++ b/omniscidb/QueryEngine/RowFuncBuilder.cpp
@@ -1140,12 +1140,9 @@ llvm::Value* RowFuncBuilder::codegenAggColumnPtr(
     size_t col_off = query_mem_desc.getColOnlyOffInBytes(agg_out_off);
     CHECK_EQ(size_t(0), col_off % chosen_bytes);
     col_off /= chosen_bytes;
-    agg_col_ptr = LL_BUILDER.CreateGEP(
-        llvm::PointerType::get(
-            LL_CONTEXT,
-            std::get<0>(agg_out_ptr_w_idx)->getType()->getPointerAddressSpace()),
-        std::get<0>(agg_out_ptr_w_idx),
-        LL_INT(col_off));
+    agg_col_ptr = LL_BUILDER.CreateGEP(get_int_type((chosen_bytes << 3), LL_CONTEXT),
+                                       std::get<0>(agg_out_ptr_w_idx),
+                                       LL_INT(col_off));
   }
   CHECK(agg_col_ptr);
   return agg_col_ptr;

--- a/omniscidb/QueryEngine/RowFuncBuilder.cpp
+++ b/omniscidb/QueryEngine/RowFuncBuilder.cpp
@@ -444,8 +444,7 @@ std::tuple<llvm::Value*, llvm::Value*> RowFuncBuilder::codegenGroupBy(
         co.codegen_traits_desc.local_addr_space_) {
       group_key = LL_BUILDER.CreateAddrSpaceCast(
           group_key,
-          llvm::PointerType::get(group_key->getType()->getPointerElementType(),
-                                 co.codegen_traits_desc.local_addr_space_),
+          llvm::PointerType::get(LL_CONTEXT, co.codegen_traits_desc.local_addr_space_),
           "group.key.cast");
     }
   }
@@ -1172,8 +1171,7 @@ void RowFuncBuilder::codegenEstimator(std::stack<llvm::BasicBlock*>& array_loops
       co.codegen_traits_desc.local_addr_space_) {
     estimator_key_lv = LL_BUILDER.CreateAddrSpaceCast(
         estimator_key_lv,
-        llvm::PointerType::get(estimator_key_lv->getType()->getPointerElementType(),
-                               cgen_traits.getLocalAddrSpace()),
+        llvm::PointerType::get(LL_CONTEXT, cgen_traits.getLocalAddrSpace()),
         "estimator.key.lv.cast");
   }
 

--- a/omniscidb/QueryEngine/RowFuncBuilder.cpp
+++ b/omniscidb/QueryEngine/RowFuncBuilder.cpp
@@ -492,9 +492,7 @@ std::tuple<llvm::Value*, llvm::Value*> RowFuncBuilder::codegenGroupBy(
       LL_BUILDER.CreateStore(
           group_expr_lv,
           LL_BUILDER.CreateGEP(
-              group_key->getType()->getScalarType()->getPointerElementType(),
-              group_key,
-              LL_INT(subkey_idx++)));
+              group_expr_lv->getType(), group_key, LL_INT(subkey_idx++)));
     }
   }
   if (query_mem_desc.getQueryDescriptionType() ==

--- a/omniscidb/QueryEngine/RowFuncBuilder.cpp
+++ b/omniscidb/QueryEngine/RowFuncBuilder.cpp
@@ -1324,7 +1324,11 @@ void RowFuncBuilder::codegenApproxQuantile(const size_t target_idx,
     calc = llvm::BasicBlock::Create(cs->context_, "calc_approx_quantile");
     skip = llvm::BasicBlock::Create(cs->context_, "skip_approx_quantile");
     irb.CreateCondBr(skip_cond, skip, calc);
+#if LLVM_VERSION_MAJOR > 15
+    cs->current_func_->insert(cs->current_func_->end(), calc);
+#else
     cs->current_func_->getBasicBlockList().push_back(calc);
+#endif
     irb.SetInsertPoint(calc);
   }
   if (!arg_type->isFloatingPoint()) {
@@ -1336,7 +1340,11 @@ void RowFuncBuilder::codegenApproxQuantile(const size_t target_idx,
       "agg_approx_quantile", llvm::Type::getVoidTy(cs->context_), agg_args);
   if (nullable) {
     irb.CreateBr(skip);
+#if LLVM_VERSION_MAJOR > 15
+    cs->current_func_->insert(cs->current_func_->end(), skip);
+#else
     cs->current_func_->getBasicBlockList().push_back(skip);
+#endif
     irb.SetInsertPoint(skip);
   }
 }

--- a/omniscidb/QueryEngine/TargetExprBuilder.cpp
+++ b/omniscidb/QueryEngine/TargetExprBuilder.cpp
@@ -399,11 +399,7 @@ void TargetExprCodegen::codegenAggregate(
       str_target_lv = target_lvs.front();
     }
     std::vector<llvm::Value*> agg_args{
-        executor->castToIntPtrTyIn(
-            (is_group_by ? agg_col_ptr : agg_out_vec[slot_index]),
-            (target_info.is_agg && target_info.type->isArray() ? sizeof(void*)
-                                                               : agg_chosen_bytes)
-                << 3),
+        is_group_by ? agg_col_ptr : agg_out_vec[slot_index],
         (is_simple_count_target && !arg_expr)
             ? (agg_chosen_bytes == sizeof(int32_t) ? LL_INT(int32_t(0))
                                                    : LL_INT(int64_t(0)))
@@ -784,8 +780,7 @@ void TargetExprCodegenBuilder::codegenMultiSlotSampleExpressions(
                                                         first_sample_expr.target_idx);
   } else {
     CHECK_LT(static_cast<size_t>(first_sample_expr.base_slot_index), agg_out_vec.size());
-    agg_col_ptr =
-        executor->castToIntPtrTyIn(agg_out_vec[first_sample_expr.base_slot_index], 64);
+    agg_col_ptr = agg_out_vec[first_sample_expr.base_slot_index];
   }
 
   auto sample_cas_lv =


### PR DESCRIPTION
Starting with the build changes, lots of assertions due to opaque pointer usage. It still compiles, but taking the type is now a runtime error (which seems like an annoying way to do it). 