### PR TITLE
Refragmenting table

### DIFF
--- a/examples/heterogeneous_demo.ipynb
+++ b/examples/heterogeneous_demo.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -136,7 +136,7 @@
     "        fragment_size *= 2\n",
     "    return res_range\n",
     "\n",
-    "def test_groups_fragment_sizes(storage, pyarrow_tbl, table_name, q_dict, step, n_iters, clear_memory_devices=[]):\n",
+    "def test_groups_fragment_sizes(storage, pyarrow_tbl, table_name, get_q_dict_callback, step, n_iters, clear_memory_devices=[]):\n",
     "    \"\"\" \n",
     "    Produces the follwing result grouping: fragment_size{query_name{timings_df}}\n",
     "    \"\"\"\n",
@@ -144,14 +144,16 @@
     "    for frag_size in fragment_size_test_range(pyarrow_tbl.num_rows):\n",
     "        table_size_MB = pyarrow_tbl.nbytes // (1024*1024)\n",
     "        print(f\"Testing {table_size_MB}MB Table with Frag.size={frag_size}\")\n",
-    "        storage.refragmentTable(table_name, frag_size)\n",
-    "        part_group_timings_dict[f\"Tbl_size_{table_size_MB}MB_frag_size_{frag_size}\"] = run_queries_all_props(q_dict, step, n_iters, clear_memory_devices)\n",
+    "        refragmented_view_name = f\"{table_name}_{frag_size}\"\n",
+    "        storage.createRefragmentedView(table_name, refragmented_view_name, frag_size)\n",
+    "        part_group_timings_dict[f\"Tbl_size_{table_size_MB}MB_frag_size_{frag_size}\"] = run_queries_all_props(get_q_dict_callback(refragmented_view_name), step, n_iters, clear_memory_devices)\n",
+    "        storage.dropTable(refragmented_view_name)\n",
     "    return part_group_timings_dict"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -164,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -179,21 +181,22 @@
     "    \"group_by_larger\" : f\"SELECT total_amount, COUNT(*) FROM {table_name} GROUP BY total_amount;\",\n",
     "}\n",
     "\n",
-    "taxi_q = {\n",
+    "def getTaxiQ_for_table(tbl_name):\n",
+    "    return {\n",
     "    \"Q1\": f\"SELECT cab_type, count(*)\\\n",
-    "            FROM {table_name}\\\n",
+    "            FROM {tbl_name}\\\n",
     "            GROUP BY cab_type;\",\n",
     "    \"Q2\": f\"SELECT passenger_count, avg(total_amount)\\\n",
-    "            FROM {table_name}\\\n",
+    "            FROM {tbl_name}\\\n",
     "            GROUP BY passenger_count;\",\n",
     "    \"Q3\": f\"SELECT passenger_count, extract(year from pickup_datetime) as pickup_year, count(*)\\\n",
-    "            FROM {table_name}\\\n",
+    "            FROM {tbl_name}\\\n",
     "            GROUP BY passenger_count, extract(year from pickup_datetime);\",\n",
     "    \"Q4\": f\"SELECT passenger_count,\\\n",
     "                extract(year from pickup_datetime) as pickup_year,\\\n",
     "                cast(trip_distance as int) AS distance,\\\n",
     "                count(*) AS the_count\\\n",
-    "            FROM {table_name}\\\n",
+    "            FROM {tbl_name}\\\n",
     "            GROUP BY passenger_count,\\\n",
     "                    pickup_year,\\\n",
     "                    distance\\\n",
@@ -203,31 +206,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Run Queries (kernel may crush, HDK-side issues)\n",
+    "# # Run Queries (kernel may crush, HDK-side issues)\n",
     "default_fragment_size = fragment_size_calc(pyarrow_tbl.num_rows)\n",
     "import_hdk_pyarrow(storage, pyarrow_tbl, table_name, default_fragment_size)\n",
     "\n",
-    "select_queries_timings = run_queries_all_props(select_queries,20,4)\n",
+    "# select_queries_timings = run_queries_all_props(select_queries,20,4) # on large tables can take quite some time on GPU\n",
     "groupby_queries_timings = run_queries_all_props(groupby_queries,10,10,clear_memory_devices=[\"CPU\", \"GPU\"])\n",
