### PR TITLE
Introduce aggregate finalization.

### DIFF
--- a/omniscidb/QueryEngine/Execute.cpp
+++ b/omniscidb/QueryEngine/Execute.cpp
@@ -1234,6 +1234,9 @@ ResultSetPtr Executor::reduceMultiDeviceResultSets(
   const auto& first = results_per_device.front().first;
 
   if (results_per_device.size() == 1) {
+    // This finalization is optional but done here to have finalization time
+    // to be a part of reduction.
+    first->finalizeAggregates();
     return first;
   }
 
@@ -1326,6 +1329,10 @@ ResultSetPtr Executor::reduceMultiDeviceResultSets(
                                  this);
     }
   }
+  // This finalization is required because reduced results might reference
+  // memory owned by other ResultSets (Quantile aggregate). Finalize aggregates
+  // so that we can safely destroy original ResultSets.
+  reduced_results->finalizeAggregates();
   reduced_results->addCompilationQueueTime(compilation_queue_time);
   return reduced_results;
 }

--- a/omniscidb/ResultSet/ResultSet.h
+++ b/omniscidb/ResultSet/ResultSet.h
@@ -633,6 +633,14 @@ class ResultSet {
 
   ResultSetPtr shallowCopy() const;
 
+  // Iterate through aggregates with delayed computaitons like Quantile
+  // and finalize their results. In some cases finalization is optional,
+  // e.g. TopK doesn't need to be finalized. But it also might be required.
+  // For instance, reduced Quantile aggregate references memory owned by
+  // other ResultSets and it has to be finalized before memory is
+  // deallocated.
+  void finalizeAggregates();
+
  private:
   ResultSet(const ResultSet& other);
 


### PR DESCRIPTION
This patch introduces finalization for aggregates that can be done after reduction. This step can be used to materialize aggregates that do not have the final result computed during reduction (AVG, APPROX_QUANTILE, TOP_K, QUANTILE). For now, I only finalize QUANTILE aggregate as the most time-consuming one.

Currently, actual quantile finalization happens when we try to fetch quantile value the first time and it actually happens when we put ResultSet to the ResultSetRegistry (rowCount iterates through all rows and materializes all values, which is another inefficiency to fix someday). rowCount doesn't expect iteration through rows to be so time-consuming and can choose single-threaded mode in a case when iteration is quite long (>1sec.). Finalization here helps by adding parallelism.

On H2O GroupBy Q6 this patch gives a significant boost speeding up finalization by >10x (due to multithreading) and overall query execution by ~2x for medium dataset.