### PR TITLE
Enable multifrag results by default.

### DIFF
--- a/omniscidb/ResultSet/ResultSet.h
+++ b/omniscidb/ResultSet/ResultSet.h
@@ -125,6 +125,8 @@ class ResultSetRowIterator {
     return crt_row_buff_idx_ - 1;
   }
 
+  bool isValid() const { return global_entry_idx_valid_; }
+
  private:
   const ResultSet* result_set_;
   size_t crt_row_buff_idx_;

--- a/omniscidb/ResultSetRegistry/ResultSetTableToken.h
+++ b/omniscidb/ResultSetRegistry/ResultSetTableToken.h
@@ -23,6 +23,64 @@ using ResultSetTableTokenPtr = std::shared_ptr<const ResultSetTableToken>;
 
 class ResultSetTableToken : public std::enable_shared_from_this<ResultSetTableToken> {
  public:
+  class Iterator {
+   public:
+    using value_type = std::vector<TargetValue>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = std::vector<TargetValue>*;
+    using reference = std::vector<TargetValue>&;
+    using iterator_category = std::input_iterator_tag;
+
+    bool operator==(const Iterator& other) const { return rs_iter_ == other.rs_iter_; }
+    bool operator!=(const Iterator& other) const { return !(*this == other); }
+
+    value_type operator*() const {
+      CHECK(rs_iter_.isValid());
+      return *rs_iter_;
+    }
+
+    inline Iterator& operator++(void) {
+      ++rs_iter_;
+      maybeMoveToNextValid();
+      return *this;
+    }
+
+    Iterator operator++(int) {
+      Iterator iter(*this);
+      ++(*this);
+      return iter;
+    }
+
+   private:
+    const ResultSetTableToken* table_;
+    ResultSetRowIterator rs_iter_;
+    size_t rs_idx_;
+    bool translate_strings_;
+    bool decimal_to_double_;
+
+    Iterator(const ResultSetTableToken* table,
+             bool translate_strings,
+             bool decimal_to_double)
+        : table_(table)
+        , rs_iter_(table->resultSet(0)->rowIterator(translate_strings, decimal_to_double))
+        , rs_idx_(0)
+        , translate_strings_(translate_strings)
+        , decimal_to_double_(decimal_to_double) {
+      // In case the first ResultSet is empty.
+      maybeMoveToNextValid();
+    }
+
+    void maybeMoveToNextValid() {
+      while (!rs_iter_.isValid() && rs_idx_ != (table_->resultSetCount() - 1)) {
+        ++rs_idx_;
+        rs_iter_ = table_->resultSet(rs_idx_)->rowIterator(translate_strings_,
+                                                           decimal_to_double_);
+      }
+    }
+
+    friend class ResultSetTableToken;
+  };
+
   ResultSetTableToken() = default;
   ResultSetTableToken(TableInfoPtr tinfo,
                       size_t row_count,
@@ -49,6 +107,15 @@ class ResultSetTableToken : public std::enable_shared_from_this<ResultSetTableTo
   static size_t columnIndex(int col_id) { return static_cast<size_t>(col_id - 2000); }
 
   size_t rowCount() const { return row_count_; }
+  size_t colCount() const { return resultSet(0)->colCount(); }
+
+  const hdk::ir::Type* colType(size_t col_idx) const {
+    return resultSet(0)->colType(col_idx);
+  }
+
+  Iterator rowIterator(bool translate_strings, bool decimal_to_double) const {
+    return Iterator(this, translate_strings, decimal_to_double);
+  }
 
   size_t resultSetCount() const { return tinfo_->fragments; }
   ResultSetPtr resultSet(size_t idx) const;

--- a/omniscidb/Shared/Config.h
+++ b/omniscidb/Shared/Config.h
@@ -107,7 +107,7 @@ struct ExecutionConfig {
   bool enable_interop = false;
   size_t parallel_linearization_threshold = 10'000;
   bool enable_multifrag_rs = true;
-  bool enable_multifrag_execution_result = false;
+  bool enable_multifrag_execution_result = true;
 
   size_t override_gpu_block_size = 0;
   size_t override_gpu_grid_size = 0;

--- a/omniscidb/Tests/ArrayTest.cpp
+++ b/omniscidb/Tests/ArrayTest.cpp
@@ -72,13 +72,13 @@ TEST_F(ArrayExtOpsEnv, ArrayAppendInteger) {
                                                            const int64_t null_sentinel) {
       ASSERT_EQ(rows->rowCount(), size_t(6));
 
-      check_row_result(rows->getNextRow(true, true), std::vector<int64_t>{1, 2, 3});
-      check_row_result(rows->getNextRow(true, true), std::vector<int64_t>{1});
-      check_row_result(rows->getNextRow(true, true), std::vector<int64_t>{-1, 0});
-      check_row_result(rows->getNextRow(true, true), std::vector<int64_t>{0});
-      check_row_result(rows->getNextRow(true, true),
+      check_row_result(rows->row(0, true, true), std::vector<int64_t>{1, 2, 3});
+      check_row_result(rows->row(1, true, true), std::vector<int64_t>{1});
+      check_row_result(rows->row(2, true, true), std::vector<int64_t>{-1, 0});
+      check_row_result(rows->row(3, true, true), std::vector<int64_t>{0});
+      check_row_result(rows->row(4, true, true),
                        std::vector<int64_t>{4, 5, null_sentinel});
-      check_row_result(rows->getNextRow(true, true), std::vector<int64_t>{null_sentinel});
+      check_row_result(rows->row(5, true, true), std::vector<int64_t>{null_sentinel});
     };
 
     // i64
@@ -128,14 +128,13 @@ TEST_F(ArrayExtOpsEnv, ArrayAppendBool) {
                                                         const int64_t null_sentinel) {
       ASSERT_EQ(rows->rowCount(), size_t(6));
 
-      check_row_result(rows->getNextRow(true, true),
-                       std::vector<int64_t>{true, false, true});
-      check_row_result(rows->getNextRow(true, true), std::vector<int64_t>{false});
-      check_row_result(rows->getNextRow(true, true), std::vector<int64_t>{true, false});
-      check_row_result(rows->getNextRow(true, true), std::vector<int64_t>{false});
-      check_row_result(rows->getNextRow(true, true),
+      check_row_result(rows->row(0, true, true), std::vector<int64_t>{true, false, true});
+      check_row_result(rows->row(1, true, true), std::vector<int64_t>{false});
+      check_row_result(rows->row(2, true, true), std::vector<int64_t>{true, false});
+      check_row_result(rows->row(3, true, true), std::vector<int64_t>{false});
+      check_row_result(rows->row(4, true, true),
                        std::vector<int64_t>{false, true, null_sentinel});
-      check_row_result(rows->getNextRow(true, true), std::vector<int64_t>{null_sentinel});
+      check_row_result(rows->row(5, true, true), std::vector<int64_t>{null_sentinel});
     };
 
     // bool
@@ -155,13 +154,13 @@ TEST_F(ArrayExtOpsEnv, ArrayAppendDouble) {
     auto check_entire_double_result = [&check_row_result](const auto& rows) {
       ASSERT_EQ(rows->rowCount(), size_t(6));
 
-      check_row_result(rows->getNextRow(true, true), std::vector<double>{1, 2, 3});
-      check_row_result(rows->getNextRow(true, true), std::vector<double>{1});
-      check_row_result(rows->getNextRow(true, true), std::vector<double>{-1, 0});
-      check_row_result(rows->getNextRow(true, true), std::vector<double>{0});
-      check_row_result(rows->getNextRow(true, true),
+      check_row_result(rows->row(0, true, true), std::vector<double>{1, 2, 3});
+      check_row_result(rows->row(1, true, true), std::vector<double>{1});
+      check_row_result(rows->row(2, true, true), std::vector<double>{-1, 0});
+      check_row_result(rows->row(3, true, true), std::vector<double>{0});
+      check_row_result(rows->row(4, true, true),
                        std::vector<double>{4, 5, inline_fp_null_value<double>()});
-      check_row_result(rows->getNextRow(true, true),
+      check_row_result(rows->row(5, true, true),
                        std::vector<double>{inline_fp_null_value<double>()});
     };
 
@@ -182,13 +181,13 @@ TEST_F(ArrayExtOpsEnv, ArrayAppendFloat) {
     auto check_entire_float_result = [&check_row_result](const auto& rows) {
       ASSERT_EQ(rows->rowCount(), size_t(6));
 
-      check_row_result(rows->getNextRow(true, true), std::vector<float>{1, 2, 3});
-      check_row_result(rows->getNextRow(true, true), std::vector<float>{1});
-      check_row_result(rows->getNextRow(true, true), std::vector<float>{-1, 0});
-      check_row_result(rows->getNextRow(true, true), std::vector<float>{0});
-      check_row_result(rows->getNextRow(true, true),
+      check_row_result(rows->row(0, true, true), std::vector<float>{1, 2, 3});
+      check_row_result(rows->row(1, true, true), std::vector<float>{1});
+      check_row_result(rows->row(2, true, true), std::vector<float>{-1, 0});
+      check_row_result(rows->row(3, true, true), std::vector<float>{0});
+      check_row_result(rows->row(4, true, true),
                        std::vector<float>{4, 5, inline_fp_null_value<float>()});
-      check_row_result(rows->getNextRow(true, true),
+      check_row_result(rows->row(5, true, true),
                        std::vector<float>{inline_fp_null_value<float>()});
     };
 

--- a/omniscidb/Tests/ArrowSQLRunner/ArrowSQLRunner.h
+++ b/omniscidb/Tests/ArrowSQLRunner/ArrowSQLRunner.h
@@ -82,9 +82,9 @@ ExecutionOptions getExecutionOptions(bool allow_loop_joins, bool just_explain = 
 
 CompilationOptions getCompilationOptions(ExecutorDeviceType device_type);
 
-std::shared_ptr<ResultSet> run_multiple_agg(const std::string& query_str,
-                                            const ExecutorDeviceType device_type,
-                                            const bool allow_loop_joins = true);
+hdk::ResultSetTableTokenPtr run_multiple_agg(const std::string& query_str,
+                                             const ExecutorDeviceType device_type,
+                                             const bool allow_loop_joins = true);
 
 TargetValue run_simple_agg(const std::string& query_str,
                            const ExecutorDeviceType device_type,

--- a/omniscidb/Tests/ArrowSQLRunner/SQLiteComparator.h
+++ b/omniscidb/Tests/ArrowSQLRunner/SQLiteComparator.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "ResultSet/ArrowResultSet.h"
+#include "ResultSetRegistry/ResultSetTableToken.h"
 #include "Shared/sqltypes.h"
 #include "SqliteConnector/SqliteConnector.h"
 
@@ -36,7 +37,7 @@ class SQLiteComparator {
     connector_.batch_insert(table_name, insert_vals);
   }
 
-  void compare(ResultSetPtr omnisci_results,
+  void compare(hdk::ResultSetTableTokenPtr omnisci_results,
                const std::string& query_string,
                const ExecutorDeviceType device_type);
 
@@ -45,7 +46,7 @@ class SQLiteComparator {
                             const ExecutorDeviceType device_type);
 
   // added to deal with time shift for now testing
-  void compare_timstamp_approx(ResultSetPtr omnisci_results,
+  void compare_timstamp_approx(hdk::ResultSetTableTokenPtr omnisci_results,
                                const std::string& query_string,
                                const ExecutorDeviceType device_type);
 

--- a/omniscidb/Tests/ArrowTestHelpers.h
+++ b/omniscidb/Tests/ArrowTestHelpers.h
@@ -269,13 +269,7 @@ void compare_arrow_table(std::shared_ptr<arrow::Table> at,
 }
 
 std::shared_ptr<arrow::Table> toArrow(const ExecutionResult& res) {
-  std::vector<std::string> col_names;
-  for (auto& target : res.getTargetsMeta()) {
-    col_names.push_back(target.get_resname());
-  }
-  auto converter =
-      std::make_unique<ArrowResultSetConverter>(res.getRows(), col_names, -1);
-  return converter->convertToArrowTable();
+  return res.getToken()->toArrow();
 }
 
 template <typename... Ts>

--- a/omniscidb/Tests/CorrelatedSubqueryTest.cpp
+++ b/omniscidb/Tests/CorrelatedSubqueryTest.cpp
@@ -106,7 +106,7 @@ void runSingleValueTestValidation(const hdk::ir::Type* colType, ExecutorDeviceTy
   {
     auto results = run_multiple_agg("SELECT SINGLE_VALUE(val) FROM test_facts;", dt);
     ASSERT_EQ(uint64_t(1), results->rowCount());
-    const auto select_crt_row = results->getNextRow(true, true);
+    const auto select_crt_row = results->row(0, true, true);
     auto val = getValue(select_crt_row[0]);
     ASSERT_EQ(1, val);
   }
@@ -115,13 +115,13 @@ void runSingleValueTestValidation(const hdk::ir::Type* colType, ExecutorDeviceTy
     auto results = run_multiple_agg(
         "SELECT id, SINGLE_VALUE(val) FROM test_facts GROUP BY id ORDER BY id;", dt);
     ASSERT_EQ(uint64_t(3), results->rowCount());
-    auto select_crt_row = results->getNextRow(true, true);
+    auto select_crt_row = results->row(0, true, true);
     ASSERT_EQ(1, getValue(select_crt_row[0]));
     ASSERT_EQ(1, getValue(select_crt_row[1]));
-    select_crt_row = results->getNextRow(true, true);
+    select_crt_row = results->row(1, true, true);
     ASSERT_EQ(2, getValue(select_crt_row[0]));
     ASSERT_EQ(1, getValue(select_crt_row[1]));
-    select_crt_row = results->getNextRow(true, true);
+    select_crt_row = results->row(2, true, true);
     ASSERT_EQ(3, getValue(select_crt_row[0]));
     ASSERT_EQ(1, getValue(select_crt_row[1]));
   }
@@ -132,13 +132,13 @@ void runSingleValueTestValidation(const hdk::ir::Type* colType, ExecutorDeviceTy
         "GROUP BY id) ORDER BY id;",
         dt);
     ASSERT_EQ(uint64_t(3), results->rowCount());
-    auto select_crt_row = results->getNextRow(true, true);
+    auto select_crt_row = results->row(0, true, true);
     ASSERT_EQ(2, getValue(select_crt_row[0]));
     ASSERT_EQ(1, getValue(select_crt_row[1]));
-    select_crt_row = results->getNextRow(true, true);
+    select_crt_row = results->row(1, true, true);
     ASSERT_EQ(3, getValue(select_crt_row[0]));
     ASSERT_EQ(1, getValue(select_crt_row[1]));
-    select_crt_row = results->getNextRow(true, true);
+    select_crt_row = results->row(2, true, true);
     ASSERT_EQ(4, getValue(select_crt_row[0]));
     ASSERT_EQ(1, getValue(select_crt_row[1]));
   }
@@ -188,10 +188,10 @@ void runSingleValueTest(const hdk::ir::Type* colType, ExecutorDeviceType dt) {
             "id;",
         dt);
     ASSERT_EQ(uint64_t(2), results->rowCount());
-    auto select_crt_row = results->getNextRow(true, true);
+    auto select_crt_row = results->row(0, true, true);
     ASSERT_EQ(2, getValue(select_crt_row[0]));
     ASSERT_EQ(1, getValue(select_crt_row[1]));
-    select_crt_row = results->getNextRow(true, true);
+    select_crt_row = results->row(1, true, true);
     ASSERT_EQ(3, getValue(select_crt_row[0]));
     ASSERT_EQ(1, getValue(select_crt_row[1]));
   }
@@ -223,7 +223,7 @@ TEST(Select, Correlated) {
   auto INT_NULL_SENTINEL = inline_null_value<int32_t>();
 
   for (int i = 0; i < factsCount; i++) {
-    const auto select_crt_row = results->getNextRow(true, false);
+    const auto select_crt_row = results->row(i, true, false);
     auto id = getIntValue(select_crt_row[0]);
     auto val = getIntValue(select_crt_row[1]);
     auto lookupId = getIntValue(select_crt_row[2]);
@@ -251,7 +251,7 @@ TEST(Select, CorrelatedWithDouble) {
   auto INT_NULL_SENTINEL = inline_null_value<int32_t>();
 
   for (int i = 0; i < factsCount; i++) {
-    const auto select_crt_row = results->getNextRow(true, false);
+    const auto select_crt_row = results->row(i, true, false);
     auto id = getIntValue(select_crt_row[0]);
     auto val = getDoubleValue(select_crt_row[1]);
     auto lookupId = getIntValue(select_crt_row[2]);
@@ -295,7 +295,7 @@ TEST(Select, CorrelatedWithInnerDuplicatesAndMinId) {
   auto INT_NULL_SENTINEL = inline_null_value<int32_t>();
 
   for (int i = 0; i < factsCount; i++) {
-    const auto select_crt_row = results->getNextRow(true, false);
+    const auto select_crt_row = results->row(i, true, false);
     auto id = getIntValue(select_crt_row[0]);
     auto val = getIntValue(select_crt_row[1]);
     auto lookupId = getIntValue(select_crt_row[2]);
@@ -328,7 +328,7 @@ TEST(Select, DISABLED_CorrelatedWithInnerDuplicatesDescIdOrder) {
   auto INT_NULL_SENTINEL = inline_null_value<int32_t>();
 
   for (int i = 0; i < factsCount; i++) {
-    const auto select_crt_row = results->getNextRow(true, false);
+    const auto select_crt_row = results->row(i, true, false);
     auto id = getIntValue(select_crt_row[0]);
     auto val = getIntValue(select_crt_row[1]);
     auto lookupId = getIntValue(select_crt_row[2]);
@@ -359,7 +359,7 @@ TEST(Select, CorrelatedWithInnerDuplicatesAndMaxId) {
   auto INT_NULL_SENTINEL = inline_null_value<int32_t>();
 
   for (int i = 0; i < factsCount; i++) {
-    const auto select_crt_row = results->getNextRow(true, false);
+    const auto select_crt_row = results->row(i, true, false);
     auto id = getIntValue(select_crt_row[0]);
     auto val = getIntValue(select_crt_row[1]);
     auto lookupId = getIntValue(select_crt_row[2]);
@@ -393,7 +393,7 @@ TEST(Select, DISABLED_CorrelatedWithInnerDuplicatesAndAscIdOrder) {
   auto INT_NULL_SENTINEL = inline_null_value<int32_t>();
 
   for (int i = 0; i < factsCount; i++) {
-    const auto select_crt_row = results->getNextRow(true, false);
+    const auto select_crt_row = results->row(i, true, false);
     auto id = getIntValue(select_crt_row[0]);
     auto val = getIntValue(select_crt_row[1]);
     auto lookupId = getIntValue(select_crt_row[2]);
@@ -421,7 +421,7 @@ TEST(Select, CorrelatedWithOuterSortAscending) {
   auto INT_NULL_SENTINEL = inline_null_value<int32_t>();
 
   for (int i = 0; i < factsCount; i++) {
-    const auto select_crt_row = results->getNextRow(true, false);
+    const auto select_crt_row = results->row(i, true, false);
     auto id = getIntValue(select_crt_row[0]);
     auto val = getIntValue(select_crt_row[1]);
     auto lookupId = getIntValue(select_crt_row[2]);
@@ -450,7 +450,7 @@ TEST(Select, CorrelatedWithOuterSortDescending) {
   auto INT_NULL_SENTINEL = inline_null_value<int32_t>();
 
   for (int i = factsCount - 1; i >= 0; i--) {
-    const auto select_crt_row = results->getNextRow(true, false);
+    const auto select_crt_row = results->row(factsCount - 1 - i, true, false);
     auto id = getIntValue(select_crt_row[0]);
     auto val = getIntValue(select_crt_row[1]);
     auto lookupId = getIntValue(select_crt_row[2]);
@@ -531,7 +531,7 @@ TEST(Select, CorrelatedWhere) {
   auto INT_NULL_SENTINEL = inline_null_value<int32_t>();
 
   for (int i = 0; i < 5; i++) {
-    const auto select_crt_row = results->getNextRow(true, false);
+    const auto select_crt_row = results->row(i, true, false);
     auto id = getIntValue(select_crt_row[0]);
     auto val = getIntValue(select_crt_row[1]);
     auto lookupId = getIntValue(select_crt_row[2]);
@@ -553,8 +553,9 @@ TEST(Select, CorrelatedWhereNull) {
 
   auto INT_NULL_SENTINEL = inline_null_value<int32_t>();
 
+  size_t row_idx = 0;
   for (int i = lookupCount; i < factsCount; i++) {
-    const auto select_crt_row = results->getNextRow(true, false);
+    const auto select_crt_row = results->row(row_idx++, true, false);
     auto id = getIntValue(select_crt_row[0]);
     auto val = getIntValue(select_crt_row[1]);
     auto lookupId = getIntValue(select_crt_row[2]);
@@ -610,7 +611,7 @@ TEST(Select, JoinCorrelation) {
   auto results1 = run_multiple_agg(sql, ExecutorDeviceType::CPU);
   uint32_t numResultRows = results1->rowCount();
   ASSERT_EQ(static_cast<uint32_t>(1), numResultRows);
-  const auto select_crt_row = results1->getNextRow(true, false);
+  const auto select_crt_row = results1->row(0, true, false);
   auto id = getIntValue(select_crt_row[0]);
   auto val = getIntValue(select_crt_row[1]);
   ASSERT_EQ(id, 4);
@@ -624,7 +625,7 @@ TEST(Select, JoinCorrelation) {
   ASSERT_EQ(static_cast<uint32_t>(12), numResultRows);
   bool correct = true;
   for (uint32_t i = 0; i < numResultRows; i++) {
-    const auto select_crt_row = results2->getNextRow(true, false);
+    const auto select_crt_row = results2->row(i, true, false);
     auto id = getIntValue(select_crt_row[0]);
     auto val = getIntValue(select_crt_row[1]);
     if (id == 4 && val == 4) {
@@ -641,7 +642,7 @@ TEST(Select, JoinCorrelation) {
   ASSERT_EQ(static_cast<uint32_t>(12), numResultRows);
   correct = true;
   for (uint32_t i = 0; i < numResultRows; i++) {
-    const auto select_crt_row = results3->getNextRow(true, false);
+    const auto select_crt_row = results3->row(i, true, false);
     auto id = getIntValue(select_crt_row[0]);
     auto val = getIntValue(select_crt_row[1]);
     if (id == 4 && val == 4) {
@@ -657,7 +658,7 @@ TEST(Select, JoinCorrelation) {
   auto results5 = run_multiple_agg(sql, ExecutorDeviceType::CPU);
   numResultRows = results5->rowCount();
   ASSERT_EQ(static_cast<uint32_t>(1), numResultRows);
-  const auto select_crt_row5 = results5->getNextRow(true, false);
+  const auto select_crt_row5 = results5->row(0, true, false);
   id = getIntValue(select_crt_row5[0]);
   val = getIntValue(select_crt_row5[1]);
   ASSERT_EQ(id, 4);
@@ -669,7 +670,7 @@ TEST(Select, JoinCorrelation) {
   auto results6 = run_multiple_agg(sql, ExecutorDeviceType::CPU);
   numResultRows = results6->rowCount();
   ASSERT_EQ(static_cast<uint32_t>(1), numResultRows);
-  const auto select_crt_row6 = results6->getNextRow(true, false);
+  const auto select_crt_row6 = results6->row(0, true, false);
   id = getIntValue(select_crt_row6[0]);
   val = getIntValue(select_crt_row6[1]);
   ASSERT_EQ(id, 4);
@@ -681,7 +682,7 @@ TEST(Select, JoinCorrelation) {
   auto results4 = run_multiple_agg(sql, ExecutorDeviceType::CPU);
   numResultRows = results4->rowCount();
   ASSERT_EQ(static_cast<uint32_t>(1), numResultRows);
-  const auto select_crt_row4 = results4->getNextRow(true, false);
+  const auto select_crt_row4 = results4->row(0, true, false);
   id = getIntValue(select_crt_row4[0]);
   val = getIntValue(select_crt_row4[1]);
   ASSERT_EQ(id, 4);
@@ -701,7 +702,7 @@ TEST(Select, JoinCorrelation_withMultipleExists) {
   auto results1 = run_multiple_agg(sql, ExecutorDeviceType::CPU);
   uint32_t numResultRows = results1->rowCount();
   ASSERT_EQ(static_cast<uint32_t>(1), numResultRows);
-  const auto select_crt_row = results1->getNextRow(true, false);
+  const auto select_crt_row = results1->row(0, true, false);
   auto id = getIntValue(select_crt_row[0]);
   auto val = getIntValue(select_crt_row[1]);
   ASSERT_EQ(id, 4);
@@ -714,7 +715,7 @@ TEST(Select, JoinCorrelation_withMultipleExists) {
   auto results2 = run_multiple_agg(sql, ExecutorDeviceType::CPU);
   numResultRows = results2->rowCount();
   ASSERT_EQ(static_cast<uint32_t>(1), numResultRows);
-  const auto select_crt_row2 = results2->getNextRow(true, false);
+  const auto select_crt_row2 = results2->row(0, true, false);
   id = getIntValue(select_crt_row2[0]);
   val = getIntValue(select_crt_row2[1]);
   ASSERT_EQ(id, 4);
@@ -729,7 +730,7 @@ TEST(Select, JoinCorrelation_withMultipleExists) {
   auto results3 = run_multiple_agg(sql, ExecutorDeviceType::CPU);
   numResultRows = results3->rowCount();
   ASSERT_EQ(static_cast<uint32_t>(1), numResultRows);
-  const auto select_crt_row3 = results3->getNextRow(true, false);
+  const auto select_crt_row3 = results3->row(0, true, false);
   id = getIntValue(select_crt_row3[0]);
   val = getIntValue(select_crt_row3[1]);
   ASSERT_EQ(id, 4);
@@ -753,7 +754,7 @@ TEST(Select, JoinCorrelation_withMultipleExists) {
   auto results5 = run_multiple_agg(sql, ExecutorDeviceType::CPU);
   numResultRows = results5->rowCount();
   ASSERT_EQ(static_cast<uint32_t>(1), numResultRows);
-  const auto select_crt_row5 = results5->getNextRow(true, false);
+  const auto select_crt_row5 = results5->row(0, true, false);
   id = getIntValue(select_crt_row5[0]);
   val = getIntValue(select_crt_row5[1]);
   ASSERT_EQ(id, 4);
@@ -780,7 +781,7 @@ TEST(Select, JoinCorrelation_InClause) {
   auto results1 = run_multiple_agg(sql, ExecutorDeviceType::CPU);
   uint32_t numResultRows = results1->rowCount();
   ASSERT_EQ(static_cast<uint32_t>(1), numResultRows);
-  const auto select_crt_row = results1->getNextRow(true, false);
+  const auto select_crt_row = results1->row(0, true, false);
   auto id = getIntValue(select_crt_row[0]);
   auto val = getIntValue(select_crt_row[1]);
   ASSERT_EQ(id, 4);
@@ -816,7 +817,7 @@ TEST(Select, JoinCorrelation_InClause) {
   auto results5 = run_multiple_agg(sql, ExecutorDeviceType::CPU);
   uint32_t numResultRows5 = results5->rowCount();
   ASSERT_EQ(static_cast<uint32_t>(1), numResultRows5);
-  const auto select_crt_row5 = results5->getNextRow(true, false);
+  const auto select_crt_row5 = results5->row(0, true, false);
   id = getIntValue(select_crt_row5[0]);
   val = getIntValue(select_crt_row5[1]);
   ASSERT_EQ(id, 4);

--- a/omniscidb/Tests/ResultSetArrowConversion.cpp
+++ b/omniscidb/Tests/ResultSetArrowConversion.cpp
@@ -223,14 +223,22 @@ void test_chunked_conversion(bool enable_columnar_output,
                              size_t fragment_size) {
   bool prev_enable_columnar_output = config().rs.enable_columnar_output;
   bool prev_enable_lazy_fetch = config().rs.enable_lazy_fetch;
+  bool prev_enable_multifrag_execution_result =
+      config().exec.enable_multifrag_execution_result;
 
-  ScopeGuard reset = [prev_enable_columnar_output, prev_enable_lazy_fetch] {
+  ScopeGuard reset = [prev_enable_columnar_output,
+                      prev_enable_lazy_fetch,
+                      prev_enable_multifrag_execution_result] {
     config().rs.enable_columnar_output = prev_enable_columnar_output;
     config().rs.enable_lazy_fetch = prev_enable_lazy_fetch;
+    config().exec.enable_multifrag_execution_result =
+        prev_enable_multifrag_execution_result;
   };
 
   config().rs.enable_columnar_output = enable_columnar_output;
   config().rs.enable_lazy_fetch = enable_lazy_fetch;
+  // We want to have multiple chunks in a single ResultSet for the test.
+  config().exec.enable_multifrag_execution_result = false;
   test_arrow_table_conversion_table6x4(fragment_size);
 }
 
@@ -683,6 +691,14 @@ TEST(ArrowTable, Chunked_Conversion4) {
 
 //  Projection operation test (column "d")
 TEST(ArrowTable, Chunked_SingleColumnConversion) {
+  bool prev_enable_multifrag_execution_result =
+      config().exec.enable_multifrag_execution_result;
+  ScopeGuard reset = [prev_enable_multifrag_execution_result] {
+    config().exec.enable_multifrag_execution_result =
+        prev_enable_multifrag_execution_result;
+  };
+  config().exec.enable_multifrag_execution_result = false;
+
   auto res = runSqlQuery("select 2*d from test_chunked;", ExecutorDeviceType::CPU, true);
   auto table = getArrowTable(res);
   ASSERT_NE(table, nullptr);
@@ -714,14 +730,20 @@ TEST(ArrowTable, Chunked_GROUPBY1) {
 void JoinTest(bool enable_columnar_output, bool enable_lazy_fetch) {
   bool prev_enable_columnar_output = config().rs.enable_columnar_output;
   bool prev_enable_lazy_fetch = config().rs.enable_lazy_fetch;
-
-  ScopeGuard reset = [prev_enable_columnar_output, prev_enable_lazy_fetch] {
+  bool prev_enable_multifrag_execution_result =
+      config().exec.enable_multifrag_execution_result;
+  ScopeGuard reset = [prev_enable_columnar_output,
+                      prev_enable_lazy_fetch,
+                      prev_enable_multifrag_execution_result] {
     config().rs.enable_columnar_output = prev_enable_columnar_output;
     config().rs.enable_lazy_fetch = prev_enable_lazy_fetch;
+    config().exec.enable_multifrag_execution_result =
+        prev_enable_multifrag_execution_result;
   };
 
   config().rs.enable_columnar_output = enable_columnar_output;
   config().rs.enable_lazy_fetch = enable_lazy_fetch;
+  config().exec.enable_multifrag_execution_result = false;
 
   auto res = runSqlQuery(
       "SELECT * FROM test_chunked INNER JOIN join_table ON test_chunked.i=join_table.i;",
@@ -757,6 +779,14 @@ TEST(ArrowTable, Chunked_JOIN4) {
 
 //  Tests with NULLs
 TEST(ArrowTable, Chunked_NULLS1) {
+  bool prev_enable_multifrag_execution_result =
+      config().exec.enable_multifrag_execution_result;
+  ScopeGuard reset = [prev_enable_multifrag_execution_result] {
+    config().exec.enable_multifrag_execution_result =
+        prev_enable_multifrag_execution_result;
+  };
+  config().exec.enable_multifrag_execution_result = false;
+
   auto res = runSqlQuery("select * from chunked_nulls;", ExecutorDeviceType::CPU, true);
   auto table = getArrowTable(res);
   ASSERT_NE(table, nullptr);
@@ -775,6 +805,14 @@ TEST(ArrowTable, Chunked_NULLS1) {
 }
 
 TEST(ArrowTable, Chunked_NULLS2) {
+  bool prev_enable_multifrag_execution_result =
+      config().exec.enable_multifrag_execution_result;
+  ScopeGuard reset = [prev_enable_multifrag_execution_result] {
+    config().exec.enable_multifrag_execution_result =
+        prev_enable_multifrag_execution_result;
+  };
+  config().exec.enable_multifrag_execution_result = false;
+
   auto res = runSqlQuery(
       "select 2*i,3*bi,4*d from chunked_nulls;", ExecutorDeviceType::CPU, true);
   auto table = getArrowTable(res);
@@ -798,14 +836,22 @@ TEST(ArrowTable, Chunked_NULLS2) {
 TEST(ArrowTable, LargeTables) {
   bool prev_enable_columnar_output = config().rs.enable_columnar_output;
   bool prev_enable_lazy_fetch = config().rs.enable_lazy_fetch;
+  bool prev_enable_multifrag_execution_result =
+      config().exec.enable_multifrag_execution_result;
 
-  ScopeGuard reset = [prev_enable_columnar_output, prev_enable_lazy_fetch] {
+  ScopeGuard reset = [prev_enable_columnar_output,
+                      prev_enable_lazy_fetch,
+                      prev_enable_multifrag_execution_result] {
     config().rs.enable_columnar_output = prev_enable_columnar_output;
     config().rs.enable_lazy_fetch = prev_enable_lazy_fetch;
+    config().exec.enable_multifrag_execution_result =
+        prev_enable_multifrag_execution_result;
   };
 
   config().rs.enable_columnar_output = true;
   config().rs.enable_lazy_fetch = false;
+  config().exec.enable_multifrag_execution_result = false;
+
   const size_t N = 500'000;
   test_single_column_table<int8_t>(N, 150);
   test_single_column_table<int16_t>(N, 150);
@@ -818,14 +864,22 @@ TEST(ArrowTable, LargeTables) {
 TEST(ArrowTable, LargeTablesRowWise) {
   bool prev_enable_columnar_output = config().rs.enable_columnar_output;
   bool prev_enable_lazy_fetch = config().rs.enable_lazy_fetch;
+  bool prev_enable_multifrag_execution_result =
+      config().exec.enable_multifrag_execution_result;
 
-  ScopeGuard reset = [prev_enable_columnar_output, prev_enable_lazy_fetch] {
+  ScopeGuard reset = [prev_enable_columnar_output,
+                      prev_enable_lazy_fetch,
+                      prev_enable_multifrag_execution_result] {
     config().rs.enable_columnar_output = prev_enable_columnar_output;
     config().rs.enable_lazy_fetch = prev_enable_lazy_fetch;
+    config().exec.enable_multifrag_execution_result =
+        prev_enable_multifrag_execution_result;
   };
 
   config().rs.enable_columnar_output = false;
   config().rs.enable_lazy_fetch = false;
+  config().exec.enable_multifrag_execution_result = false;
+
   const size_t N = 500'000;
   test_single_column_table<int8_t>(N, 150);
   test_single_column_table<int16_t>(N, 150);

--- a/omniscidb/Tests/ResultSetTest.cpp
+++ b/omniscidb/Tests/ResultSetTest.cpp
@@ -3005,23 +3005,23 @@ TEST(ResultsetConversion, EnforceParallelColumnarConversion) {
 
   for (auto dt : testedDevices()) {
     // single-frag test
-    std::shared_ptr<ResultSet> res1 = run_multiple_agg(
+    auto res1 = run_multiple_agg(
         "SELECT COUNT(1) FROM (SELECT x FROM t_large WHERE x < 2) t, t_small r where t.x "
         "= r.x",
         dt,
         false);
     EXPECT_EQ(1, (int64_t)res1.get()->rowCount());
-    const auto crt_row1 = res1.get()->getNextRow(false, false);
+    const auto crt_row1 = res1.get()->row(0, false, false);
     EXPECT_EQ(answer, v<int64_t>(crt_row1[0]));
 
     // multi-frag test
-    std::shared_ptr<ResultSet> res2 = run_multiple_agg(
+    auto res2 = run_multiple_agg(
         "SELECT COUNT(1) FROM (SELECT x FROM t_large_multi_frag WHERE x < 2) t, t_small "
         "r where t.x = r.x",
         dt,
         false);
     EXPECT_EQ(1, (int64_t)res2.get()->rowCount());
-    const auto crt_row2 = res2.get()->getNextRow(false, false);
+    const auto crt_row2 = res2.get()->row(0, false, false);
     EXPECT_EQ(answer, v<int64_t>(crt_row1[0]));
   }
 }

--- a/omniscidb/Tests/StringFunctionsTest.cpp
+++ b/omniscidb/Tests/StringFunctionsTest.cpp
@@ -74,8 +74,8 @@ void assert_value_equals(ScalarTargetValue& expected,
 
 void compare_result_set(
     const std::vector<std::vector<ScalarTargetValue>>& expected_result_set,
-    const std::shared_ptr<ResultSet>& actual_result_set) {
-  auto row_count = actual_result_set->rowCount(false);
+    const hdk::ResultSetTableTokenPtr& actual_result_set) {
+  auto row_count = actual_result_set->rowCount();
   ASSERT_EQ(expected_result_set.size(), row_count)
       << "Returned result set does not have the expected number of rows";
 
@@ -90,7 +90,7 @@ void compare_result_set(
   ;
 
   for (size_t r = 0; r < row_count; ++r) {
-    auto row = actual_result_set->getNextRow(true, true);
+    auto row = actual_result_set->row(r, true, true);
     for (size_t c = 0; c < column_count; c++) {
       auto column_value = boost::get<ScalarTargetValue>(row[c]);
       auto expected_column_value = expected_result_set[r][c];

--- a/omniscidb/Tests/UdfTest.cpp
+++ b/omniscidb/Tests/UdfTest.cpp
@@ -295,12 +295,12 @@ TEST_F(UDFCompilerTest, UdfQuery) {
       const auto rows = run_multiple_agg(
           "SELECT array_ret_udf(pay_by_quarter, CAST(1.2 AS DOUBLE)) FROM sal_emp;", dt);
       ASSERT_EQ(rows->rowCount(), size_t(4));
-      check_row_result(rows->getNextRow(false, false),
+      check_row_result(rows->row(0, false, false),
                        std::vector<double>{6000, 7200, 8400, 9600});
-      check_row_result(rows->getNextRow(false, false),
+      check_row_result(rows->row(1, false, false),
                        std::vector<double>{3600, 4200, 4800, 5160});
-      check_row_result(rows->getNextRow(false, false), std::vector<double>{});
-      check_row_result(rows->getNextRow(false, false),
+      check_row_result(rows->row(2, false, false), std::vector<double>{});
+      check_row_result(rows->row(3, false, false),
                        std::vector<double>{8400,
                                            inline_fp_null_value<double>(),
                                            inline_fp_null_value<double>(),


### PR DESCRIPTION
This option enables multiple fragments in a query execution result by default. This should improve Modin's performance because it now runs queries directly on execution results.

Also, I see no reason to have `enable_multifrag_rs` and `enable_multifrag_execution_result` anymore. If everything works fine I'd remove them eventually.