-    "taxi_queries_timings = run_queries_all_props(taxi_q,10,3)\n"
+    "taxi_queries_timings = run_queries_all_props(getTaxiQ_for_table(table_name),10,3)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "taxi_frags = test_groups_fragment_sizes(storage, pyarrow_tbl, table_name, taxi_q, 10, 4)"
+    "taxi_frags = test_groups_fragment_sizes(storage, pyarrow_tbl, table_name, getTaxiQ_for_table, 10, 4)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -295,7 +298,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -305,7 +308,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/heterogeneous_demo.ipynb
+++ b/examples/heterogeneous_demo.ipynb
@@ -144,14 +144,14 @@
     "    for frag_size in fragment_size_test_range(pyarrow_tbl.num_rows):\n",
     "        table_size_MB = pyarrow_tbl.nbytes // (1024*1024)\n",
     "        print(f\"Testing {table_size_MB}MB Table with Frag.size={frag_size}\")\n",
-    "        import_hdk_pyarrow(storage, pyarrow_tbl, table_name, frag_size)\n",
+    "        storage.refragmentTable(table_name, frag_size)\n",
     "        part_group_timings_dict[f\"Tbl_size_{table_size_MB}MB_frag_size_{frag_size}\"] = run_queries_all_props(q_dict, step, n_iters, clear_memory_devices)\n",
     "    return part_group_timings_dict"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -164,7 +164,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -203,7 +203,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -218,7 +218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -227,7 +227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -295,7 +295,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -305,7 +305,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -314,7 +314,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/omniscidb/ArrowStorage/ArrowStorage.cpp
+++ b/omniscidb/ArrowStorage/ArrowStorage.cpp
@@ -630,6 +630,120 @@ TableInfoPtr ArrowStorage::importArrowTable(std::shared_ptr<arrow::Table> at,
   return importArrowTable(at, table_name, columns, options);
 }
 
