### PR TITLE
Add quantile aggregate.

### DIFF
--- a/omniscidb/IR/Expr.cpp
+++ b/omniscidb/IR/Expr.cpp
@@ -533,7 +533,8 @@ ExprPtr AggExpr::withType(const Type* new_type) const {
   if (type_->equal(new_type)) {
     return shared_from_this();
   }
-  return makeExpr<AggExpr>(new_type, agg_type_, arg_, is_distinct_, arg1_);
+  return makeExpr<AggExpr>(
+      new_type, agg_type_, arg_, is_distinct_, arg1_, interpolation_);
 }
 
 ExprPtr CaseExpr::withType(const Type* new_type) const {
@@ -1193,7 +1194,8 @@ bool AggExpr::operator==(const Expr& rhs) const {
     return false;
   }
   const AggExpr& rhs_ae = dynamic_cast<const AggExpr&>(rhs);
-  if (agg_type_ != rhs_ae.aggType() || is_distinct_ != rhs_ae.isDistinct()) {
+  if (agg_type_ != rhs_ae.aggType() || is_distinct_ != rhs_ae.isDistinct() ||
+      interpolation_ != rhs_ae.interpolation_) {
     return false;
   }
   if (arg_.get() == rhs_ae.arg()) {
@@ -1597,6 +1599,9 @@ std::string AggExpr::toString() const {
   }
   if (arg1_) {
     ss << arg1_->toString();
+  }
+  if (agg_type_ == AggType::kQuantile) {
+    ss << " " << interpolation_;
   }
   ss << ")";
   return ss.str();
@@ -2058,6 +2063,9 @@ size_t AggExpr::hash() const {
     boost::hash_combine(*hash_, is_distinct_);
     if (arg1_) {
       boost::hash_combine(*hash_, arg1_->hash());
+    }
+    if (agg_type_ == AggType::kQuantile) {
+      boost::hash_combine(*hash_, static_cast<int>(interpolation_));
     }
   }
   return *hash_;

--- a/omniscidb/IR/Expr.h
+++ b/omniscidb/IR/Expr.h
@@ -787,11 +787,22 @@ class LikelihoodExpr : public Expr {
  */
 class AggExpr : public Expr {
  public:
-  AggExpr(const Type* type, AggType a, ExprPtr arg, bool d, ExprPtr arg1)
-      : Expr(type, true), agg_type_(a), arg_(arg), is_distinct_(d), arg1_(arg1) {
+  AggExpr(const Type* type,
+          AggType a,
+          ExprPtr arg,
+          bool d,
+          ExprPtr arg1,
+          Interpolation interpolation = Interpolation::kLinear)
+      : Expr(type, true)
+      , agg_type_(a)
+      , arg_(arg)
+      , is_distinct_(d)
+      , arg1_(arg1)
+      , interpolation_(interpolation) {
     if (arg1) {
       if (agg_type_ == AggType::kApproxCountDistinct ||
-          agg_type_ == AggType::kApproxQuantile || agg_type_ == AggType::kTopK) {
+          agg_type_ == AggType::kApproxQuantile || agg_type_ == AggType::kTopK ||
+          agg_type_ == AggType::kQuantile) {
         CHECK(arg1_->is<Constant>());
       } else {
         CHECK(agg_type_ == AggType::kCorr);
@@ -804,6 +815,7 @@ class AggExpr : public Expr {
   bool isDistinct() const { return is_distinct_; }
   const Expr* arg1() const { return arg1_.get(); }
   ExprPtr arg1Shared() const { return arg1_; }
+  Interpolation interpolation() const { return interpolation_; }
   ExprPtr withType(const Type* new_type) const override;
   bool operator==(const Expr& rhs) const override;
   std::string toString() const override;
@@ -817,6 +829,8 @@ class AggExpr : public Expr {
   // APPROX_COUNT_DISTINCT error_rate, APPROX_QUANTILE quantile,
   // CORR second arg
   ExprPtr arg1_;
+  // QUANTILE interpolation
+  Interpolation interpolation_;
 };
 
 /*

--- a/omniscidb/IR/ExprRewriter.h
+++ b/omniscidb/IR/ExprRewriter.h
@@ -320,8 +320,12 @@ class ExprRewriter : public ExprVisitor<ExprPtr> {
     ExprPtr new_arg = agg->arg() ? visit(agg->arg()) : nullptr;
     ExprPtr new_arg1 = agg->arg1() ? visit(agg->arg1()) : nullptr;
     if (new_arg.get() != agg->arg() || new_arg1.get() != agg->arg1()) {
-      return hdk::ir::makeExpr<hdk::ir::AggExpr>(
-          agg->type(), agg->aggType(), new_arg, agg->isDistinct(), new_arg1);
+      return hdk::ir::makeExpr<hdk::ir::AggExpr>(agg->type(),
+                                                 agg->aggType(),
+                                                 new_arg,
+                                                 agg->isDistinct(),
+                                                 new_arg1,
+                                                 agg->interpolation());
     }
     return defaultResult(agg);
   }

--- a/omniscidb/IR/OpType.h
+++ b/omniscidb/IR/OpType.h
@@ -105,6 +105,8 @@ inline std::string toString(hdk::ir::AggType agg) {
       return "SINGLE_VALUE";
     case hdk::ir::AggType::kTopK:
       return "TOP_K";
+    case hdk::ir::AggType::kQuantile:
+      return "QUANTILE";
     case hdk::ir::AggType::kStdDevSamp:
       return "STDDEV";
     case hdk::ir::AggType::kCorr:
@@ -153,6 +155,23 @@ inline std::string toString(hdk::ir::WindowFunctionKind kind) {
   return "";
 }
 
+inline std::string toString(hdk::ir::Interpolation interpolation) {
+  switch (interpolation) {
+    case hdk::ir::Interpolation::kLower:
+      return "LOWER";
+    case hdk::ir::Interpolation::kHigher:
+      return "HIGHER";
+    case hdk::ir::Interpolation::kNearest:
+      return "NEAREST";
+    case hdk::ir::Interpolation::kMidpoint:
+      return "MIDPOINT";
+    case hdk::ir::Interpolation::kLinear:
+      return "LINEAR";
+  }
+  LOG(FATAL) << "Invalid interpolation kind " << (int)interpolation;
+  return "";
+}
+
 namespace hdk::ir {
 
 inline std::ostream& operator<<(std::ostream& os, hdk::ir::OpType op) {
@@ -169,6 +188,10 @@ inline std::ostream& operator<<(std::ostream& os, hdk::ir::AggType agg) {
 
 inline std::ostream& operator<<(std::ostream& os, hdk::ir::WindowFunctionKind kind) {
   return os << toString(kind);
+}
+
+inline std::ostream& operator<<(std::ostream& os, hdk::ir::Interpolation interpolation) {
+  return os << toString(interpolation);
 }
 
 }  // namespace hdk::ir

--- a/omniscidb/IR/OpTypeEnums.h
+++ b/omniscidb/IR/OpTypeEnums.h
@@ -86,6 +86,7 @@ enum class AggType {
   kSample,
   kSingleValue,
   kTopK,
+  kQuantile,
   // Compound aggregates
   kStdDevSamp,
   kCorr,
@@ -109,5 +110,7 @@ enum class WindowFunctionKind {
   Count,
   SumInternal  // For deserialization from Calcite only. Gets rewritten to a regular SUM.
 };
+
+enum class Interpolation { kLower, kHigher, kNearest, kMidpoint, kLinear };
 
 }  // namespace hdk::ir

--- a/omniscidb/QueryBuilder/QueryBuilder.h
+++ b/omniscidb/QueryBuilder/QueryBuilder.h
@@ -78,6 +78,8 @@ class BuilderExpr {
   BuilderExpr singleValue() const;
   BuilderExpr topK(int count) const;
   BuilderExpr bottomK(int count) const;
+  BuilderExpr quantile(double val,
+                       Interpolation interpolation = Interpolation::kLinear) const;
   BuilderExpr stdDev() const;
   BuilderExpr corr(const BuilderExpr& arg) const;
 
@@ -90,12 +92,18 @@ class BuilderExpr {
   BuilderExpr agg(const std::string& agg_str, double val = HUGE_VAL) const;
   BuilderExpr agg(const std::string& agg_str, int val) const;
   BuilderExpr agg(AggType agg_kind, const BuilderExpr& arg) const;
-  BuilderExpr agg(AggType agg_kind, double val) const;
+  BuilderExpr agg(AggType agg_kind,
+                  double val,
+                  Interpolation interpolation = Interpolation::kLinear) const;
   BuilderExpr agg(AggType agg_kind, int val) const;
-  BuilderExpr agg(AggType agg_kind, bool is_dinstinct, const BuilderExpr& arg) const;
+  BuilderExpr agg(AggType agg_kind,
+                  bool is_dinstinct,
+                  const BuilderExpr& arg,
+                  Interpolation interpolation = Interpolation::kLinear) const;
   BuilderExpr agg(AggType agg_kind,
                   bool is_dinstinct = false,
-                  double val = HUGE_VAL) const;
+                  double val = HUGE_VAL,
+                  Interpolation interpolation = Interpolation::kLinear) const;
 
   BuilderExpr extract(DateExtractField field) const;
   BuilderExpr extract(const std::string& field) const;

--- a/omniscidb/QueryEngine/CMakeLists.txt
+++ b/omniscidb/QueryEngine/CMakeLists.txt
@@ -182,6 +182,7 @@ set(hdk_default_runtime_functions_module_dependencies
     DecodersImpl.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../Utils/ExtractFromTime.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../Utils/StringLike.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../Shared/quantile.h
     GroupByRuntime.cpp
     TopKRuntime.cpp)
 

--- a/omniscidb/QueryEngine/CMakeLists.txt
+++ b/omniscidb/QueryEngine/CMakeLists.txt
@@ -73,6 +73,7 @@ set(query_engine_source_files
     OutputBufferInitialization.cpp
     QueryPhysicalInputsCollector.cpp
     PlanState.cpp
+    QuantileRuntime.cpp
     QueryRewrite.cpp
     QueryTemplateGenerator.cpp
     QueryExecutionContext.cpp
@@ -136,6 +137,7 @@ set(group_by_hash_test_files
         GroupByHashTest.cpp
         MurmurHash.cpp
         DynamicWatchdog.cpp
+        QuantileRuntime.cpp
         RuntimeFunctions.cpp
         )
 

--- a/omniscidb/QueryEngine/CalciteDeserializerUtils.h
+++ b/omniscidb/QueryEngine/CalciteDeserializerUtils.h
@@ -134,7 +134,29 @@ inline hdk::ir::AggType to_agg_kind(const std::string& agg_name) {
   if (agg_name == std::string("TOP_K")) {
     return hdk::ir::AggType::kTopK;
   }
+  if (agg_name == std::string("QUANTILE")) {
+    return hdk::ir::AggType::kQuantile;
+  }
   throw std::runtime_error("Aggregate function " + agg_name + " not supported");
+}
+
+inline hdk::ir::Interpolation to_interpolation(const std::string& interpolation) {
+  if (interpolation == std::string("LOWER")) {
+    return hdk::ir::Interpolation::kLower;
+  }
+  if (interpolation == std::string("HIGHER")) {
+    return hdk::ir::Interpolation::kHigher;
+  }
+  if (interpolation == std::string("NEAREST")) {
+    return hdk::ir::Interpolation::kNearest;
+  }
+  if (interpolation == std::string("MIDPOINT")) {
+    return hdk::ir::Interpolation::kMidpoint;
+  }
+  if (interpolation == std::string("LINEAR")) {
+    return hdk::ir::Interpolation::kLinear;
+  }
+  throw std::runtime_error("Interpolation " + interpolation + " is not supported");
 }
 
 namespace hdk::ir {
@@ -145,9 +167,11 @@ class Type;
 
 }  // namespace hdk::ir
 
-const hdk::ir::Type* get_agg_type(hdk::ir::AggType agg_kind,
-                                  const hdk::ir::Expr* arg_expr,
-                                  bool bigint_count);
+const hdk::ir::Type* get_agg_type(
+    hdk::ir::AggType agg_kind,
+    const hdk::ir::Expr* arg_expr,
+    bool bigint_count,
+    hdk::ir::Interpolation interpolation = hdk::ir::Interpolation::kLower);
 
 hdk::ir::DateExtractField to_datepart_field(const std::string&);
 

--- a/omniscidb/QueryEngine/CgenState.cpp
+++ b/omniscidb/QueryEngine/CgenState.cpp
@@ -201,7 +201,7 @@ void CgenState::maybeCloneFunctionRecursive(llvm::Function* fn, bool is_l0) {
     if (llvm::isa<llvm::CallInst>(*it)) {
       auto& call = llvm::cast<llvm::CallInst>(*it);
       // Ignore indirect calls (e.g. virtual function calls).
-      if (call.getCalledFunction()) {
+      if (!call.isIndirectCall()) {
         maybeCloneFunctionRecursive(call.getCalledFunction(), is_l0);
       }
     }

--- a/omniscidb/QueryEngine/CgenState.cpp
+++ b/omniscidb/QueryEngine/CgenState.cpp
@@ -200,7 +200,10 @@ void CgenState::maybeCloneFunctionRecursive(llvm::Function* fn, bool is_l0) {
   for (auto it = llvm::inst_begin(fn), e = llvm::inst_end(fn); it != e; ++it) {
     if (llvm::isa<llvm::CallInst>(*it)) {
       auto& call = llvm::cast<llvm::CallInst>(*it);
-      maybeCloneFunctionRecursive(call.getCalledFunction(), is_l0);
+      // Ignore indirect calls (e.g. virtual function calls).
+      if (call.getCalledFunction()) {
+        maybeCloneFunctionRecursive(call.getCalledFunction(), is_l0);
+      }
     }
   }
 }

--- a/omniscidb/QueryEngine/GroupByRuntime.cpp
+++ b/omniscidb/QueryEngine/GroupByRuntime.cpp
@@ -412,17 +412,17 @@ DEF_AGG_TOPK_ALL(double, double)
 #undef DEF_AGG_TOPK_SKIP_VAL
 #undef DEF_AGG_TOPK
 
-#define DEF_AGG_QUANTILE(val_type, suffix)                                        \
-  extern "C" RUNTIME_EXPORT DEVICE void agg_quantile_impl_##suffix(int64_t* agg,  \
-                                                                   val_type val); \
-  extern "C" RUNTIME_EXPORT ALWAYS_INLINE DEVICE void agg_quantile_##suffix(      \
-      int64_t* agg, val_type val) {                                               \
-    agg_quantile_impl_##suffix(agg, val);                                         \
+#define DEF_AGG_QUANTILE(val_type, suffix)                                   \
+  extern "C" RUNTIME_EXPORT DEVICE void agg_quantile_impl_##suffix(          \
+      GENERIC_ADDR_SPACE int64_t* agg, val_type val);                        \
+  extern "C" RUNTIME_EXPORT ALWAYS_INLINE DEVICE void agg_quantile_##suffix( \
+      GENERIC_ADDR_SPACE int64_t* agg, val_type val) {                       \
+    agg_quantile_impl_##suffix(agg, val);                                    \
   }
 
 #define DEF_AGG_QUANTILE_SKIP_VAL(val_type, suffix)                                     \
   extern "C" RUNTIME_EXPORT ALWAYS_INLINE DEVICE void agg_quantile_##suffix##_skip_val( \
-      int64_t* agg, val_type val, val_type skip_val) {                                  \
+      GENERIC_ADDR_SPACE int64_t* agg, val_type val, val_type skip_val) {               \
     if (val != skip_val) {                                                              \
       agg_quantile_##suffix(agg, val);                                                  \
     }                                                                                   \

--- a/omniscidb/QueryEngine/GroupByRuntime.cpp
+++ b/omniscidb/QueryEngine/GroupByRuntime.cpp
@@ -19,7 +19,6 @@
 
 #ifndef __CUDACC__
 #include "QueryEngine/TopKAggRuntime.h"
-#include "Shared/quantile.h"
 #endif
 
 extern "C" RUNTIME_EXPORT ALWAYS_INLINE DEVICE uint32_t
@@ -413,16 +412,12 @@ DEF_AGG_TOPK_ALL(double, double)
 #undef DEF_AGG_TOPK_SKIP_VAL
 #undef DEF_AGG_TOPK
 
-template <typename ValueType>
-void agg_quantile_impl(int64_t* agg, ValueType val) {
-  auto* quantile = reinterpret_cast<hdk::quantile::Quantile*>(*agg);
-  quantile->add<ValueType>(val);
-}
-
-#define DEF_AGG_QUANTILE(val_type, suffix)                                   \
-  extern "C" RUNTIME_EXPORT ALWAYS_INLINE DEVICE void agg_quantile_##suffix( \
-      int64_t* agg, val_type val) {                                          \
-    agg_quantile_impl<val_type>(agg, val);                                   \
+#define DEF_AGG_QUANTILE(val_type, suffix)                                        \
+  extern "C" RUNTIME_EXPORT DEVICE void agg_quantile_impl_##suffix(int64_t* agg,  \
+                                                                   val_type val); \
+  extern "C" RUNTIME_EXPORT ALWAYS_INLINE DEVICE void agg_quantile_##suffix(      \
+      int64_t* agg, val_type val) {                                               \
+    agg_quantile_impl_##suffix(agg, val);                                         \
   }
 
 #define DEF_AGG_QUANTILE_SKIP_VAL(val_type, suffix)                                     \

--- a/omniscidb/QueryEngine/MemoryLayoutBuilder.cpp
+++ b/omniscidb/QueryEngine/MemoryLayoutBuilder.cpp
@@ -967,13 +967,14 @@ std::unique_ptr<QueryMemoryDescriptor> build_query_memory_descriptor(
       UNREACHABLE() << "Unknown query type";
   }
 
-  auto approx_quantile =
-      anyOf(ra_exe_unit.target_exprs, hdk::ir::AggType::kApproxQuantile);
+  auto any_quantile =
+      anyOf(ra_exe_unit.target_exprs, hdk::ir::AggType::kApproxQuantile) ||
+      anyOf(ra_exe_unit.target_exprs, hdk::ir::AggType::kQuantile);
   auto topk_agg = anyOf(ra_exe_unit.target_exprs, hdk::ir::AggType::kTopK);
   return std::make_unique<QueryMemoryDescriptor>(executor->getDataMgr(),
                                                  executor->getConfigPtr(),
                                                  query_infos,
-                                                 approx_quantile,
+                                                 any_quantile,
                                                  topk_agg,
                                                  allow_multifrag,
                                                  keyless_hash,

--- a/omniscidb/QueryEngine/NativeCodegen.cpp
+++ b/omniscidb/QueryEngine/NativeCodegen.cpp
@@ -786,6 +786,9 @@ std::vector<std::string> get_agg_fnames(
       case hdk::ir::AggType::kTopK:
         result.emplace_back("agg_topk");
         break;
+      case hdk::ir::AggType::kQuantile:
+        result.emplace_back("agg_quantile");
+        break;
       default:
         CHECK(false);
     }

--- a/omniscidb/QueryEngine/OutputBufferInitialization.cpp
+++ b/omniscidb/QueryEngine/OutputBufferInitialization.cpp
@@ -164,6 +164,7 @@ int64_t get_agg_initial_val(hdk::ir::AggType agg,
     case hdk::ir::AggType::kApproxCountDistinct:
     case hdk::ir::AggType::kTopK:
       return 0;
+    case hdk::ir::AggType::kQuantile:
     case hdk::ir::AggType::kApproxQuantile:
       return {};  // Init value is a quantile::TDigest* set elsewhere.
     case hdk::ir::AggType::kMin: {

--- a/omniscidb/QueryEngine/QuantileRuntime.cpp
+++ b/omniscidb/QueryEngine/QuantileRuntime.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "Shared/quantile.h"
+
+#define DEF_AGG_QUANTILE_IMPL(val_type, suffix)                                    \
+  extern "C" RUNTIME_EXPORT DEVICE void agg_quantile_impl_##suffix(int64_t* agg,   \
+                                                                   val_type val) { \
+    auto* quantile = reinterpret_cast<hdk::quantile::Quantile*>(*agg);             \
+    quantile->add<val_type>(val);                                                  \
+  }
+
+DEF_AGG_QUANTILE_IMPL(int8_t, int8)
+DEF_AGG_QUANTILE_IMPL(int16_t, int16)
+DEF_AGG_QUANTILE_IMPL(int32_t, int32)
+DEF_AGG_QUANTILE_IMPL(int64_t, int64)
+DEF_AGG_QUANTILE_IMPL(float, float)
+DEF_AGG_QUANTILE_IMPL(double, double)

--- a/omniscidb/QueryEngine/QueryMemoryInitializer.h
+++ b/omniscidb/QueryEngine/QueryMemoryInitializer.h
@@ -121,7 +121,7 @@ class QueryMemoryInitializer {
                           const std::vector<int64_t>& init_vals,
                           const Executor* executor);
 
-  using QuantileParam = std::optional<double>;
+  using QuantileParam = std::optional<std::pair<hdk::ir::AggType, double>>;
   void initColumnsPerRow(const QueryMemoryDescriptor& query_mem_desc,
                          int8_t* row_ptr,
                          const std::vector<int64_t>& init_vals,
@@ -141,9 +141,10 @@ class QueryMemoryInitializer {
 
   int64_t allocateCountDistinctSet();
 
-  std::vector<QuantileParam> allocateTDigests(const QueryMemoryDescriptor& query_mem_desc,
-                                              const bool deferred,
-                                              const Executor* executor);
+  std::vector<QuantileParam> allocateQuantiles(
+      const QueryMemoryDescriptor& query_mem_desc,
+      const bool deferred,
+      const Executor* executor);
 
   std::vector<int> allocateTopKBuffers(const QueryMemoryDescriptor& query_mem_desc,
                                        const bool deferred,

--- a/omniscidb/QueryEngine/ResultSetReduction.h
+++ b/omniscidb/QueryEngine/ResultSetReduction.h
@@ -100,6 +100,10 @@ class ResultSetReduction {
                                           int8_t* this_ptr1,
                                           const int8_t* that_ptr1,
                                           const size_t target_logical_idx);
+  static void reduceOneQuantileSlot(const QueryMemoryDescriptor& query_mem_desc,
+                                    int8_t* this_ptr1,
+                                    const int8_t* that_ptr1,
+                                    const size_t target_logical_idx);
   static void reduceOneCountDistinctSlot(const ResultSetStorage& this_,
                                          const ResultSetStorage& that,
                                          int8_t* this_ptr1,

--- a/omniscidb/QueryEngine/ResultSetReductionJIT.h
+++ b/omniscidb/QueryEngine/ResultSetReductionJIT.h
@@ -125,6 +125,11 @@ class ResultSetReductionJIT {
                                    const size_t target_logical_idx,
                                    Function* ir_reduce_one_entry) const;
 
+  void reduceOneQuantileSlot(Value* this_ptr1,
+                             Value* that_ptr1,
+                             const size_t target_logical_idx,
+                             Function* ir_reduce_one_entry) const;
+
   void reduceOneTopKSlot(Value* this_ptr1,
                          Value* that_ptr1,
                          const hdk::ir::Type* arg_type,

--- a/omniscidb/QueryEngine/RowFuncBuilder.cpp
+++ b/omniscidb/QueryEngine/RowFuncBuilder.cpp
@@ -815,8 +815,9 @@ llvm::Value* RowFuncBuilder::convertNullIfAny(const hdk::ir::Type* arg_type,
     CHECK(agg_info.agg_kind == hdk::ir::AggType::kTopK);
     agg_type = agg_type->as<hdk::ir::ArrayBaseType>()->elemType();
   } else if (agg_info.agg_kind == hdk::ir::AggType::kQuantile) {
-    // Quantile collects orginal values and we don't care about the
-    // result type at the moment.
+    // Quantile aggregate slot doesn't hold the result but holds a pointer to the object
+    // that collects orginal values. The result type is used on aggregate finalization
+    // only and aggregate collection works with an argument type only.
     agg_type = arg_type;
   }
   const size_t chosen_bytes = agg_type->size();

--- a/omniscidb/QueryEngine/RowFuncBuilder.cpp
+++ b/omniscidb/QueryEngine/RowFuncBuilder.cpp
@@ -814,6 +814,10 @@ llvm::Value* RowFuncBuilder::convertNullIfAny(const hdk::ir::Type* arg_type,
   if (agg_type->isArray()) {
     CHECK(agg_info.agg_kind == hdk::ir::AggType::kTopK);
     agg_type = agg_type->as<hdk::ir::ArrayBaseType>()->elemType();
+  } else if (agg_info.agg_kind == hdk::ir::AggType::kQuantile) {
+    // Quantile collects orginal values and we don't care about the
+    // result type at the moment.
+    agg_type = arg_type;
   }
   const size_t chosen_bytes = agg_type->size();
 

--- a/omniscidb/QueryEngine/WorkUnitBuilder.cpp
+++ b/omniscidb/QueryEngine/WorkUnitBuilder.cpp
@@ -452,7 +452,8 @@ void WorkUnitBuilder::processAggregate(const ir::Aggregate* agg) {
     target_expr = fold_expr(target_expr.get());
     new_target_exprs.emplace_back(target_expr);
     if (co_.device_type == ExecutorDeviceType::GPU && expr->is<ir::AggExpr>() &&
-        expr->as<ir::AggExpr>()->aggType() == ir::AggType::kTopK) {
+        (expr->as<ir::AggExpr>()->aggType() == ir::AggType::kTopK ||
+         expr->as<ir::AggExpr>()->aggType() == ir::AggType::kQuantile)) {
       throw QueryMustRunOnCpu();
     }
   }

--- a/omniscidb/ResultSet/ArrowResultSetConverter.cpp
+++ b/omniscidb/ResultSet/ArrowResultSetConverter.cpp
@@ -1884,9 +1884,9 @@ void appendToColumnBuilder<arrow::Decimal128Builder, int64_t>(
   std::vector<int64_t> vals = boost::get<std::vector<int64_t>>(values);
   auto typed_builder = dynamic_cast<arrow::Decimal128Builder*>(arrow_builder);
   CHECK(typed_builder);
-  CHECK_EQ(is_valid->size(), vals.size());
   if (column_builder.field->nullable()) {
     CHECK(is_valid.get());
+    CHECK_EQ(is_valid->size(), vals.size());
     for (size_t i = 0; i < vals.size(); i++) {
       const auto v = vals[i];
       const auto valid = (*is_valid)[i];

--- a/omniscidb/ResultSet/CMakeLists.txt
+++ b/omniscidb/ResultSet/CMakeLists.txt
@@ -3,6 +3,7 @@ set(result_set_source_files
     ArrowResultSetConverter.cpp
     BitmapGenerators.cpp
     ColSlotContext.cpp
+    QuantileAccessors.cpp
     QueryMemoryDescriptor.cpp
     ResultSet.cpp
     ResultSetIteration.cpp

--- a/omniscidb/ResultSet/ColSlotContext.cpp
+++ b/omniscidb/ResultSet/ColSlotContext.cpp
@@ -55,7 +55,8 @@ ColSlotContext::ColSlotContext(const std::vector<const hdk::ir::Expr*>& col_expr
       const auto agg_info = get_target_info(col_expr, bigint_count);
       const auto chosen_type = get_compact_type(agg_info);
 
-      if (agg_info.agg_kind == hdk::ir::AggType::kTopK) {
+      if (agg_info.agg_kind == hdk::ir::AggType::kTopK ||
+          agg_info.agg_kind == hdk::ir::AggType::kQuantile) {
         addSlotForColumn(sizeof(int64_t), col_expr_idx);
         ++col_expr_idx;
         continue;

--- a/omniscidb/ResultSet/QuantileAccessors.cpp
+++ b/omniscidb/ResultSet/QuantileAccessors.cpp
@@ -1,0 +1,203 @@
+/*
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "QuantileAccessors.h"
+
+#include "Shared/TypePunning.h"
+
+namespace {
+
+template <typename ResultType>
+void finalizeQuantile(hdk::quantile::Quantile* quantile,
+                      const hdk::ir::Type* arg_type,
+                      double q,
+                      hdk::ir::Interpolation interpolation) {
+  if (arg_type->isFloatingPoint()) {
+    switch (arg_type->size()) {
+      case 4:
+        return quantile->finalize<float, ResultType>(q, interpolation);
+      case 8:
+        return quantile->finalize<double, ResultType>(q, interpolation);
+    }
+  } else {
+    switch (arg_type->canonicalSize()) {
+      case 1:
+        return quantile->finalize<int8_t, ResultType>(q, interpolation);
+      case 2:
+        return quantile->finalize<int16_t, ResultType>(q, interpolation);
+      case 4:
+        return quantile->finalize<int32_t, ResultType>(q, interpolation);
+      case 8:
+        return quantile->finalize<int64_t, ResultType>(q, interpolation);
+    }
+  }
+  CHECK(false);
+}
+
+template <typename ResultType>
+ResultType getQuantile(hdk::quantile::Quantile* quantile,
+                       const hdk::ir::Type* arg_type,
+                       double q,
+                       hdk::ir::Interpolation interpolation) {
+  if (arg_type->isFloatingPoint()) {
+    switch (arg_type->size()) {
+      case 4:
+        return quantile->quantile<float, ResultType>(q, interpolation);
+      case 8:
+        return quantile->quantile<double, ResultType>(q, interpolation);
+    }
+  } else {
+    switch (arg_type->canonicalSize()) {
+      case 1:
+        return quantile->quantile<int8_t, ResultType>(q, interpolation);
+      case 2:
+        return quantile->quantile<int16_t, ResultType>(q, interpolation);
+      case 4:
+        return quantile->quantile<int32_t, ResultType>(q, interpolation);
+      case 8:
+        return quantile->quantile<int64_t, ResultType>(q, interpolation);
+    }
+  }
+  CHECK(false);
+  return 0;
+}
+
+}  // namespace
+
+void finalizeQuantile(hdk::quantile::Quantile* quantile, const TargetInfo& target_info) {
+  if (target_info.type->isFloatingPoint()) {
+    switch (target_info.type->size()) {
+      case 4:
+        return finalizeQuantile<float>(quantile,
+                                       target_info.agg_arg_type,
+                                       target_info.quantile_param,
+                                       target_info.interpolation);
+      case 8:
+        return finalizeQuantile<double>(quantile,
+                                        target_info.agg_arg_type,
+                                        target_info.quantile_param,
+                                        target_info.interpolation);
+    }
+  } else {
+    switch (target_info.type->canonicalSize()) {
+      case 1:
+        return finalizeQuantile<int8_t>(quantile,
+                                        target_info.agg_arg_type,
+                                        target_info.quantile_param,
+                                        target_info.interpolation);
+      case 2:
+        return finalizeQuantile<int16_t>(quantile,
+                                         target_info.agg_arg_type,
+                                         target_info.quantile_param,
+                                         target_info.interpolation);
+      case 4:
+        return finalizeQuantile<int32_t>(quantile,
+                                         target_info.agg_arg_type,
+                                         target_info.quantile_param,
+                                         target_info.interpolation);
+      case 8:
+        return finalizeQuantile<int64_t>(quantile,
+                                         target_info.agg_arg_type,
+                                         target_info.quantile_param,
+                                         target_info.interpolation);
+    }
+  }
+  CHECK(false);
+}
+
+TargetValue getQuantile(hdk::quantile::Quantile* quantile,
+                        const TargetInfo& target_info) {
+  if (target_info.type->isFloatingPoint()) {
+    switch (target_info.type->size()) {
+      case 4:
+        return getQuantile<float>(quantile,
+                                  target_info.agg_arg_type,
+                                  target_info.quantile_param,
+                                  target_info.interpolation);
+      case 8:
+        return getQuantile<double>(quantile,
+                                   target_info.agg_arg_type,
+                                   target_info.quantile_param,
+                                   target_info.interpolation);
+    }
+  } else {
+    switch (target_info.type->canonicalSize()) {
+      case 1:
+        return static_cast<int64_t>(getQuantile<int8_t>(quantile,
+                                                        target_info.agg_arg_type,
+                                                        target_info.quantile_param,
+                                                        target_info.interpolation));
+      case 2:
+        return static_cast<int64_t>(getQuantile<int16_t>(quantile,
+                                                         target_info.agg_arg_type,
+                                                         target_info.quantile_param,
+                                                         target_info.interpolation));
+      case 4:
+        return static_cast<int64_t>(getQuantile<int32_t>(quantile,
+                                                         target_info.agg_arg_type,
+                                                         target_info.quantile_param,
+                                                         target_info.interpolation));
+      case 8:
+        return getQuantile<int64_t>(quantile,
+                                    target_info.agg_arg_type,
+                                    target_info.quantile_param,
+                                    target_info.interpolation);
+    }
+  }
+  CHECK(false) << "Unexpected quantile type: " << target_info.type->toString();
+  return (int64_t)0;
+}
+
+InternalTargetValue getQuantileInternal(hdk::quantile::Quantile* quantile,
+                                        const TargetInfo& target_info) {
+  if (target_info.type->isFloatingPoint()) {
+    switch (target_info.type->size()) {
+      case 4: {
+        float fval = getQuantile<float>(quantile,
+                                        target_info.agg_arg_type,
+                                        target_info.quantile_param,
+                                        target_info.interpolation);
+        return InternalTargetValue(
+            static_cast<int64_t>(*reinterpret_cast<int32_t*>(may_alias_ptr(&fval))));
+      }
+      case 8: {
+        double dval = getQuantile<double>(quantile,
+                                          target_info.agg_arg_type,
+                                          target_info.quantile_param,
+                                          target_info.interpolation);
+        return InternalTargetValue(*reinterpret_cast<int64_t*>(may_alias_ptr(&dval)));
+      }
+    }
+  } else {
+    switch (target_info.type->canonicalSize()) {
+      case 1:
+        return InternalTargetValue(
+            static_cast<int64_t>(getQuantile<int8_t>(quantile,
+                                                     target_info.agg_arg_type,
+                                                     target_info.quantile_param,
+                                                     target_info.interpolation)));
+      case 2:
+        return InternalTargetValue(
+            static_cast<int64_t>(getQuantile<int16_t>(quantile,
+                                                      target_info.agg_arg_type,
+                                                      target_info.quantile_param,
+                                                      target_info.interpolation)));
+      case 4:
+        return InternalTargetValue(
+            static_cast<int64_t>(getQuantile<int32_t>(quantile,
+                                                      target_info.agg_arg_type,
+                                                      target_info.quantile_param,
+                                                      target_info.interpolation)));
+      case 8:
+        return InternalTargetValue(getQuantile<int64_t>(quantile,
+                                                        target_info.agg_arg_type,
+                                                        target_info.quantile_param,
+                                                        target_info.interpolation));
+    }
+  }
+  CHECK(false) << "Unexpected quantile type: " << target_info.type->toString();
+  return InternalTargetValue();
+}

--- a/omniscidb/ResultSet/QuantileAccessors.h
+++ b/omniscidb/ResultSet/QuantileAccessors.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "TargetValue.h"
+
+#include "Shared/TargetInfo.h"
+#include "Shared/quantile.h"
+
+void finalizeQuantile(hdk::quantile::Quantile* quantile, const TargetInfo& target_info);
+TargetValue getQuantile(hdk::quantile::Quantile* quantile, const TargetInfo& target_info);
+InternalTargetValue getQuantileInternal(hdk::quantile::Quantile* quantile,
+                                        const TargetInfo& target_info);

--- a/omniscidb/ResultSet/QueryMemoryDescriptor.cpp
+++ b/omniscidb/ResultSet/QueryMemoryDescriptor.cpp
@@ -27,7 +27,7 @@ QueryMemoryDescriptor::QueryMemoryDescriptor(
     Data_Namespace::DataMgr* data_mgr,
     ConfigPtr config,
     const std::vector<InputTableInfo>& query_infos,
-    const bool approx_quantile,
+    const bool any_quantile,
     const bool topk_agg,
     const bool allow_multifrag,
     const bool keyless_hash,
@@ -82,7 +82,7 @@ QueryMemoryDescriptor::QueryMemoryDescriptor(
         output_columnar_ = output_columnar_hint &&
                            QueryMemoryDescriptor::countDescriptorsLogicallyEmpty(
                                count_distinct_descriptors_) &&
-                           !approx_quantile && !topk_agg;
+                           !any_quantile && !topk_agg;
         break;
       default:
         output_columnar_ = false;

--- a/omniscidb/ResultSet/QueryMemoryDescriptor.h
+++ b/omniscidb/ResultSet/QueryMemoryDescriptor.h
@@ -76,7 +76,7 @@ class QueryMemoryDescriptor {
   QueryMemoryDescriptor(Data_Namespace::DataMgr* data_mgr,
                         ConfigPtr config,
                         const std::vector<InputTableInfo>& query_infos,
-                        const bool approx_quantile,
+                        const bool any_quantile,
                         const bool topk_agg,
                         const bool allow_multifrag,
                         const bool keyless_hash,

--- a/omniscidb/ResultSet/ResultSetStorage.h
+++ b/omniscidb/ResultSet/ResultSetStorage.h
@@ -182,7 +182,7 @@ int64_t lazy_decode(const ColumnLazyFetchInfo& col_lazy_fetch,
 void fill_empty_key(void* key_ptr, const size_t key_count, const size_t key_width);
 
 int8_t get_width_for_slot(const size_t target_slot_idx,
-                          const bool float_argument_input,
+                          const TargetInfo& target_info,
                           const QueryMemoryDescriptor& query_mem_desc);
 
 size_t get_byteoff_of_slot(const size_t slot_idx,

--- a/omniscidb/ResultSet/RowSetMemoryOwner.cpp
+++ b/omniscidb/ResultSet/RowSetMemoryOwner.cpp
@@ -8,6 +8,7 @@
 #include "RowSetMemoryOwner.h"
 
 #include "Shared/approx_quantile.h"
+#include "Shared/quantile.h"
 
 EXTERN extern bool g_cache_string_hash;
 EXTERN extern size_t g_approx_quantile_buffer;
@@ -41,6 +42,11 @@ quantile::TDigest* RowSetMemoryOwner::nullTDigest(double const q) {
       .emplace_back(std::make_unique<quantile::TDigest>(
           q, this, g_approx_quantile_buffer, g_approx_quantile_centroids))
       .get();
+}
+
+hdk::quantile::Quantile* RowSetMemoryOwner::quantile() {
+  std::lock_guard<std::mutex> lock(state_mutex_);
+  return quantiles_.emplace_back(std::make_unique<hdk::quantile::Quantile>(this)).get();
 }
 
 int8_t* RowSetMemoryOwner::topKBuffer(size_t size) {

--- a/omniscidb/ResultSet/RowSetMemoryOwner.h
+++ b/omniscidb/ResultSet/RowSetMemoryOwner.h
@@ -30,6 +30,7 @@
 #include "DataProvider/DataProvider.h"
 #include "Logger/Logger.h"
 #include "Shared/approx_quantile.h"
+#include "Shared/quantile.h"
 #include "StringDictionary/StringDictionaryProxy.h"
 #include "ThirdParty/robin_hood.h"
 
@@ -243,6 +244,7 @@ class RowSetMemoryOwner final : public SimpleAllocator, boost::noncopyable {
   }
 
   quantile::TDigest* nullTDigest(double const q);
+  hdk::quantile::Quantile* quantile();
 
   int8_t* topKBuffer(size_t size);
 
@@ -269,6 +271,7 @@ class RowSetMemoryOwner final : public SimpleAllocator, boost::noncopyable {
   std::vector<Data_Namespace::AbstractBuffer*> varlen_input_buffers_;
   std::vector<std::unique_ptr<quantile::TDigest>> t_digests_;
   std::unordered_map<const int8_t*, std::unique_ptr<AbstractDataToken>> data_tokens_;
+  std::vector<std::unique_ptr<hdk::quantile::Quantile>> quantiles_;
 
   DataProvider* data_provider_;  // for metadata lookups
   size_t arena_block_size_;      // for cloning

--- a/omniscidb/ResultSetRegistry/ResultSetRegistry.cpp
+++ b/omniscidb/ResultSetRegistry/ResultSetRegistry.cpp
@@ -99,6 +99,7 @@ std::shared_ptr<ResultSetRegistry> ResultSetRegistry::getOrCreate(
 }
 
 ResultSetTableTokenPtr ResultSetRegistry::put(ResultSetTable table) {
+  auto timer = DEBUG_TIMER(__func__);
   CHECK(!table.empty());
 
   mapd_unique_lock<mapd_shared_mutex> schema_lock(schema_mutex_);

--- a/omniscidb/Shared/InlineNullValues.h
+++ b/omniscidb/Shared/InlineNullValues.h
@@ -28,6 +28,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <limits>
+#include <type_traits>
 
 #define NULL_BOOLEAN INT8_MIN
 #define NULL_TINYINT INT8_MIN

--- a/omniscidb/Shared/SqlTypesLayout.h
+++ b/omniscidb/Shared/SqlTypesLayout.h
@@ -57,7 +57,8 @@ inline const hdk::ir::Type* get_compact_type(const TargetInfo& target) {
 inline void set_compact_type(TargetInfo& target, const hdk::ir::Type* new_type) {
   if (target.is_agg) {
     const auto agg_type = target.agg_kind;
-    if ((agg_type != hdk::ir::AggType::kCount && agg_type != hdk::ir::AggType::kTopK) ||
+    if ((agg_type != hdk::ir::AggType::kCount && agg_type != hdk::ir::AggType::kTopK &&
+         agg_type != hdk::ir::AggType::kQuantile) ||
         !target.agg_arg_type) {
       target.agg_arg_type = new_type;
       return;

--- a/omniscidb/Shared/approx_quantile.h
+++ b/omniscidb/Shared/approx_quantile.h
@@ -15,7 +15,7 @@
  */
 
 /*
- * @file    quantile.h
+ * @file    approx_quantile.h
  * @author  Matt Pulver <matt.pulver@omnisci.com>
  * @description Calculate approximate median and general quantiles, based on
  *   "Computing Extremely Accurate Quantiles Using t-Digests" by T. Dunning et al.

--- a/omniscidb/Shared/quantile.h
+++ b/omniscidb/Shared/quantile.h
@@ -11,6 +11,8 @@
 
 #include "IR/OpTypeEnums.h"
 
+#include <algorithm>
+#include <cmath>
 #include <cstdint>
 #include <vector>
 
@@ -260,18 +262,18 @@ class Quantile {
     size_t right_idx;
     switch (interpolation) {
       case ir::Interpolation::kLower:
-        left_idx = right_idx = floor(pos);
+        left_idx = right_idx = std::floor(pos);
         break;
       case ir::Interpolation::kHigher:
-        left_idx = right_idx = ceil(pos);
+        left_idx = right_idx = std::ceil(pos);
         break;
       case ir::Interpolation::kNearest:
-        left_idx = right_idx = round(pos);
+        left_idx = right_idx = std::round(pos);
         break;
       case ir::Interpolation::kMidpoint:
       case ir::Interpolation::kLinear:
-        left_idx = floor(pos);
-        right_idx = ceil(pos);
+        left_idx = std::floor(pos);
+        right_idx = std::ceil(pos);
         break;
     }
 

--- a/omniscidb/Shared/quantile.h
+++ b/omniscidb/Shared/quantile.h
@@ -156,7 +156,7 @@ class ChunkedArray {
       return chunk_offs_ <= other.chunk_offs_;
     }
 
-    T& operator*() {
+    T& operator*() const {
       auto data = reinterpret_cast<T*>((*chunks_)[chunk_idx_].data);
       return data[chunk_offs_];
     }

--- a/omniscidb/Shared/quantile.h
+++ b/omniscidb/Shared/quantile.h
@@ -1,0 +1,341 @@
+/*
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "InlineNullValues.h"
+#include "SimpleAllocator.h"
+
+#include "IR/OpTypeEnums.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace hdk::quantile {
+
+namespace details {
+
+class ChunkedArray {
+ public:
+  struct Chunk {
+    int8_t* data;
+    // Size holds number of elements, not bytes. Element size
+    // is determined on push.
+    size_t size;
+  };
+
+  // Random access iterator to be used with std::nth_element.
+  template <typename T>
+  class Iterator {
+   public:
+    typedef T value_type;
+    typedef int64_t difference_type;
+    typedef T* pointer;
+    typedef T& reference;
+    typedef std::random_access_iterator_tag iterator_category;
+
+    Iterator(const std::vector<Chunk>* chunks, size_t chunk_idx, size_t chunk_offs)
+        : chunks_(chunks), chunk_idx_(chunk_idx), chunk_offs_(chunk_offs) {}
+
+    Iterator(const Iterator& other) = default;
+    Iterator& operator=(const Iterator& other) = default;
+
+    int64_t operator-(const Iterator& other) const {
+      if (chunk_idx_ == other.chunk_idx_) {
+        return chunk_offs_ - other.chunk_offs_;
+      } else if (chunk_idx_ > other.chunk_idx_) {
+        auto res = (*chunks_)[other.chunk_idx_].size - other.chunk_offs_ + chunk_offs_;
+        for (auto i = other.chunk_idx_ + 1; i < chunk_idx_; ++i) {
+          res += (*chunks_)[i].size;
+        }
+        return (int64_t)res;
+      } else {
+        auto res = (*chunks_)[chunk_idx_].size - chunk_offs_ + other.chunk_offs_;
+        for (auto i = chunk_idx_ + 1; i < other.chunk_idx_; ++i) {
+          res += (*chunks_)[i].size;
+        }
+        return -(int64_t)res;
+      }
+    }
+
+    Iterator& operator+=(int64_t i) {
+      if (i < 0) {
+        operator-=(-i);
+      } else {
+        while (true) {
+          int64_t rem = int64_t((*chunks_)[chunk_idx_].size - chunk_offs_);
+          if (rem > i) {
+            chunk_offs_ += i;
+            break;
+          } else {
+            ++chunk_idx_;
+            chunk_offs_ = 0;
+            i -= rem;
+          }
+        }
+      }
+      return *this;
+    }
+
+    Iterator operator+(int64_t i) const {
+      Iterator res = *this;
+      res += i;
+      return res;
+    }
+
+    Iterator& operator-=(int64_t i) {
+      if (i < 0) {
+        operator+=(-i);
+      } else {
+        while ((int64_t)chunk_offs_ < i) {
+          --chunk_idx_;
+          i -= chunk_offs_;
+          chunk_offs_ = (*chunks_)[chunk_idx_].size;
+        }
+        chunk_offs_ -= i;
+      }
+      return *this;
+    }
+
+    Iterator operator-(int64_t i) const {
+      Iterator res = *this;
+      res -= i;
+      return res;
+    }
+
+    Iterator& operator++() {
+      ++chunk_offs_;
+      if (chunk_offs_ == (*chunks_)[chunk_idx_].size) {
+        ++chunk_idx_;
+        chunk_offs_ = 0;
+      }
+      return *this;
+    }
+
+    Iterator operator++(int) {
+      Iterator res = *this;
+      operator++();
+      return res;
+    }
+
+    Iterator& operator--() {
+      if (!chunk_offs_) {
+        --chunk_idx_;
+        chunk_offs_ = (*chunks_)[chunk_idx_].size;
+      }
+      --chunk_offs_;
+      return *this;
+    }
+
+    Iterator operator--(int) {
+      Iterator res = *this;
+      operator--();
+      return res;
+    }
+
+    bool operator==(const Iterator& other) const {
+      return chunk_idx_ == other.chunk_idx_ && chunk_offs_ == other.chunk_offs_;
+    }
+
+    bool operator!=(const Iterator& other) const { return !(*this == other); }
+
+    bool operator<(const Iterator& other) const {
+      if (chunk_idx_ != other.chunk_idx_) {
+        return chunk_idx_ < other.chunk_idx_;
+      }
+      return chunk_offs_ < other.chunk_offs_;
+    }
+
+    bool operator<=(const Iterator& other) const {
+      if (chunk_idx_ != other.chunk_idx_) {
+        return chunk_idx_ < other.chunk_idx_;
+      }
+      return chunk_offs_ <= other.chunk_offs_;
+    }
+
+    T& operator*() {
+      auto data = reinterpret_cast<T*>((*chunks_)[chunk_idx_].data);
+      return data[chunk_offs_];
+    }
+
+   private:
+    const std::vector<Chunk>* chunks_;
+    // Current chunk index. Can be equal to size of chunks_ vector for `end` iterator.
+    size_t chunk_idx_;
+    // Offset in the current chunk. Should always be less than chunk size when the
+    // index points to a valid chunk.
+    size_t chunk_offs_;
+  };
+
+  ChunkedArray(SimpleAllocator* allocator) : allocator_(allocator), cur_idx_(0) {}
+
+  template <typename T>
+  void push(T value) {
+    // Check if we need to allocate a new chunk.
+    if (chunks_.empty() || cur_idx_ == chunks_.back().size) {
+      // Allocator is most probably a RowSetMemoryOwner object. It is not supposed to be
+      // used to allocate very small objects, so we start with 1 KB and double it each
+      // time with 64KB limit.
+      size_t size_to_allocate = std::max((size_t)64, (size_t)1 << chunks_.size()) << 10;
+      Chunk chunk{allocator_->allocate(size_to_allocate), size_to_allocate / sizeof(T)};
+      chunks_.emplace_back(chunk);
+      cur_idx_ = 0;
+    }
+    auto data = reinterpret_cast<T*>(chunks_.back().data);
+    data[cur_idx_++] = value;
+  }
+
+  void merge(const ChunkedArray& other) {
+    if (!other.chunks_.empty()) {
+      // We are not going to add values to the current last chunk anymore, so fix-up
+      // its size for proper iteration.
+      if (!chunks_.empty()) {
+        chunks_.back().size = cur_idx_;
+      }
+      chunks_.insert(chunks_.end(), other.chunks_.begin(), other.chunks_.end());
+      cur_idx_ = other.cur_idx_;
+    }
+  }
+
+  template <typename T>
+  Iterator<T> begin() {
+    return Iterator<T>(&chunks_, 0, 0);
+  }
+
+  template <typename T>
+  Iterator<T> end() {
+    // Chunk offset in iterator is always expected to be less than chunk size. So, end
+    // iterator for a full chunk is supposed to point the start of the next chunk.
+    // Take care of it if all chunks are full.
+    if (!chunks_.empty() && cur_idx_ == chunks_.back().size) {
+      return Iterator<T>(&chunks_, chunks_.size(), 0);
+    }
+    return Iterator<T>(&chunks_, chunks_.size() - 1, cur_idx_);
+  }
+
+  bool empty() const { return chunks_.empty(); }
+
+  size_t size() const {
+    if (chunks_.empty()) {
+      return 0;
+    }
+
+    size_t res = cur_idx_;
+    for (size_t i = 0; i < chunks_.size() - 1; ++i) {
+      res += chunks_[i].size;
+    }
+    return res;
+  }
+
+  void finalize() const {}
+
+ private:
+  SimpleAllocator* allocator_;
+  std::vector<Chunk> chunks_;
+  // Insertion position in the last chunk.
+  size_t cur_idx_;
+};
+
+class Quantile {
+ public:
+  Quantile(SimpleAllocator* simple_allocator)
+      : values_(simple_allocator), finalized_(false) {}
+
+  template <typename ValueType>
+  void add(ValueType val) {
+    values_.push<ValueType>(val);
+  }
+
+  template <typename ValueType, typename ResultType>
+  void finalize(double q, ir::Interpolation interpolation) {
+    if (finalized_ || values_.empty()) {
+      return;
+    }
+
+    double pos = (values_.size() - 1) * q;
+    size_t left_idx;
+    size_t right_idx;
+    switch (interpolation) {
+      case ir::Interpolation::kLower:
+        left_idx = right_idx = floor(pos);
+        break;
+      case ir::Interpolation::kHigher:
+        left_idx = right_idx = ceil(pos);
+        break;
+      case ir::Interpolation::kNearest:
+        left_idx = right_idx = round(pos);
+        break;
+      case ir::Interpolation::kMidpoint:
+      case ir::Interpolation::kLinear:
+        left_idx = floor(pos);
+        right_idx = ceil(pos);
+        break;
+    }
+
+    auto begin_iter = values_.begin<ValueType>();
+    auto end_iter = values_.end<ValueType>();
+    auto left_iter = begin_iter + left_idx;
+
+    std::nth_element(begin_iter, left_iter, end_iter);
+    auto left_value = *left_iter;
+    ResultType res;
+    if (left_idx != right_idx) {
+      auto right_iter = left_iter + 1;
+      std::nth_element(left_iter, right_iter, end_iter);
+      // It is either midpoint or linear interpolation.
+      double diff_coeff =
+          interpolation == hdk::ir::Interpolation::kMidpoint ? 0.5 : pos - floor(pos);
+      auto right_value = *right_iter;
+      res = static_cast<ResultType>(left_value + (right_value - left_value) * diff_coeff);
+    } else {
+      res = static_cast<ResultType>(left_value);
+    }
+
+    static_assert(sizeof(ResultType) <= sizeof(res_));
+    *reinterpret_cast<ResultType*>(&res_) = res;
+
+    finalized_ = true;
+  }
+
+  // Parameters are designed for future updates to compute multiple quantiles
+  // out of a single data set. It's not supported right now.
+  // Currently, we don't expect this method to be called multiple times with
+  // different parameters. We also don't expect finalize method to be called
+  // with a different set of parameters than this method.
+  template <typename ValueType, typename ResultType>
+  ResultType quantile(double q, hdk::ir::Interpolation interpolation) {
+    if (values_.empty()) {
+      return inline_null_value<ResultType>();
+    }
+    if (!finalized_) {
+      finalize<ValueType, ResultType>(q, interpolation);
+    }
+    static_assert(sizeof(ResultType) <= sizeof(res_));
+    return *reinterpret_cast<const ResultType*>(&res_);
+  }
+
+  void merge(Quantile& other) {
+    values_.merge(other.values_);
+    // We are not supposed to compute quantile before reduction. But when debug
+    // log is enabled, we print row count for each computed ResultSet and rowCount
+    // call triggers quantile computation.
+    // TODO: make rowCount more efficient by avoiding TargetValue materialization.
+    finalized_ = false;
+  }
+
+  bool empty() const { return values_.empty(); }
+
+ private:
+  ChunkedArray values_;
+  bool finalized_;
+  int64_t res_;
+};
+
+}  // namespace details
+
+using Quantile = details::Quantile;
+
+}  // namespace hdk::quantile

--- a/python/pyhdk/_builder.pxd
+++ b/python/pyhdk/_builder.pxd
@@ -9,7 +9,7 @@ from libcpp.string cimport string
 from libcpp.vector cimport vector
 from libcpp.memory cimport shared_ptr, unique_ptr
 
-from pyhdk._common cimport CContext, CConfigPtr, CType, TypeInfo
+from pyhdk._common cimport CContext, CConfigPtr, CType, TypeInfo, CInterpolation
 from pyhdk._ir cimport CExpr, CExprPtr, CNode, CNodePtr
 from pyhdk._storage cimport CSchemaProviderPtr, CColumnInfoPtr
 from pyhdk._sql cimport CExecutionResult, CQueryDag
@@ -38,6 +38,7 @@ cdef extern from "omniscidb/QueryBuilder/QueryBuilder.h":
     CBuilderExpr count(bool) except +
     CBuilderExpr approxCountDist() except +
     CBuilderExpr approxQuantile(double) except +
+    CBuilderExpr quantile(double, CInterpolation) except +
     CBuilderExpr sample() except +
     CBuilderExpr singleValue() except +
     CBuilderExpr topK(int) except +

--- a/python/pyhdk/_common.pxd
+++ b/python/pyhdk/_common.pxd
@@ -26,6 +26,14 @@ cdef extern from "omniscidb/IR/Type.h":
       kColumn "hdk::ir::Type::Id::kColumn" = 14,
       kColumnList "hdk::ir::Type::Id::kColumnList" = 15,
 
+cdef extern from "omniscidb/IR/OpTypeEnums.h":
+  enum CInterpolation "hdk::ir::Interpolation":
+    kLower "hdk::ir::Interpolation::kLower" = 0,
+    kHigher "hdk::ir::Interpolation::kHigher" = 1,
+    kNearest "hdk::ir::Interpolation::kNearest" = 2,
+    kMidpoint "hdk::ir::Interpolation::kMidpoint" = 3,
+    kLinear "hdk::ir::Interpolation::kLinear" = 4,
+
 cdef extern from "omniscidb/IR/Type.h":
   cdef cppclass CType "hdk::ir::Type":
     

--- a/python/pyhdk/hdk.py
+++ b/python/pyhdk/hdk.py
@@ -223,6 +223,35 @@ class QueryExprAPI:
         """
         pass
 
+    def quantile(self, prob, interpolation="linear"):
+        """
+        Create QUANTILE aggregate expression with the current expression as its argument.
+
+        Parameters
+        ----------
+        prob : float
+            Quantile probability. Should be in [0, 1] range.
+        interpolation : str, default: 'linear'
+            Interpolation method to be used when quantile is between two data points.
+            Supported values: 'lower', 'higher', 'nearest', 'midpoint', 'linear'.
+
+        Returns
+        -------
+        QueryExpr
+
+        Examples
+        --------
+        >>> hdk = pyhdk.init()
+        >>> ht = hdk.import_pydict({"x": [4, 0, 2, 8, 6, 10]})
+        >>> ht.agg([], ht["x"].quantile(0.25), ht["x"].quantile(0.25, 'nearest')).run()
+        Schema:
+          x_quantile: FP64
+          x_quantile_1: INT64
+        Data:
+        2.5|2
+        """
+        pass
+
     def sample(self):
         """
         Create SAMPLE aggregate expression with the current expression as its

--- a/python/tests/test_pyhdk_api.py
+++ b/python/tests/test_pyhdk_api.py
@@ -1188,6 +1188,34 @@ class TestBuilder(BaseTest):
 
         hdk.drop_table(ht)
 
+    def test_quantile(self):
+        hdk = pyhdk.init()
+        ht = hdk.import_pydict({"a": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]})
+
+        res = ht.agg([], r=ht["a"].quantile(0.3)).run()
+        check_res(res, {"r": [2.7]})
+
+        res = ht.agg([], r=ht["a"].quantile(0.3, "lower")).run()
+        check_res(res, {"r": [2]})
+
+        res = ht.agg([], r=ht["a"].quantile(0.3, "higher")).run()
+        check_res(res, {"r": [3]})
+
+        res = ht.agg([], r=ht["a"].quantile(0.3, "nearest")).run()
+        check_res(res, {"r": [3]})
+
+        res = ht.agg([], r=ht["a"].quantile(0.3, "midpoint")).run()
+        check_res(res, {"r": [2.5]})
+
+        with pytest.raises(ValueError) as e:
+            ht.agg([], r=ht["a"].quantile(-0.3))
+        with pytest.raises(ValueError) as e:
+            ht.agg([], r=ht["a"].quantile(1.3))
+        with pytest.raises(ValueError) as e:
+            ht.agg([], r=ht["a"].quantile(0.3, "some val"))
+
+        hdk.drop_table(ht)
+
 
 class TestSql(BaseTest):
     def test_no_alias(self, exe_cfg):


### PR DESCRIPTION
This patch introduces QUANTILE aggregate to compute precise quantiles.

Quantile supports multiple interpolations. This is to match pandas' quantile options for Modin.

Quantile implementation is similar to approx quantile implementation except it collects all values and computes the precise quantile value. Quantile objects simply collect all values into vectors of raw buffers, memory is allocated via RowSetMemoryOwner in 1-64KB chunks on demand. On reduction, all buffers are collected together. At the finalization, a special chunked iterator is used to call `std::nth_element` to get values affecting the quantile result in proper places. It might seem from the code that we don't finalize quantiles until data is fetched from the ResutSet but in fact, it is implicitly finalized on `rowCount` call when we put the ResultSet into the registry (that's why I added a new timer there). In the future, I want to add an explicit finalization stage to be used for quantiles and topK and also avoid TargetValue materialization on rowCount.

For the quantile result type, I decided to keep the original argument type unless `midpoint` or `linear` interpolation is used for integer values. In the latter case, the result is fp64.

In the builder, I don't expand the string parser to support interpolations, and the `quantile` method is supposed to be used for non-default interpolations.