### PR TITLE
Fix arrays fetch in ResultSetRegistry.

### DIFF
--- a/omniscidb/ResultSet/ResultSetIteration.cpp
+++ b/omniscidb/ResultSet/ResultSetIteration.cpp
@@ -798,6 +798,10 @@ TargetValue build_array_target_value(const hdk::ir::Type* array_type,
                                      std::shared_ptr<RowSetMemoryOwner> row_set_mem_owner,
                                      const Data_Namespace::DataMgr* data_mgr) {
   CHECK(array_type->isArray());
+  // Zero size for fixed-length arrays means NULL value.
+  if (array_type->size() > 0 && !buff_sz) {
+    return ArrayTargetValue(boost::optional<std::vector<ScalarTargetValue>>{});
+  }
   auto elem_type = array_type->as<hdk::ir::ArrayBaseType>()->elemType();
   if (elem_type->isString() || elem_type->isExtDictionary()) {
     auto dict_id = elem_type->isExtDictionary()

--- a/omniscidb/ResultSetRegistry/ColumnarResults.cpp
+++ b/omniscidb/ResultSetRegistry/ColumnarResults.cpp
@@ -458,10 +458,11 @@ inline void ColumnarResults::writeBackCell(const TargetValue& col_val,
       for (auto& elem_val : **arr_col_val) {
         write_scalar(&elem_val, offset++, elem_type);
       }
+    } else if (type->isFixedLenArray()) {
       // Put NULL sentinel value for fixed length array
-      if (type->isFixedLenArray() && (*arr_col_val)->size() == 0) {
-        write_arr_null_value(offset, elem_type);
-      }
+      auto elem_type = type->as<hdk::ir::ArrayBaseType>()->elemType();
+      auto offset = row_idx * type->as<hdk::ir::FixedLenArrayType>()->numElems();
+      write_arr_null_value(offset, elem_type);
     }
   }
 }

--- a/omniscidb/Tests/ArrowSQLRunner/ArrowSQLRunner.cpp
+++ b/omniscidb/Tests/ArrowSQLRunner/ArrowSQLRunner.cpp
@@ -147,6 +147,7 @@ class ArrowSQLRunnerImpl {
   CompilationOptions getCompilationOptions(ExecutorDeviceType device_type) {
     auto co = CompilationOptions::defaults(device_type, isGPUPlatformL0());
     co.hoist_literals = config_->exec.codegen.hoist_literals;
+    co.allow_lazy_fetch = config_->rs.enable_lazy_fetch;
     return co;
   }
 

--- a/omniscidb/Tests/QueryBuilderTest.cpp
+++ b/omniscidb/Tests/QueryBuilderTest.cpp
@@ -61,7 +61,8 @@ class TestSuite : public ::testing::Test {
   ExecutionResult runQuery(std::unique_ptr<QueryDag> dag) {
     auto ra_executor = RelAlgExecutor(getExecutor(), getStorage(), std::move(dag));
     auto eo = ExecutionOptions::fromConfig(config());
-    return ra_executor.executeRelAlgQuery(CompilationOptions(), eo, false);
+    return ra_executor.executeRelAlgQuery(
+        getCompilationOptions(ExecutorDeviceType::CPU), eo, false);
   }
 };
 
@@ -6731,12 +6732,17 @@ TEST_F(QueryBuilderTest, NoneEncodedStringInRes) {
 }
 
 TEST_F(QueryBuilderTest, VarlenArrayInRes) {
-  for (bool enable_columnar : {true, false}) {
+  std::vector<std::pair<bool, bool>> variants = {
+      {true, false}, {true, true}, {false, false}, {false, true}};
+  for (auto [enable_columnar, lazy_fetch] : variants) {
     auto orig_enable_columnar = config().rs.enable_columnar_output;
-    ScopeGuard guard([orig_enable_columnar]() {
+    auto orig_enable_lazy_fetch = config().rs.enable_lazy_fetch;
+    ScopeGuard guard([&]() {
       config().rs.enable_columnar_output = orig_enable_columnar;
+      config().rs.enable_lazy_fetch = orig_enable_lazy_fetch;
     });
     config().rs.enable_columnar_output = enable_columnar;
+    config().rs.enable_lazy_fetch = lazy_fetch;
 
     QueryBuilder builder(ctx(), schema_mgr_, configPtr());
 
@@ -6791,12 +6797,17 @@ TEST_F(QueryBuilderTest, VarlenArrayInRes) {
 }
 
 TEST_F(QueryBuilderTest, FixedArrayInRes) {
-  for (bool enable_columnar : {true, false}) {
+  std::vector<std::pair<bool, bool>> variants = {
+      {true, false}, {true, true}, {false, false}, {false, true}};
+  for (auto [enable_columnar, lazy_fetch] : variants) {
     auto orig_enable_columnar = config().rs.enable_columnar_output;
-    ScopeGuard guard([orig_enable_columnar]() {
+    auto orig_enable_lazy_fetch = config().rs.enable_lazy_fetch;
+    ScopeGuard guard([&]() {
       config().rs.enable_columnar_output = orig_enable_columnar;
+      config().rs.enable_lazy_fetch = orig_enable_lazy_fetch;
     });
     config().rs.enable_columnar_output = enable_columnar;
+    config().rs.enable_lazy_fetch = lazy_fetch;
 
     QueryBuilder builder(ctx(), schema_mgr_, configPtr());
 


### PR DESCRIPTION
Currently, NULL value for fixed-length arrays in TargetValue can be expressed in two different ways - nullopt and zero-length array. Only arrow converter supports both cases, fetch and contentToString don't cover both. This patch forces nullopt to be always used.

Also, this patch fixes the fetch of varlen arrays with lazy fetch.

Resolves #627 