+void ArrowStorage::refragmentTable(const std::string& table_name,
+                                   const size_t new_frag_size) {
+  auto tinfo = getTableInfo(db_id_, table_name);
+  if (!tinfo) {
+    throw std::runtime_error("Unknown table: "s + table_name);
+  }
+  if (!new_frag_size) {
+    throw std::runtime_error("Cannot refragment to fragment size 0");
+  }
+  mapd_shared_lock<mapd_shared_mutex> data_lock(data_mutex_);
+  auto& table = *tables_.at(tinfo->table_id);
+  mapd_unique_lock<mapd_shared_mutex> table_lock(table.mutex);
+  data_lock.unlock();
+  if (new_frag_size == table.fragment_size) {
+    return;
+  }
+  const size_t new_frag_count =
+      table.row_count / new_frag_size + ((table.row_count % new_frag_size) != 0);
+  std::vector<DataFragment> new_fragments(new_frag_count);
+
+  for (size_t new_frag_idx = 0; new_frag_idx < new_frag_count - 1; new_frag_idx++) {
+    new_fragments[new_frag_idx].metadata.resize(table.col_data.size());
+    new_fragments[new_frag_idx].offset = new_frag_idx * new_frag_size;
+    new_fragments[new_frag_idx].row_count = new_frag_size;
+  }
+  new_fragments[new_frag_count - 1].metadata.resize(table.col_data.size());
+  new_fragments[new_frag_count - 1].offset = (new_frag_count - 1) * new_frag_size;
+  new_fragments[new_frag_count - 1].row_count = table.row_count % new_frag_size;
+  std::vector<bool> lazy_fetch_cols(table.col_data.size(), false);
+
+  if (config_->storage.enable_lazy_dict_materialization) {
+    VLOG(1) << "Refragmenting with lazy dictionary materialization enabled";
+    mapd_shared_lock<mapd_shared_mutex> dict_lock(dict_mutex_);
+    for (size_t col_idx = 0; col_idx < lazy_fetch_cols.size(); col_idx++) {
+      auto col_info = getColumnInfo(db_id_, tinfo->table_id, columnId(col_idx));
+      CHECK(col_info);
+      auto col_type = col_info->type;
+      auto col_arr = table.col_data[col_idx];
+      if (col_type->isExtDictionary() && col_arr->type()->id() == arrow::Type::STRING) {
+        auto dict_data =
+            dicts_.at(dynamic_cast<const hdk::ir::ExtDictionaryType*>(col_type)->dictId())
+                .get();
+        CHECK(dict_data);
+        if (!dict_data->is_materialized) {
+          lazy_fetch_cols[col_idx] = true;
+        }
+      }
+    }
+  }
+  tbb::parallel_for(tbb::blocked_range(0, (int)table.col_data.size()), [&](auto range) {
+    for (auto col_idx = range.begin(); col_idx != range.end(); col_idx++) {
+      auto col_info = getColumnInfo(db_id_, tinfo->table_id, columnId(col_idx));
+      auto col_type = col_info->type;
+      auto col_arr = table.col_data[col_idx];
+      auto elem_type =
+          col_type->isArray()
+              ? dynamic_cast<const hdk::ir::ArrayBaseType*>(col_type)->elemType()
+              : col_type;
+      bool compute_stats = !col_type->isString();
+      if (compute_stats) {
+        size_t elems_count = 1;
+        if (col_type->isFixedLenArray()) {
+          elems_count = col_type->size() / elem_type->size();
+        }
+        // Compute stats for each fragment.
+        tbb::parallel_for(
+            tbb::blocked_range(size_t(0), new_frag_count), [&](auto frag_range) {
+              for (size_t frag_idx = frag_range.begin(); frag_idx != frag_range.end();
+                   ++frag_idx) {
+                auto& frag = new_fragments[frag_idx];
+                size_t num_bytes;
+                if (col_type->isFixedLenArray()) {
+                  num_bytes = frag.row_count * col_type->size();
+                } else if (col_type->isVarLenArray()) {
+                  num_bytes =
+                      computeTotalStringsLength(col_arr, frag.offset, frag.row_count);
+                } else {
+                  num_bytes = frag.row_count * col_type->size();
+                }
+                auto meta = std::make_shared<ChunkMetadata>(
+                    col_info->type, num_bytes, frag.row_count);
+
+                if (!lazy_fetch_cols[col_idx]) {
+                  meta->fillChunkStats(computeStats(
+                      col_arr->Slice(frag.offset, frag.row_count * elems_count),
+                      col_type));
+                } else {
+                  int32_t min = 0;
+                  int32_t max = -1;
+                  meta->fillChunkStats(min, max, /*has_nulls=*/true);
+                }
+                frag.metadata[col_idx] = meta;
+              }
+            });  // each new fragment
+      } else {
+        bool has_nulls = false;
+        for (size_t frag_idx = 0; frag_idx < new_frag_count; ++frag_idx) {
+          auto& frag = new_fragments[frag_idx];
+          CHECK(col_type->isText());
+          auto meta = std::make_shared<ChunkMetadata>(
+              col_info->type,
+              computeTotalStringsLength(col_arr, frag.offset, frag.row_count),
+              frag.row_count);
+          meta->fillStringChunkStats(
+              col_arr->Slice(frag.offset, frag.row_count)->null_count());
+          has_nulls = has_nulls || meta->chunkStats().has_nulls;
+          frag.metadata[col_idx] = meta;
+        }
+      }
+    }
+  });
+  table.fragments = std::move(new_fragments);
+}
+
 void ArrowStorage::appendArrowTable(std::shared_ptr<arrow::Table> at,
                                     const std::string& table_name) {
   auto tinfo = getTableInfo(db_id_, table_name);

--- a/omniscidb/ArrowStorage/ArrowStorage.cpp
+++ b/omniscidb/ArrowStorage/ArrowStorage.cpp
@@ -633,12 +633,9 @@ TableInfoPtr ArrowStorage::importArrowTable(std::shared_ptr<arrow::Table> at,
 TableInfoPtr ArrowStorage::createRefragmentedView(const std::string& table_name,
                                                   const std::string& new_table_name,
                                                   const size_t new_frag_size) {
-  if (!new_frag_size) {
-    throw std::runtime_error("Cannot refragment to fragment size 0");
-  }
-
-  if (table_name.empty()) {
-    throw std::runtime_error("Cannot create table with empty name");
+  CHECK(new_frag_size);
+  if (new_table_name.empty() || table_name.empty()) {
+    throw std::runtime_error("Empty table names are not allowed");
   }
   TableInfoPtr res;
   int new_table_id;
@@ -701,8 +698,7 @@ void ArrowStorage::refragmentTable(TableData& table,
   if (!new_frag_size) {
     throw std::runtime_error("Cannot refragment to fragment size 0");
   }
-  const size_t new_frag_count =
-      std::ceil(static_cast<float>(table.row_count) / new_frag_size);
+  const size_t new_frag_count = (table.row_count + new_frag_size - 1) / new_frag_size;
   std::vector<DataFragment> new_fragments(new_frag_count);
 
   for (size_t new_frag_idx = 0; new_frag_idx < new_frag_count - 1; new_frag_idx++) {

--- a/omniscidb/ArrowStorage/ArrowStorage.h
+++ b/omniscidb/ArrowStorage/ArrowStorage.h
@@ -86,6 +86,8 @@ class ArrowStorage : public SimpleSchemaProvider, public AbstractDataProvider {
                                 const std::string& table_name,
                                 const TableOptions& options = TableOptions());
 
+  void refragmentTable(const std::string& table_name, const size_t new_frag_size);
+
   void appendArrowTable(std::shared_ptr<arrow::Table> at, const std::string& table_name);
   void appendArrowTable(std::shared_ptr<arrow::Table> at, int table_id);
 

--- a/omniscidb/ArrowStorage/ArrowStorage.h
+++ b/omniscidb/ArrowStorage/ArrowStorage.h
@@ -85,9 +85,9 @@ class ArrowStorage : public SimpleSchemaProvider, public AbstractDataProvider {
   TableInfoPtr importArrowTable(std::shared_ptr<arrow::Table> at,
                                 const std::string& table_name,
                                 const TableOptions& options = TableOptions());
-
-  void refragmentTable(const std::string& table_name, const size_t new_frag_size);
-
+  TableInfoPtr createRefragmentedView(const std::string& table_name,
+                                      const std::string& new_table_name,
+                                      const size_t new_frag_size);
   void appendArrowTable(std::shared_ptr<arrow::Table> at, const std::string& table_name);
   void appendArrowTable(std::shared_ptr<arrow::Table> at, int table_id);
 
@@ -237,7 +237,7 @@ class ArrowStorage : public SimpleSchemaProvider, public AbstractDataProvider {
                             Data_Namespace::AbstractBuffer* dest,
                             size_t elem_size,
                             size_t num_bytes) const;
-
+  void refragmentTable(TableData& table, const int table_id, const size_t new_frag_size);
   void materializeDictionary(DictionaryData* dict_data);
 
   int db_id_;

--- a/python/pyhdk/_builder.pyx
+++ b/python/pyhdk/_builder.pyx
@@ -447,6 +447,15 @@ cdef class QueryNode:
   def __getitem__(self, col):
     return self.ref(col)
 
+  def refragmented_view(self, fragment_size, new_table_name=None):
+    if not self.is_scan:
+      raise TypeError("Only table scan QueryNode can be refragmented")
+    res_name, exists = self._hdk._process_import_table_name(new_table_name)
+    if exists:
+      raise RuntimeError("New table name already exists")
+    self._hdk._storage.createRefragmentedView(self.table_name, res_name, fragment_size)
+    return self._hdk.scan(res_name)
+
   def proj(self, *args, exprs=None, **kwargs):
     cdef vector[CBuilderExpr] proj_exprs
 

--- a/python/pyhdk/_storage.pxd
+++ b/python/pyhdk/_storage.pxd
@@ -133,6 +133,7 @@ cdef extern from "omniscidb/ArrowStorage/ArrowStorage.h":
     CTableInfoPtr createTable(const string&, const vector[CColumnDescription]&, const CTableOptions&) except +
 
     CTableInfoPtr importArrowTable(shared_ptr[CArrowTable], string&, CTableOptions&) except +;
+    void refragmentTable(const string&, const size_t) except +
     void appendArrowTable(shared_ptr[CArrowTable], const string&) except +
     CTableInfoPtr importCsvFile(string&, string&, CTableOptions&, CCsvParseOptions) except +
     CTableInfoPtr importCsvFileWithSchema "importCsvFile"(string&, string&, const vector[CColumnDescription]&, CTableOptions&, CCsvParseOptions) except +

--- a/python/pyhdk/_storage.pxd
+++ b/python/pyhdk/_storage.pxd
@@ -131,9 +131,8 @@ cdef extern from "omniscidb/ArrowStorage/ArrowStorage.h":
     CArrowStorage(int, string, int, shared_ptr[CConfig]) except +;
 
     CTableInfoPtr createTable(const string&, const vector[CColumnDescription]&, const CTableOptions&) except +
-
+    CTableInfoPtr createRefragmentedView(const string& , const string&, const size_t) except +
     CTableInfoPtr importArrowTable(shared_ptr[CArrowTable], string&, CTableOptions&) except +;
-    void refragmentTable(const string&, const size_t) except +
     void appendArrowTable(shared_ptr[CArrowTable], const string&) except +
     CTableInfoPtr importCsvFile(string&, string&, CTableOptions&, CCsvParseOptions) except +
     CTableInfoPtr importCsvFileWithSchema "importCsvFile"(string&, string&, const vector[CColumnDescription]&, CTableOptions&, CCsvParseOptions) except +

--- a/python/pyhdk/_storage.pyx
+++ b/python/pyhdk/_storage.pyx
@@ -289,8 +289,8 @@ cdef class ArrowStorage(Storage):
     cdef shared_ptr[CArrowTable] at = pyarrow_unwrap_table(table)
     self.c_storage.get().importArrowTable(at, name, options.c_options)
 
-  def refragmentTable(self, name, fragment_size):
-    self.c_storage.get().refragmentTable(name, fragment_size)
+  def createRefragmentedView(self, name, view_name, new_frag_size):
+    self.c_storage.get().createRefragmentedView(name, view_name, new_frag_size)
 
   def appendArrowTable(self, table, name):
     cdef shared_ptr[CArrowTable] at = pyarrow_unwrap_table(table)

--- a/python/pyhdk/_storage.pyx
+++ b/python/pyhdk/_storage.pyx
@@ -289,6 +289,9 @@ cdef class ArrowStorage(Storage):
     cdef shared_ptr[CArrowTable] at = pyarrow_unwrap_table(table)
     self.c_storage.get().importArrowTable(at, name, options.c_options)
 
+  def refragmentTable(self, name, fragment_size):
+    self.c_storage.get().refragmentTable(name, fragment_size)
+
   def appendArrowTable(self, table, name):
     cdef shared_ptr[CArrowTable] at = pyarrow_unwrap_table(table)
     self.c_storage.get().appendArrowTable(at, name)

--- a/python/tests/test_pyhdk_api.py
+++ b/python/tests/test_pyhdk_api.py
@@ -165,6 +165,27 @@ class TestBuilder(BaseTest):
             _ = hdk.scan(1)
         hdk.drop_table(table_name)
 
+    def test_refragment(self, exe_cfg):
+        # Initialize HDK components hidden from users
+        hdk = pyhdk.init()
+
+        # Import data
+        trips = hdk.import_csv(
+            "omniscidb/Tests/ArrowStorageDataFiles/taxi_sample_header.csv"
+        )
+
+        # Refragment a table
+        res = trips.refragmented_view(2, new_table_name="trips_2")
+        res1 = trips.refragmented_view(3)
+
+        assert res.is_scan
+        assert res1.is_scan
+        assert res.table_name == "trips_2"
+
+        hdk.drop_table(trips)
+        hdk.drop_table(res)
+        hdk.drop_table(res1)
+
     def test_drop_table(self, exe_cfg):
         hdk = pyhdk.init()
         table_name = "table_test_drop_table"


### PR DESCRIPTION
This PR introduces a table refragmentation functionality, which allows to avoid doing an import of the same table just for a new fragment size.
It is relatively cheaper to refragment a table (as opposed to re-inserting it), since we don't have to modify the physical layout/location of the data in memory. The price we pay for refragmenting is recalculating the metadata (basically fragment's offset, row_count + small materialized aggregates per fragment) in order to change the logical view of the table. 

Addresses #572 .

Spends quite some time in `ArrowStorage::computeStats()`, the code for `FixedLengthEncoder::updateStatsEncoded()` appears to be scalar, possible performance improvement opportunity for calculating min/max/detecting nulls using SIMD.