### PR TITLE
Make FP64 capability check a GpuMgr responsibility

### DIFF
--- a/omniscidb/CudaMgr/CudaMgr.h
+++ b/omniscidb/CudaMgr/CudaMgr.h
@@ -164,6 +164,8 @@ class CudaMgr : public GpuMgr {
     return getMinNumMPsForAllDevices();
   };
 
+  bool hasFP64Support() const override { return isArchPascalOrLater(); }
+
   bool hasSharedMemoryAtomicsSupport() const override {
     /*
      * From CUDA Toolkit documentation:

--- a/omniscidb/DataMgr/GpuMgr.h
+++ b/omniscidb/DataMgr/GpuMgr.h
@@ -62,5 +62,7 @@ struct GpuMgr {
   virtual uint32_t getGridSize() const = 0;
   virtual uint32_t getMinEUNumForAllDevices() const = 0;
   virtual bool hasSharedMemoryAtomicsSupport() const = 0;
+  // TODO: hasFP64Support implementations do not account for different device capabilities
+  virtual bool hasFP64Support() const { return true; };
   virtual size_t getMinSharedMemoryPerBlockForAllDevices() const = 0;
 };

--- a/omniscidb/L0Mgr/L0Mgr.cpp
+++ b/omniscidb/L0Mgr/L0Mgr.cpp
@@ -451,6 +451,14 @@ bool L0Manager::hasSharedMemoryAtomicsSupport() const {
   return true;
 }
 
+bool L0Manager::hasFP64Support() const {
+  CHECK_GT(drivers_[0]->devices().size(), size_t(0));
+  ze_device_module_properties_t module_props{ZE_STRUCTURE_TYPE_DEVICE_MODULE_PROPERTIES};
+  L0_SAFE_CALL(
+      zeDeviceGetModuleProperties(drivers_[0]->devices()[0]->device(), &module_props));
+  return module_props.fp64flags;
+}
+
 size_t L0Manager::getMinSharedMemoryPerBlockForAllDevices() const {
   auto comp = [](const auto& a, const auto& b) {
     return a->maxSharedLocalMemory() < b->maxSharedLocalMemory();

--- a/omniscidb/L0Mgr/L0Mgr.h
+++ b/omniscidb/L0Mgr/L0Mgr.h
@@ -239,12 +239,13 @@ class L0Manager : public GpuMgr {
   size_t getMaxAllocationSize(const int device_num) const;
   size_t getPageSize(const int device_num) const { return 4096u; }
 
-  virtual uint32_t getMaxBlockSize() const override;
-  virtual int8_t getSubGroupSize() const override;
-  virtual uint32_t getGridSize() const override;
-  virtual uint32_t getMinEUNumForAllDevices() const override;
-  virtual bool hasSharedMemoryAtomicsSupport() const override;
-  virtual size_t getMinSharedMemoryPerBlockForAllDevices() const override;
+  uint32_t getMaxBlockSize() const override;
+  int8_t getSubGroupSize() const override;
+  uint32_t getGridSize() const override;
+  uint32_t getMinEUNumForAllDevices() const override;
+  bool hasSharedMemoryAtomicsSupport() const override;
+  bool hasFP64Support() const override;
+  size_t getMinSharedMemoryPerBlockForAllDevices() const override;
 
   const std::vector<std::shared_ptr<L0Driver>>& drivers() const;
 

--- a/omniscidb/L0Mgr/L0MgrNoL0.cpp
+++ b/omniscidb/L0Mgr/L0MgrNoL0.cpp
@@ -148,6 +148,11 @@ size_t L0Manager::getMinSharedMemoryPerBlockForAllDevices() const {
   return 0u;
 };
 
+bool L0Manager::hasFP64Support() const {
+  CHECK(false);
+  return false;
+}
+
 const std::vector<std::shared_ptr<L0Driver>>& L0Manager::drivers() const {
   return drivers_;
 }

--- a/omniscidb/QueryEngine/Execute.cpp
+++ b/omniscidb/QueryEngine/Execute.cpp
@@ -880,19 +880,9 @@ GpuMgr* Executor::gpuMgr() const {
   return gpu_mgr;
 }
 
-bool Executor::isArchPascalOrLater(const ExecutorDeviceType dt) const {
-  if (dt == ExecutorDeviceType::GPU) {
-    return gpuMgr()->getPlatform() == GpuMgrPlatform::CUDA
-               ? cudaMgr()->isArchPascalOrLater()
-               : false;
-  }
-  return false;
-}
-
 bool Executor::deviceSupportsFP64(const ExecutorDeviceType dt) const {
   if (dt == ExecutorDeviceType::GPU) {
-    return gpuMgr()->getPlatform() == GpuMgrPlatform::CUDA ? isArchPascalOrLater(dt)
-                                                           : true;
+    return gpuMgr()->hasFP64Support();
   }
   return true;
 }

--- a/omniscidb/QueryEngine/Execute.h
+++ b/omniscidb/QueryEngine/Execute.h
@@ -431,8 +431,6 @@ class Executor : public StringDictionaryProxyProvider {
 
   GpuMgr* gpuMgr() const;
 
-  bool isArchPascalOrLater(const ExecutorDeviceType dt) const;
-
   bool deviceSupportsFP64(const ExecutorDeviceType dt) const;
 
   bool needFetchAllFragments(const InputColDescriptor& col_desc,


### PR DESCRIPTION
This seems to be the last piece to gracefully handle missing doubles support on GPU. We probably should revisit the idea of not using fp64 as the default type for certain aggregations someday.

Resolves #322 