### PR TITLE
Refactor GPU shared memory tests and add L0-specific ones [2/2]

### DIFF
--- a/omniscidb/QueryEngine/Compiler/genx.cpp
+++ b/omniscidb/QueryEngine/Compiler/genx.cpp
@@ -187,8 +187,8 @@ int32_t atomicSum32SkipVal(GENERIC_ADDR_SPACE int32_t* addr,
 int64_t atomicSum64SkipVal(GENERIC_ADDR_SPACE int64_t* addr,
                            const int64_t val,
                            const int64_t skip_val) {
-  int32_t old = atomic_xchg_int_64(addr, 0);
-  int32_t old2 = agg_sum_shared(addr, old == skip_val ? val : (val + old));
+  int64_t old = atomic_xchg_int_64(addr, 0);
+  int64_t old2 = agg_sum_shared(addr, old == skip_val ? val : (val + old));
   return old == skip_val ? old2 : (old2 + old);
 }
 
@@ -205,6 +205,16 @@ int32_t agg_sum_int32_skip_val_shared(GENERIC_ADDR_SPACE int32_t* agg,
 int64_t agg_sum_int64_skip_val_shared(GENERIC_ADDR_SPACE int64_t* agg,
                                       const int64_t val,
                                       const int64_t skip_val) {
+  if (val != skip_val) {
+    const int64_t old = atomicSum64SkipVal(agg, val, skip_val);
+    return old;
+  }
+  return 0;
+}
+
+int64_t agg_sum_skip_val_shared(GENERIC_ADDR_SPACE int64_t* agg,
+                                const int64_t val,
+                                const int64_t skip_val) {
   if (val != skip_val) {
     const int64_t old = atomicSum64SkipVal(agg, val, skip_val);
     return old;

--- a/omniscidb/QueryEngine/Compiler/genx.cpp
+++ b/omniscidb/QueryEngine/Compiler/genx.cpp
@@ -214,7 +214,9 @@ void agg_sum_float_skip_val_shared(GENERIC_ADDR_SPACE int32_t* agg,
                                    const float skip_val) {
   if (hdk_float_as_int32_t(val) != hdk_float_as_int32_t(skip_val)) {
     int32_t old = atomic_xchg_int_32(agg, hdk_float_as_int32_t(0.f));
-    agg_sum_float_shared(agg, old == hdk_float_as_int32_t(skip_val) ? val : (val + old));
+    agg_sum_float_shared(
+        agg,
+        old == hdk_float_as_int32_t(skip_val) ? val : (val + hdk_int32_t_as_float(old)));
   }
 }
 
@@ -279,6 +281,24 @@ const GENERIC_ADDR_SPACE int64_t* init_shared_mem(
   }
   sync_threadblock();
   return shared_groups_buffer;
+}
+
+int64_t agg_count_double_skip_val_shared(GENERIC_ADDR_SPACE int64_t* agg,
+                                         const double val,
+                                         const double skip_val) {
+  if (hdk_double_as_int64_t(val) != hdk_double_as_int64_t(skip_val)) {
+    return agg_count_double_shared(agg, val);
+  }
+  return *agg;
+}
+
+uint32_t agg_count_float_skip_val_shared(GENERIC_ADDR_SPACE uint32_t* agg,
+                                         const float val,
+                                         const float skip_val) {
+  if (hdk_float_as_int32_t(val) != hdk_float_as_int32_t(skip_val)) {
+    return agg_count_float_shared(agg, val);
+  }
+  return *agg;
 }
 
 void agg_count_distinct_bitmap_gpu(GENERIC_ADDR_SPACE int64_t* agg,

--- a/omniscidb/QueryEngine/Compiler/genx.ll
+++ b/omniscidb/QueryEngine/Compiler/genx.ll
@@ -167,20 +167,6 @@ define void @agg_sum_double_skip_val_shared(i64 addrspace(4)* %agg, double nound
     ret void
 }
 
-define i64 @agg_sum_skip_val_shared(i64 addrspace(4)* %agg, i64 noundef %val, i64 noundef %skip_val) {
-    %no_skip = icmp ne i64 %val, %skip_val
-    br i1 %no_skip, label %.noskip, label %.skip
-.noskip:
-    %old = atomicrmw xchg i64 addrspace(4)* %agg, i64 0 monotonic
-    %isempty = icmp eq i64 %old, -9223372036854775808
-    %sel = select i1 %isempty, i64 0, i64 %old
-    %new_val = add nsw i64 %val, %sel
-    %old2 = atomicrmw add i64 addrspace(4)* %agg, i64 %new_val monotonic
-    ret i64 %old2
-.skip:
-    ret i64 0
-}
-
 define void @atomic_or(i32 addrspace(4)* %addr, i32 noundef %val) {
 .entry:
     %orig = load atomic i32, i32 addrspace(4)* %addr unordered, align 8

--- a/omniscidb/QueryEngine/Compiler/genx.ll
+++ b/omniscidb/QueryEngine/Compiler/genx.ll
@@ -12,10 +12,10 @@ declare i64 @__spirv_BuiltInSubgroupSize(i32 %dimention)
 
 declare void @__spirv_ControlBarrier(i32 %execution_scope, i32 %memory_scope, i32 %memory_semantics)
 
-@slm.buf.i64 = internal local_unnamed_addr addrspace(3) global [1024 x i64] zeroinitializer, align 4
+@slm.buf.i64 = internal local_unnamed_addr addrspace(3) global [4096 x i64] zeroinitializer, align 4
 
 define i64 addrspace(4)* @declare_dynamic_shared_memory() {
-    %res.share = bitcast [1024 x i64] addrspace(3)* @slm.buf.i64 to i64 addrspace(3)*
+    %res.share = bitcast [4096 x i64] addrspace(3)* @slm.buf.i64 to i64 addrspace(3)*
     %res = addrspacecast i64 addrspace(3)* %res.share to i64 addrspace(4)*
     ret i64 addrspace(4)* %res
 }
@@ -333,7 +333,7 @@ define i64 addrspace(4)* @init_shared_mem(i64 addrspace(4)* %agg_init_val, i32 n
 .for_body:
     %pos.idx = phi i64 [ %pos, %.entry ], [ %pos.idx.new, %.for_body ]
     %agg_init_val.idx = getelementptr inbounds i64, i64 addrspace(4)* %agg_init_val, i64 %pos.idx
-    %slm.idx = getelementptr inbounds [1024 x i64], [1024 x i64] addrspace(3)* @slm.buf.i64, i64 0, i64 %pos.idx
+    %slm.idx = getelementptr inbounds [4096 x i64], [4096 x i64] addrspace(3)* @slm.buf.i64, i64 0, i64 %pos.idx
     %val = load i64, i64 addrspace(4)* %agg_init_val.idx
     store i64 %val, i64 addrspace(3)* %slm.idx
     %pos.idx.new = add nsw i64 %pos.idx, %wgnum
@@ -341,7 +341,7 @@ define i64 addrspace(4)* @init_shared_mem(i64 addrspace(4)* %agg_init_val, i32 n
     br i1 %cond, label %.for_body, label %.exit
 .exit:
     call void @sync_threadblock()
-    %res.ptr = bitcast [1024 x i64] addrspace(3)* @slm.buf.i64 to i64 addrspace(3)*
+    %res.ptr = bitcast [4096 x i64] addrspace(3)* @slm.buf.i64 to i64 addrspace(3)*
     %res.ptr.casted = addrspacecast i64 addrspace(3)* %res.ptr to i64 addrspace(4)*
     ret i64 addrspace(4)* %res.ptr.casted
 }

--- a/omniscidb/QueryEngine/Compiler/genx.ll
+++ b/omniscidb/QueryEngine/Compiler/genx.ll
@@ -128,6 +128,7 @@ define void @agg_sum_float_shared(i32 addrspace(4)* %agg, float noundef %val) {
     ret void
 }
 
+; fixme
 define void @agg_sum_float_skip_val_shared(i32 addrspace(4)* %agg, float noundef %val, float noundef %skip_val) {
     %no_skip = fcmp one float %val, %skip_val
     br i1 %no_skip, label %.noskip, label %.skip
@@ -193,45 +194,6 @@ define void @atomic_or(i32 addrspace(4)* %addr, i32 noundef %val) {
     br i1 %success, label %.exit, label %.loop
 .exit:
     ret void
-}
-
-define double @atomic_min_float(float addrspace(4)* %addr, float noundef %val) {
-.entry:
-    %orig = load float, float addrspace(4)* %addr, align 8
-    br label %.loop
-.loop:
-    %loaded = phi float [ %orig, %.entry], [ %old.cst, %.loop ]
-    %isless = fcmp olt float %val, %loaded
-    %min = select i1 %isless, float %val, float %loaded
-    %min.cst = bitcast float %min to i32
-    %loaded.cst = bitcast float %loaded to i32
-    %addr.cst = bitcast float addrspace(4)* %addr to i32 addrspace(4)*
-    %old = call i32 @atomic_cas_int_32(i32 addrspace(4)* %addr.cst, i32 %loaded.cst, i32 %min.cst)
-    %old.cst = bitcast i32 %old to float
-    %success = icmp eq i32 %old, %loaded.cst
-    br i1 %success, label %.exit, label %.loop
-.exit:
-    %res = fpext float %old.cst to double
-    ret double %res
-}
-
-define double @atomic_min_double(double addrspace(4)* %addr, double noundef %val) {
-.entry:
-    %orig = load double, double addrspace(4)* %addr, align 8
-    br label %.loop
-.loop:
-    %loaded = phi double [ %orig, %.entry], [ %old.cst, %.loop ]
-    %isless = fcmp olt double %val, %loaded
-    %min = select i1 %isless, double %val, double %loaded
-    %min.cst = bitcast double %min to i64
-    %loaded.cst = bitcast double %loaded to i64
-    %addr.cst = bitcast double addrspace(4)* %addr to i64 addrspace(4)*
-    %old = call i64 @atomic_cas_int_64(i64 addrspace(4)* %addr.cst, i64 %loaded.cst, i64 %min.cst)
-    %old.cst = bitcast i64 %old to double
-    %success = icmp eq i64 %old, %loaded.cst
-    br i1 %success, label %.exit, label %.loop
-.exit:
-    ret double %old.cst
 }
 
 define double @atomic_max_float(float addrspace(4)* %addr, float noundef %val) {

--- a/omniscidb/QueryEngine/Compiler/genx.ll
+++ b/omniscidb/QueryEngine/Compiler/genx.ll
@@ -273,60 +273,6 @@ define double @atomic_max_double(double addrspace(4)* %addr, double noundef %val
     ret double %old.cst
 }
 
-
-define void @agg_count_distinct_bitmap_gpu(i64 addrspace(4)* %agg, i64 noundef %val, i64 noundef %min_val, i64 noundef %base_dev_addr, i64 noundef %base_host_addr, i64 noundef %sub_bitmap_count, i64 noundef %bitmap_bytes) {
-    %bitmap_idx = sub nsw i64 %val, %min_val
-    %bitmap_idx.i32 = trunc i64 %bitmap_idx to i32
-    %byte_idx.i64 = lshr i64 %bitmap_idx, 3
-    %byte_idx = trunc i64 %byte_idx.i64 to i32
-    %word_idx = lshr i32 %byte_idx, 2
-    %word_idx.i64 = zext i32 %word_idx to i64
-    %byte_word_idx = and i32 %byte_idx, 3
-    %host_addr = load i64, i64 addrspace(4)* %agg
-    %sub_bm_m1 = sub i64 %sub_bitmap_count, 1
-    %tid = call i64 @get_thread_index()
-    %sub_tid = and i64 %sub_bm_m1, %tid
-    %rhs = mul i64 %sub_tid, %bitmap_bytes
-    %base_dev = add nsw i64 %base_dev_addr, %host_addr
-    %lhs = sub nsw i64 %base_dev, %base_host_addr
-    %bitmap_addr = add i64 %lhs, %rhs
-    %bitmap = inttoptr i64 %bitmap_addr to i32 addrspace(4)*
-    switch i32 %byte_word_idx, label %.exit [
-        i32 0, label %.c0
-        i32 1, label %.c1
-        i32 2, label %.c2
-        i32 3, label %.c3
-   ]
-
-.c0:
-    %btwi0 = getelementptr inbounds i32, i32 addrspace(4)* %bitmap, i64 %word_idx.i64
-    %res0 = and i32 %bitmap_idx.i32, 7
-    br label %.default
-.c1:
-    %btwi1 = getelementptr inbounds i32, i32 addrspace(4)* %bitmap, i64 %word_idx.i64
-    %btidx71 = and i32 %bitmap_idx.i32, 7
-    %res1 = or i32 %btidx71, 8
-    br label %.default
-.c2:
-    %btwi2 = getelementptr inbounds i32, i32 addrspace(4)* %bitmap, i64 %word_idx.i64
-    %btidx72 = and i32 %bitmap_idx.i32, 7
-    %res2 = or i32 %btidx72, 16
-    br label %.default
-.c3:
-    %btwi3 = getelementptr inbounds i32, i32 addrspace(4)* %bitmap, i64 %word_idx.i64
-    %btidx73 = and i32 %bitmap_idx.i32, 7
-    %res3 = or i32 %btidx73, 24
-    br label %.default
-.default:
-    %res = phi i32 [ %res0, %.c0 ], [ %res1, %.c1 ], [ %res2, %.c2], [ %res3, %.c3 ]
-    %arg0 = phi i32 addrspace(4)* [ %btwi0, %.c0 ], [ %btwi1, %.c1 ], [ %btwi2, %.c2], [ %btwi3, %.c3 ]
-    %arg1 = shl nuw i32 1, %res
-    tail call void @atomic_or(i32 addrspace(4)* %arg0, i32 noundef %arg1)
-    br label %.exit
-.exit:
-    ret void
-}
-
 define void @write_back_non_grouped_agg(i64 addrspace(4)* %input_buffer, i64 addrspace(4)* %output_buffer, i32 noundef %agg_idx) {
     %tid = call i64 @get_thread_index()
     %agg_idx.i64 = sext i32 %agg_idx to i64

--- a/omniscidb/QueryEngine/Compiler/genx.ll
+++ b/omniscidb/QueryEngine/Compiler/genx.ll
@@ -87,18 +87,6 @@ define i64 @agg_count_skip_val_shared(i64 addrspace(4)* %agg, i64 noundef %val, 
     ret i64 0
 }
 
-define i64 @agg_count_double_skip_val_shared(i64 addrspace(4)* %agg, double noundef %val, double noundef %skip_val) {
-    %no_skip = fcmp one double %val, %skip_val
-    br i1 %no_skip, label %.noskip, label %.skip
-.noskip:
-    %val_cst = bitcast double %val to i64
-    %res = call i64 @agg_count_shared(i64 addrspace(4)* %agg, i64 %val_cst)
-    ret i64 %res
-.skip:
-    %orig = load i64, i64 addrspace(4)* %agg
-    ret i64 %orig
-}
-
 ;; TODO: may cause a CPU fallback on codegen
 define i64 @agg_sum_shared(i64 addrspace(4)* %agg, i64 noundef %val) {
     %old = atomicrmw add i64 addrspace(4)* %agg, i64 %val monotonic

--- a/omniscidb/QueryEngine/Compiler/genx.ll
+++ b/omniscidb/QueryEngine/Compiler/genx.ll
@@ -128,17 +128,6 @@ define void @agg_sum_float_shared(i32 addrspace(4)* %agg, float noundef %val) {
     ret void
 }
 
-; fixme
-define void @agg_sum_float_skip_val_shared(i32 addrspace(4)* %agg, float noundef %val, float noundef %skip_val) {
-    %no_skip = fcmp one float %val, %skip_val
-    br i1 %no_skip, label %.noskip, label %.skip
-.noskip:
-    call void @agg_sum_float_shared(i32 addrspace(4)* %agg, float noundef %val)
-    br label %.skip
-.skip:
-    ret void
-}
-
 define void @agg_sum_double_shared(i64 addrspace(4)* %agg, double noundef %val) {
 .entry:
     %orig = load atomic i64, i64 addrspace(4)* %agg unordered, align 8
@@ -154,16 +143,6 @@ define void @agg_sum_double_shared(i64 addrspace(4)* %agg, double noundef %val) 
     %success = extractvalue {i64, i1} %val_success, 1
     br i1 %success, label %.exit, label %.loop
 .exit:
-    ret void
-}
-
-define void @agg_sum_double_skip_val_shared(i64 addrspace(4)* %agg, double noundef %val, double noundef %skip_val) {
-    %no_skip = fcmp one double %val, %skip_val
-    br i1 %no_skip, label %.noskip, label %.skip
-.noskip:
-    call void @agg_sum_double_shared(i64 addrspace(4)* %agg, double noundef %val)
-    br label %.skip
-.skip:
     ret void
 }
 

--- a/omniscidb/QueryEngine/Compiler/genx.ll
+++ b/omniscidb/QueryEngine/Compiler/genx.ll
@@ -128,24 +128,6 @@ define void @agg_sum_float_shared(i32 addrspace(4)* %agg, float noundef %val) {
     ret void
 }
 
-define void @agg_sum_double_shared(i64 addrspace(4)* %agg, double noundef %val) {
-.entry:
-    %orig = load atomic i64, i64 addrspace(4)* %agg unordered, align 8
-    %cst = bitcast i64 %orig to double
-    br label %.loop
-.loop:
-    %cmp = phi i64 [ %orig, %.entry ], [ %loaded, %.loop ]
-    %cmp_cst = bitcast i64 %cmp to double
-    %new_val = fadd double %cmp_cst, %val
-    %new_val_cst = bitcast double %new_val to i64
-    %val_success = cmpxchg i64 addrspace(4)* %agg, i64 %cmp, i64 %new_val_cst acq_rel monotonic
-    %loaded = extractvalue {i64, i1} %val_success, 0
-    %success = extractvalue {i64, i1} %val_success, 1
-    br i1 %success, label %.exit, label %.loop
-.exit:
-    ret void
-}
-
 define void @atomic_or(i32 addrspace(4)* %addr, i32 noundef %val) {
 .entry:
     %orig = load atomic i32, i32 addrspace(4)* %addr unordered, align 8

--- a/omniscidb/Tests/IntelGPUEnablingTest.cpp
+++ b/omniscidb/Tests/IntelGPUEnablingTest.cpp
@@ -530,17 +530,15 @@ TEST_F(GroupByAggTest, GroupByCount) {
 }
 
 TEST_F(GroupByAggTest, GroupBySum) {
-  GTEST_SKIP();
   c("SELECT SUM(x) FROM small_tests GROUP BY z;", g_dt);
   c("SELECT SUM(x + y) FROM small_tests GROUP BY z;", g_dt);
 }
 
 TEST_F(GroupByAggTest, AggHaving) {
-  GTEST_SKIP();
   c("SELECT COUNT(*) FROM test WHERE x < y GROUP BY x HAVING 0=1;", g_dt);
   c("SELECT COUNT(*) FROM test WHERE x < y GROUP BY x HAVING 1=1;", g_dt);
   c("SELECT x, COUNT(*) AS n FROM test GROUP BY x, ufd ORDER BY x, n;", g_dt);
-  c("SELECT MIN(x), MAX(x) FROM test WHERE real_str LIKE '%nope%';", g_dt);
+  // c("SELECT MIN(x), MAX(x) FROM test WHERE real_str LIKE '%nope%';", g_dt);
   c("SELECT COUNT(*) FROM test WHERE (x > 7 AND y / (x - 7) < 44);", g_dt);
   c("SELECT x, AVG(ff) AS val FROM test GROUP BY x ORDER BY val;", g_dt);
   c("SELECT x, MAX(fn) as val FROM test WHERE fn IS NOT NULL GROUP BY x ORDER BY val;",
@@ -566,11 +564,10 @@ TEST_F(GroupByTest, WithFilter) {
 }
 
 TEST_F(GroupByTest, WithOrdering) {
-  GTEST_SKIP();
   c("SELECT x, dd, COUNT(*) FROM test GROUP BY x, dd ORDER BY x, dd;", g_dt);
-  c("SELECT 'literal_string' AS key0 FROM test GROUP BY key0;", g_dt);
-  c("SELECT str, MIN(y) FROM test WHERE y IS NOT NULL GROUP BY str ORDER BY str DESC;",
-    g_dt);
+  // c("SELECT 'literal_string' AS key0 FROM test GROUP BY key0;", g_dt);
+  // c("SELECT str, MIN(y) FROM test WHERE y IS NOT NULL GROUP BY str ORDER BY str DESC;",
+  // g_dt);
   c("SELECT x, AVG(u), COUNT(*) AS n FROM test GROUP BY x ORDER BY n DESC;", g_dt);
   c("SELECT f, ss FROM test GROUP BY f, ss ORDER BY f DESC;", g_dt);
   c("SELECT fx, COUNT(*) n FROM test GROUP BY fx ORDER BY n DESC, fx IS NULL DESC;",
@@ -684,7 +681,6 @@ TEST_F(BasicTest, Time) {
 }
 
 TEST_F(BasicTest, Time2) {
-  GTEST_SKIP();
   ASSERT_EQ(
       static_cast<int64_t>(g_num_rows + g_num_rows / 2),
       v<int64_t>(run_simple_agg(
@@ -920,7 +916,7 @@ TEST_F(BasicTest, SumAndAverage) {
   c("SELECT AVG(w) FROM test;", g_dt);
   c("SELECT AVG(z) FROM test;", g_dt);
   c("SELECT SUM(CAST(x AS FLOAT)) FROM test GROUP BY y;", g_dt);
-  // c("SELECT AVG(CAST(x AS FLOAT)) FROM test GROUP BY y;", g_dt);
+  c("SELECT AVG(CAST(x AS FLOAT)) FROM test GROUP BY y;", g_dt);
   c("SELECT count(*) FROM test GROUP BY x;", g_dt);
   c("SELECT count(ff) FROM test GROUP BY x;", g_dt);
   c("SELECT x, AVG(ff) AS val FROM test GROUP BY x;", g_dt);

--- a/omniscidb/Tests/L0SharedMemoryTest.cpp
+++ b/omniscidb/Tests/L0SharedMemoryTest.cpp
@@ -282,8 +282,8 @@ TEST(Smoke, Simple) {
 }
 
 TEST(SingleColumn, VariableEntries_CountQuery_4B_Group) {
-  GTEST_SKIP();
-  for (auto num_entries : {1, 2, 3, 5, 13, 31, 63, 126, 241, 511, 1021}) {
+  // Gen9 has a max group size of 256
+  for (auto num_entries : {1, 2, 3, 5, 13, 31, 63, 126, 241 /*, 511, 1021*/}) {
     TestInputData input;
     input.setDeviceId(0)
         .setNumInputBuffers(4)
@@ -300,8 +300,8 @@ TEST(SingleColumn, VariableEntries_CountQuery_4B_Group) {
 }
 
 TEST(SingleColumn, VariableEntries_CountQuery_8B_Group) {
-  GTEST_SKIP();
-  for (auto num_entries : {1, 2, 3, 5, 13, 31, 63, 126, 241, 511, 1021}) {
+  // Gen9 has a max group size of 256
+  for (auto num_entries : {1, 2, 3, 5, 13, 31, 63, 126, 241 /*, 511, 1021*/}) {
     TestInputData input;
     input.setDeviceId(0)
         .setNumInputBuffers(4)

--- a/omniscidb/Tests/L0SharedMemoryTest.cpp
+++ b/omniscidb/Tests/L0SharedMemoryTest.cpp
@@ -266,19 +266,99 @@ void perform_test_and_verify_results(TestInputData input) {
   ASSERT_EQ(cmp_result, 0);
 }
 
-TEST(Smoke, Simple) {
-  TestInputData input;
-  input.setDeviceId(0)
-      .setNumInputBuffers(1)
-      .setTargetInfos(generate_custom_agg_target_infos(
-          {1}, {hdk::ir::AggType::kCount}, {int32_type}, {int32_type}))
-      .setAggWidth(4)
-      .setMinEntry(0)
-      .setMaxEntry(10)
-      .setStepSize(2)
-      .setKeylessHash(true)
-      .setTargetIndexForKey(0);
-  perform_test_and_verify_results(input);
+TEST(Smoke, Count) {
+  std::vector<const hdk::ir::Type*> variants = {
+      int32_type, int64_type, float_type, double_type};
+  for (auto* type : variants) {
+    TestInputData input;
+    input.setDeviceId(0)
+        .setNumInputBuffers(1)
+        .setTargetInfos(generate_custom_agg_target_infos(
+            {1}, {hdk::ir::AggType::kCount}, {type}, {type}))
+        .setAggWidth(type->size())
+        .setMinEntry(0)
+        .setMaxEntry(10)
+        .setStepSize(2)
+        .setKeylessHash(true)
+        .setTargetIndexForKey(0);
+    perform_test_and_verify_results(input);
+  }
+}
+
+TEST(Smoke, Min) {
+  std::vector<const hdk::ir::Type*> variants = {
+      int32_type, int64_type, float_type, double_type};
+  for (auto* type : variants) {
+    TestInputData input;
+    input.setDeviceId(0)
+        .setNumInputBuffers(4)
+        .setTargetInfos(generate_custom_agg_target_infos(
+            {1}, {hdk::ir::AggType::kMin}, {type}, {type}))
+        .setAggWidth(type->size())
+        .setMinEntry(0)
+        .setMaxEntry(10)
+        .setStepSize(2)
+        .setKeylessHash(true)
+        .setTargetIndexForKey(0);
+    perform_test_and_verify_results(input);
+  }
+}
+
+TEST(Smoke, Max) {
+  std::vector<const hdk::ir::Type*> variants = {
+      int32_type, int64_type, float_type, double_type};
+  for (auto* type : variants) {
+    TestInputData input;
+    input.setDeviceId(0)
+        .setNumInputBuffers(4)
+        .setTargetInfos(generate_custom_agg_target_infos(
+            {1}, {hdk::ir::AggType::kMax}, {type}, {type}))
+        .setAggWidth(type->size())
+        .setMinEntry(0)
+        .setMaxEntry(10)
+        .setStepSize(2)
+        .setKeylessHash(true)
+        .setTargetIndexForKey(0);
+    perform_test_and_verify_results(input);
+  }
+}
+
+TEST(Smoke, Sum) {
+  std::vector<const hdk::ir::Type*> variants = {
+      int32_type, int64_type, float_type, double_type};
+  for (auto* type : variants) {
+    TestInputData input;
+    input.setDeviceId(0)
+        .setNumInputBuffers(4)
+        .setTargetInfos(generate_custom_agg_target_infos(
+            {1}, {hdk::ir::AggType::kSum}, {type}, {type}))
+        .setAggWidth(type->size())
+        .setMinEntry(0)
+        .setMaxEntry(10)
+        .setStepSize(2)
+        .setKeylessHash(true)
+        .setTargetIndexForKey(0);
+    perform_test_and_verify_results(input);
+  }
+}
+
+TEST(Smoke, Avg) {
+  std::vector<const hdk::ir::Type*> variants = {
+      int32_type, int64_type, float_type, double_type};
+  for (auto* type : variants) {
+    TestInputData input;
+    input.setDeviceId(0)
+        .setNumInputBuffers(4)
+        .setTargetInfos(generate_custom_agg_target_infos(
+            {1}, {hdk::ir::AggType::kAvg}, {type}, {type}))
+        .setAggWidth(8)  // type->size()?
+        .setMinEntry(0)
+        .setMaxEntry(10)
+        .setStepSize(2)
+        .setKeylessHash(true)
+        .setTargetIndexForKey(0);
+    perform_test_and_verify_results(input);
+  }
 }
 
 TEST(SingleColumn, VariableEntries_CountQuery_4B_Group) {
@@ -418,12 +498,11 @@ TEST(SingleColumn, VariableSteps_FixedEntries_4) {
 }
 
 TEST(SingleColumn, VariableNumBuffers) {
-  GTEST_SKIP();
   TestInputData input;
   input.setDeviceId(0)
       .setAggWidth(8)
       .setMinEntry(0)
-      .setMaxEntry(266)
+      .setMaxEntry(255)
       .setKeylessHash(true)
       .setTargetIndexForKey(0)
       .setTargetInfos(generate_custom_agg_target_infos(

--- a/omniscidb/Tests/L0SharedMemoryTest.cpp
+++ b/omniscidb/Tests/L0SharedMemoryTest.cpp
@@ -368,13 +368,12 @@ TEST(SingleColumn, VariableSteps_FixedEntries_2) {
 }
 
 TEST(SingleColumn, VariableSteps_FixedEntries_3) {
-  GTEST_SKIP();
   TestInputData input;
   input.setDeviceId(0)
       .setNumInputBuffers(4)
       .setAggWidth(8)
       .setMinEntry(0)
-      .setMaxEntry(367)
+      .setMaxEntry(204)
       .setKeylessHash(true)
       .setTargetIndexForKey(0)
       .setTargetInfos(generate_custom_agg_target_infos(
@@ -394,13 +393,12 @@ TEST(SingleColumn, VariableSteps_FixedEntries_3) {
 }
 
 TEST(SingleColumn, VariableSteps_FixedEntries_4) {
-  GTEST_SKIP();
   TestInputData input;
   input.setDeviceId(0)
       .setNumInputBuffers(4)
       .setAggWidth(8)
       .setMinEntry(0)
-      .setMaxEntry(517)
+      .setMaxEntry(255)
       .setKeylessHash(true)
       .setTargetIndexForKey(0)
       .setTargetInfos(generate_custom_agg_target_infos(


### PR DESCRIPTION
This patch moves most of the aggregation function implementations to the cpp module. It also applies some fixes that are required since we don't have the automatic zero initialization of the memory. I tried to be as close to cuda implementations as possible to keep it simple and generalize later. It also re-enables some tests that were excluded from CI after turning smem support on by default.