### PR TITLE
Remove `getPointerElementType()` usage

### DIFF
--- a/omniscidb/QueryEngine/ArrayIR.cpp
+++ b/omniscidb/QueryEngine/ArrayIR.cpp
@@ -137,16 +137,8 @@ std::vector<llvm::Value*> CodeGenerator::codegenArrayExpr(
 
   llvm::Value* allocated_target_buffer;
   if (array_expr->isLocalAlloc()) {
-    allocated_target_buffer = ir_builder.CreateAlloca(array_type);
-    if (allocated_target_buffer->getType()->getPointerAddressSpace() !=
-        codegen_traits_desc.local_addr_space_) {
-      allocated_target_buffer = ir_builder.CreateAddrSpaceCast(
-          allocated_target_buffer,
-          llvm::PointerType::get(
-              allocated_target_buffer->getType()->getPointerElementType(),
-              co.codegen_traits_desc.local_addr_space_),
-          "allocated.target.buffer.cast");
-    }
+    allocated_target_buffer =
+        ir_builder.CreateAlloca(array_type, co.codegen_traits_desc.local_addr_space_);
   } else {
     if (co.device_type == ExecutorDeviceType::GPU) {
       throw QueryMustRunOnCpu();

--- a/omniscidb/QueryEngine/CgenState.h
+++ b/omniscidb/QueryEngine/CgenState.h
@@ -253,7 +253,7 @@ struct CgenState {
     CHECK(func_type);
     if (has_struct_return) {
       const auto arg_ti = func_type->getParamType(0);
-      CHECK(arg_ti->isPointerTy() && arg_ti->getPointerElementType()->isStructTy());
+      CHECK(arg_ti->isPointerTy());
       auto attr_list = func->getAttributes();
 #if LLVM_VERSION_MAJOR > 13
       llvm::AttrBuilder arr_arg_builder(context_, attr_list.getParamAttrs(0));
@@ -266,6 +266,7 @@ struct CgenState {
     const size_t arg_start = has_struct_return ? 1 : 0;
     for (size_t i = arg_start; i < func->arg_size(); i++) {
       const auto arg_ti = func_type->getParamType(i);
+      // TODO(llvm16): what is the LLVM 16 type for array_append arguments?
       if (arg_ti->isPointerTy() && arg_ti->getPointerElementType()->isStructTy()) {
         auto attr_list = func->getAttributes();
 #if LLVM_VERSION_MAJOR > 13

--- a/omniscidb/QueryEngine/ColumnIR.cpp
+++ b/omniscidb/QueryEngine/ColumnIR.cpp
@@ -431,9 +431,8 @@ llvm::Value* CodeGenerator::posArg(const hdk::ir::Expr* expr) const {
     const auto hash_pos_it = cgen_state_->scan_idx_to_hash_pos_.find(col_var->rteIdx());
     CHECK(hash_pos_it != cgen_state_->scan_idx_to_hash_pos_.end());
     if (hash_pos_it->second->getType()->isPointerTy()) {
-      CHECK(hash_pos_it->second->getType()->getPointerElementType()->isIntegerTy(32));
       llvm::Value* result = cgen_state_->ir_builder_.CreateLoad(
-          hash_pos_it->second->getType()->getPointerElementType(), hash_pos_it->second);
+          get_int_type(32, cgen_state_->context_), hash_pos_it->second);
       result = cgen_state_->ir_builder_.CreateSExt(
           result, get_int_type(64, cgen_state_->context_));
       return result;

--- a/omniscidb/QueryEngine/ColumnIR.cpp
+++ b/omniscidb/QueryEngine/ColumnIR.cpp
@@ -273,11 +273,12 @@ llvm::Value* CodeGenerator::codegenRowId(const hdk::ir::ColumnVar* col_var,
   } else if (col_var->rteIdx() > 0) {
     auto frag_off_ptr = get_arg_by_name(cgen_state_->row_func_, "frag_row_off");
     auto input_off_ptr = cgen_state_->ir_builder_.CreateGEP(
-        frag_off_ptr->getType()->getScalarType()->getPointerElementType(),
+        llvm::PointerType::get(get_int_type(64, cgen_state_->context_),
+                               frag_off_ptr->getType()->getPointerAddressSpace()),
         frag_off_ptr,
         cgen_state_->llInt(int32_t(col_var->rteIdx())));
     auto rowid_offset_lv = cgen_state_->ir_builder_.CreateLoad(
-        input_off_ptr->getType()->getPointerElementType(), input_off_ptr);
+        get_int_type(64, cgen_state_->context_), input_off_ptr);
     rowid_lv = cgen_state_->ir_builder_.CreateAdd(rowid_lv, rowid_offset_lv);
   }
   if (table_generation.start_rowid > 0) {

--- a/omniscidb/QueryEngine/Compiler/Backend.h
+++ b/omniscidb/QueryEngine/Compiler/Backend.h
@@ -86,6 +86,9 @@ class CodegenTraits {
   llvm::PointerType* localPointerType(llvm::Type* ElementType) const {
     return llvm::PointerType::get(ElementType, local_addr_space_);
   }
+  llvm::PointerType* localOpaquePointerType(llvm::LLVMContext& ctx) const {
+    return llvm::PointerType::get(ctx, local_addr_space_);
+  }
   llvm::PointerType* smemPointerType(llvm::Type* ElementType) const {
     return llvm::PointerType::get(ElementType, smem_addr_space_);
   }

--- a/omniscidb/QueryEngine/Compiler/Backend.h
+++ b/omniscidb/QueryEngine/Compiler/Backend.h
@@ -92,6 +92,9 @@ class CodegenTraits {
   llvm::PointerType* smemPointerType(llvm::Type* ElementType) const {
     return llvm::PointerType::get(ElementType, smem_addr_space_);
   }
+  llvm::PointerType* smemOpaquePointerType(llvm::LLVMContext& ctx) const {
+    return llvm::PointerType::get(ctx, smem_addr_space_);
+  }
   llvm::PointerType* globalPointerType(llvm::Type* ElementType) const {
     return llvm::PointerType::get(ElementType, global_addr_space_);
   }

--- a/omniscidb/QueryEngine/Execute.cpp
+++ b/omniscidb/QueryEngine/Execute.cpp
@@ -3804,7 +3804,7 @@ void Executor::preloadFragOffsets(const std::vector<InputDescriptor>& input_desc
     } else {
       if (frag_count > 1) {
         cgen_state_->frag_offsets_.push_back(cgen_state_->ir_builder_.CreateLoad(
-            frag_off_ptr->getType()->getPointerElementType(), frag_off_ptr));
+            get_int_type(64, cgen_state_->context_), frag_off_ptr));
       } else {
         cgen_state_->frag_offsets_.push_back(nullptr);
       }

--- a/omniscidb/QueryEngine/LLVMGlobalContext.cpp
+++ b/omniscidb/QueryEngine/LLVMGlobalContext.cpp
@@ -29,6 +29,7 @@ std::once_flag context_init_flag;
 llvm::orc::ThreadSafeContext& getGlobalLLVMThreadSafeContext() {
   std::call_once(context_init_flag, []() {
     auto global_context = std::make_unique<llvm::LLVMContext>();
+    global_context->enableOpaquePointers();
     g_global_context = llvm::orc::ThreadSafeContext(std::move(global_context));
   });
   return g_global_context;

--- a/omniscidb/QueryEngine/NativeCodegen.cpp
+++ b/omniscidb/QueryEngine/NativeCodegen.cpp
@@ -632,8 +632,7 @@ llvm::Function* create_row_function(const size_t in_col_count,
   row_process_arg_types.push_back(llvm::Type::getInt64Ty(context));
 
   // fragment row offset argument
-  row_process_arg_types.push_back(
-      traits.localPointerType(llvm::Type::getInt64Ty(context)));
+  row_process_arg_types.push_back(traits.localOpaquePointerType(context));
 
   // number of rows for each scan
   row_process_arg_types.push_back(

--- a/omniscidb/QueryEngine/ScalarCodeGenerator.cpp
+++ b/omniscidb/QueryEngine/ScalarCodeGenerator.cpp
@@ -116,8 +116,7 @@ ScalarCodeGenerator::CompiledExpression ScalarCodeGenerator::compile(
     std::vector<llvm::Value*> loaded_args = {wrapper_scalar_expr_func->arg_begin() + 1};
     for (size_t i = 2; i < wrapper_arg_types.size(); ++i) {
       auto* value = wrapper_scalar_expr_func->arg_begin() + i;
-      loaded_args.push_back(
-          b.CreateLoad(value->getType()->getPointerElementType(), value));
+      loaded_args.push_back(b.CreateLoad(arg_types[i - 1], value));
     }
     auto error_lv = b.CreateCall(scalar_expr_func, loaded_args);
     b.CreateStore(error_lv, wrapper_scalar_expr_func->arg_begin());


### PR DESCRIPTION
`getPointerElementType()` is deprecated in LLVM. To make the process of moving to LLVM 16 a little cleaner, I am working to remove all calls to `getPointerElementType()` without our current dependencies (LLVM 14 for conda). 

(not complete, putting this up for CI checks) 