### PR TITLE
Proper heterogen execution modes

### DIFF
--- a/omniscidb/QueryEngine/CompilationOptions.cpp
+++ b/omniscidb/QueryEngine/CompilationOptions.cpp
@@ -71,6 +71,11 @@ std::ostream& operator<<(std::ostream& os, const compiler::CallingConvDesc& desc
   }
 }
 
+std::ostream& operator<<(std::ostream& os, const ExecutorDispatchMode ddm) {
+  constexpr char const* strings[]{"KernelPerFragment", "MultifragmentKernel"};
+  return os << strings[static_cast<int>(ddm)];
+}
+
 std::ostream& operator<<(std::ostream& os,
                          const compiler::CodegenTraitsDescriptor& desc) {
   os << "{local=" << desc.local_addr_space_ << ",global=" << desc.global_addr_space_

--- a/omniscidb/QueryEngine/CompilationOptions.h
+++ b/omniscidb/QueryEngine/CompilationOptions.h
@@ -201,6 +201,7 @@ std::ostream& operator<<(std::ostream& os, const compiler::CallingConvDesc& desc
 std::ostream& operator<<(std::ostream& os, const compiler::CodegenTraitsDescriptor& desc);
 std::ostream& operator<<(std::ostream& os, const ExecutorExplainType& eet);
 std::ostream& operator<<(std::ostream& os, const CompilationOptions& co);
+std::ostream& operator<<(std::ostream& os, const ExecutorDispatchMode ddm);
 #endif
 
 #endif  // QUERYENGINE_COMPILATIONOPTIONS_H

--- a/omniscidb/QueryEngine/CostModel/CostModel.h
+++ b/omniscidb/QueryEngine/CostModel/CostModel.h
@@ -49,7 +49,9 @@ class CostModel {
 
   virtual void calibrate(const CaibrationConfig& conf);
   virtual std::unique_ptr<policy::ExecutionPolicy> predict(
-      QueryInfo query_info) const = 0;
+      QueryInfo query_info,
+      const std::map<ExecutorDeviceType, ExecutorDispatchMode>& devices_dispatch_modes)
+      const = 0;
 
  protected:
   struct DeviceExtrapolations {

--- a/omniscidb/QueryEngine/CostModel/Dispatchers/DefaultExecutionPolicy.cpp
+++ b/omniscidb/QueryEngine/CostModel/Dispatchers/DefaultExecutionPolicy.cpp
@@ -24,7 +24,7 @@ SchedulingAssignment FragmentIDAssignmentExecutionPolicy::scheduleSingleFragment
   int device_id = fragment.deviceIds[static_cast<int>(memory_level)];
   return {dt_, device_id};
 }
-std::vector<ExecutorDeviceType> FragmentIDAssignmentExecutionPolicy::devices() const {
+std::set<ExecutorDeviceType> FragmentIDAssignmentExecutionPolicy::devices() const {
   return {dt_};
 }
 }  // namespace policy

--- a/omniscidb/QueryEngine/CostModel/Dispatchers/DefaultExecutionPolicy.h
+++ b/omniscidb/QueryEngine/CostModel/Dispatchers/DefaultExecutionPolicy.h
@@ -18,11 +18,14 @@
 namespace policy {
 class FragmentIDAssignmentExecutionPolicy : public ExecutionPolicy {
  public:
-  FragmentIDAssignmentExecutionPolicy(ExecutorDeviceType dt) : dt_(dt){};
+  FragmentIDAssignmentExecutionPolicy(
+      ExecutorDeviceType dt,
+      const std::map<ExecutorDeviceType, ExecutorDispatchMode>& devices_dispatch_modes)
+      : ExecutionPolicy(devices_dispatch_modes), dt_(dt){};
   SchedulingAssignment scheduleSingleFragment(const FragmentInfo&,
                                               size_t frag_id,
                                               size_t frag_num) const override;
-  std::vector<ExecutorDeviceType> devices() const override;
+  std::set<ExecutorDeviceType> devices() const override;
   std::string name() const override { return "ExecutionPolicy::FragmentIDAssignment"; };
 
  private:

--- a/omniscidb/QueryEngine/CostModel/Dispatchers/ExecutionPolicy.h
+++ b/omniscidb/QueryEngine/CostModel/Dispatchers/ExecutionPolicy.h
@@ -37,10 +37,21 @@ class ExecutionPolicy {
   virtual std::string name() const = 0;
 
   virtual ~ExecutionPolicy() = default;
+
+  // Probe/modify modes during kernel building (do not iterate). These are the default
+  // modes.
+  std::unordered_map<ExecutorDeviceType, ExecutorDispatchMode> devices_dispatch_modes{
+      {ExecutorDeviceType::CPU, ExecutorDispatchMode::KernelPerFragment},
+      {ExecutorDeviceType::GPU, ExecutorDispatchMode::KernelPerFragment}};
 };
 
 inline std::ostream& operator<<(std::ostream& os, const ExecutionPolicy& policy) {
-  return os << policy.name();
+  os << policy.name() << "\n";
+  os << "Dispatching modes: \n";
+  for (const auto& device_disp_mode : policy.devices_dispatch_modes) {
+    os << device_disp_mode.first << " - " << device_disp_mode.second << "\n";
+  }
+  return os;
 }
 
 }  // namespace policy

--- a/omniscidb/QueryEngine/CostModel/Dispatchers/ProportionBasedExecutionPolicy.cpp
+++ b/omniscidb/QueryEngine/CostModel/Dispatchers/ProportionBasedExecutionPolicy.cpp
@@ -19,9 +19,11 @@
 namespace policy {
 
 ProportionBasedExecutionPolicy::ProportionBasedExecutionPolicy(
-    std::map<ExecutorDeviceType, unsigned>&& propotion) {
-  CHECK_GT(propotion.size(), 0u);
-  proportion_.merge(propotion);
+    std::map<ExecutorDeviceType, unsigned>&& proportion,
+    const std::map<ExecutorDeviceType, ExecutorDispatchMode>& devices_dispatch_modes)
+    : ExecutionPolicy(devices_dispatch_modes) {
+  CHECK_GT(proportion.size(), 0u);
+  proportion_.merge(proportion);
   total_parts_ = std::accumulate(
       proportion_.begin(), proportion_.end(), 0u, [](unsigned acc, auto& cur) {
         return acc + cur.second;

--- a/omniscidb/QueryEngine/CostModel/Dispatchers/ProportionBasedExecutionPolicy.h
+++ b/omniscidb/QueryEngine/CostModel/Dispatchers/ProportionBasedExecutionPolicy.h
@@ -24,7 +24,9 @@ namespace policy {
  */
 class ProportionBasedExecutionPolicy : public ExecutionPolicy {
  public:
-  ProportionBasedExecutionPolicy(std::map<ExecutorDeviceType, unsigned>&& proportion);
+  ProportionBasedExecutionPolicy(
+      std::map<ExecutorDeviceType, unsigned>&& proportion,
+      const std::map<ExecutorDeviceType, ExecutorDispatchMode>& devices_dispatch_modes);
   SchedulingAssignment scheduleSingleFragment(const FragmentInfo&,
                                               size_t frag_id,
                                               size_t frag_num) const override;

--- a/omniscidb/QueryEngine/CostModel/Dispatchers/RRExecutionPolicy.h
+++ b/omniscidb/QueryEngine/CostModel/Dispatchers/RRExecutionPolicy.h
@@ -18,6 +18,10 @@
 namespace policy {
 class RoundRobinExecutionPolicy : public ExecutionPolicy {
  public:
+  RoundRobinExecutionPolicy(
+      const std::map<ExecutorDeviceType, ExecutorDispatchMode>& devices_dispatch_modes)
+      : ExecutionPolicy(devices_dispatch_modes){};
+
   SchedulingAssignment scheduleSingleFragment(const FragmentInfo&,
                                               size_t frag_id,
                                               size_t frag_num) const override;

--- a/omniscidb/QueryEngine/CostModel/IterativeCostModel.cpp
+++ b/omniscidb/QueryEngine/CostModel/IterativeCostModel.cpp
@@ -31,7 +31,9 @@ IterativeCostModel::IterativeCostModel()
 #endif
 
 std::unique_ptr<policy::ExecutionPolicy> IterativeCostModel::predict(
-    QueryInfo query_info) const {
+    QueryInfo query_info,
+    const std::map<ExecutorDeviceType, ExecutorDispatchMode>& devices_dispatch_modes)
+    const {
   std::shared_lock<std::shared_mutex> l(latch_);
 
   unsigned cpu_prop = 1, gpu_prop = 0;
@@ -74,6 +76,7 @@ std::unique_ptr<policy::ExecutionPolicy> IterativeCostModel::predict(
   proportion[ExecutorDeviceType::GPU] = gpu_prop;
   proportion[ExecutorDeviceType::CPU] = cpu_prop;
 
-  return std::make_unique<policy::ProportionBasedExecutionPolicy>(std::move(proportion));
+  return std::make_unique<policy::ProportionBasedExecutionPolicy>(std::move(proportion),
+                                                                  devices_dispatch_modes);
 }
 }  // namespace costmodel

--- a/omniscidb/QueryEngine/CostModel/IterativeCostModel.h
+++ b/omniscidb/QueryEngine/CostModel/IterativeCostModel.h
@@ -24,7 +24,10 @@ class IterativeCostModel : public CostModel {
   IterativeCostModel();
   IterativeCostModel(CostModelConfig config) : CostModel(std::move(config)) {}
 
-  virtual std::unique_ptr<policy::ExecutionPolicy> predict(QueryInfo query_info) const;
+  virtual std::unique_ptr<policy::ExecutionPolicy> predict(
+      QueryInfo query_info,
+      const std::map<ExecutorDeviceType, ExecutorDispatchMode>& devices_dispatch_modes)
+      const;
 
  private:
   static constexpr size_t optimization_iterations_ = 1024;

--- a/omniscidb/QueryEngine/Descriptors/QueryFragmentDescriptor.cpp
+++ b/omniscidb/QueryEngine/Descriptors/QueryFragmentDescriptor.cpp
@@ -333,6 +333,7 @@ void QueryFragmentDescriptor::buildMultifragKernelMap(
     if (device_type == ExecutorDeviceType::GPU) {
       checkDeviceMemoryUsage(fragment, device_id, num_bytes_for_row);
     }
+
     for (size_t j = 0; j < ra_exe_unit.input_descs.size(); ++j) {
       const auto db_id = ra_exe_unit.input_descs[j].getDatabaseId();
       const auto table_id = ra_exe_unit.input_descs[j].getTableId();

--- a/omniscidb/QueryEngine/Execute.cpp
+++ b/omniscidb/QueryEngine/Execute.cpp
@@ -1924,84 +1924,6 @@ hdk::ResultSetTable Executor::finishStreamExecution(
   return result;
 }
 
-std::pair<std::unique_ptr<policy::ExecutionPolicy>, ExecutorDeviceType>
-Executor::getExecutionPolicyForTargets(const RelAlgExecutionUnit& ra_exe_unit,
-                                       const ExecutorDeviceType requested_device_type,
-                                       const std::vector<InputTableInfo>& query_infos,
-                                       size_t& max_groups_buffer_entry_guess,
-                                       const ExecutionOptions& eo) {
-  if (needFallbackOnCPU(ra_exe_unit, requested_device_type)) {
-    LOG(DEBUG1) << "Devices Restricted, falling back on CPU";
-    return {std::make_unique<policy::FragmentIDAssignmentExecutionPolicy>(
-                ExecutorDeviceType::CPU),
-            ExecutorDeviceType::CPU};
-  }
-
-  CHECK(!query_infos.empty());
-  if (!max_groups_buffer_entry_guess) {
-    LOG(DEBUG1) << "The query has failed the first execution attempt because of running "
-                   "out of group by slots. Make the conservative choice: allocate "
-                   "fragment size slots and run on the CPU.";
-    max_groups_buffer_entry_guess = compute_buffer_entry_guess(query_infos);
-    return {std::make_unique<policy::FragmentIDAssignmentExecutionPolicy>(
-                ExecutorDeviceType::CPU),
-            ExecutorDeviceType::CPU};
-  }
-
-  std::unique_ptr<policy::ExecutionPolicy> exe_policy;
-  auto cfg = config_->exec.heterogeneous;
-
-  if (config_->exec.enable_cost_model && ra_exe_unit.cost_model != nullptr &&
-      cfg.enable_heterogeneous_execution && !ra_exe_unit.templs.empty()) {
-    size_t bytes = 0;
-
-    // TODO(bagrorg): how can we get bytes estimation more correctly?
-    for (const auto& e : query_infos) {
-      auto t = e.info;
-      for (const auto& f : t.fragments) {
-        for (const auto& [k, v] : f.getChunkMetadataMapPhysical()) {
-          bytes += v->numBytes();
-        }
-      }
-    }
-
-    LOG(DEBUG1) << "Cost Model enabled, making prediction for templates "
-                << toString(ra_exe_unit.templs) << " for size " << bytes;
-
-    costmodel::QueryInfo qi = {ra_exe_unit.templs, bytes};
-
-    try {
-      exe_policy = ra_exe_unit.cost_model->predict(qi);
-      return {std::move(exe_policy), requested_device_type};
-    } catch (costmodel::CostModelException& e) {
-      LOG(DEBUG1) << "Cost model got an exception: " << e.what();
-    }
-  }
-
-  LOG(DEBUG1) << "Cost Model disabled, template is unknown or error occured: templs="
-              << toString(ra_exe_unit.templs) << " cost_model=" << ra_exe_unit.cost_model
-              << ", cost model in config: "
-              << (config_->exec.enable_cost_model ? "enabled" : "disabled")
-              << ", heterogeneous execution: "
-              << (cfg.enable_heterogeneous_execution ? "enabled" : "disabled");
-
-  if (cfg.enable_heterogeneous_execution) {
-    if (cfg.forced_heterogeneous_distribution) {
-      std::map<ExecutorDeviceType, unsigned> distribution{
-          {ExecutorDeviceType::CPU, eo.forced_cpu_proportion},
-          {ExecutorDeviceType::GPU, eo.forced_gpu_proportion}};
-      exe_policy = std::make_unique<policy::ProportionBasedExecutionPolicy>(
-          std::move(distribution));
-    } else {
-      exe_policy = std::make_unique<policy::RoundRobinExecutionPolicy>();
-    }
-  } else {
-    exe_policy = std::make_unique<policy::FragmentIDAssignmentExecutionPolicy>(
-        requested_device_type);
-  }
-  return {std::move(exe_policy), requested_device_type};
-}
-
 // TODO: move this code to QueryMemoryInitializer
 void Executor::allocateShuffleBuffers(
     const std::vector<InputTableInfo>& query_infos,
@@ -2090,6 +2012,153 @@ void Executor::allocateShuffleBuffers(
   }
 }
 
+std::set<ExecutorDeviceType> Executor::getAvailableDeviceTypes() const {
+  std::set<ExecutorDeviceType> res{ExecutorDeviceType::CPU};
+  if (data_mgr_->gpusPresent()) {
+    res.insert(ExecutorDeviceType::GPU);
+  }
+  return res;
+}
+
+std::set<ExecutorDeviceType> Executor::getDeviceTypesForQuery(
+    const RelAlgExecutionUnit& ra_exe_unit,
+    const std::vector<InputTableInfo>& table_infos,
+    const ExecutorDeviceType requested_dt,
+    size_t& max_groups_buffer_entry_guess,
+    const ExecutionOptions& eo) {
+  if (needFallbackOnCPU(ra_exe_unit, requested_dt)) {
+    LOG(DEBUG1) << "Devices Restricted, falling back on CPU";
+    return {ExecutorDeviceType::CPU};
+  }
+
+  CHECK(!table_infos.empty());
+  if (!max_groups_buffer_entry_guess) {
+    LOG(DEBUG1) << "The query has failed the first execution attempt because of running "
+                   "out of group by slots. Make the conservative choice: allocate "
+                   "fragment size slots and run on the CPU.";
+    max_groups_buffer_entry_guess = compute_buffer_entry_guess(table_infos);
+    return {ExecutorDeviceType::CPU};
+  }
+
+  if (config_->exec.heterogeneous.enable_heterogeneous_execution) {
+    return getAvailableDeviceTypes();
+  } else {
+    return {requested_dt};
+  }
+}
+
+namespace {
+bool has_lazy_fetched_columns(const std::vector<ColumnLazyFetchInfo>& fetched_cols) {
+  for (const auto& col : fetched_cols) {
+    if (col.is_lazily_fetched) {
+      return true;
+    }
+  }
+  return false;
+}
+}  // namespace
+
+std::unique_ptr<policy::ExecutionPolicy> Executor::getExecutionPolicy(
+    const bool is_agg,
+    const std::map<ExecutorDeviceType, std::unique_ptr<QueryMemoryDescriptor>>&
+        query_mem_descs,
+    const RelAlgExecutionUnit& ra_exe_unit,
+    const std::vector<InputTableInfo>& table_infos,
+    const ExecutionOptions& eo) {
+  std::unique_ptr<policy::ExecutionPolicy> exe_policy;
+  auto cfg = config_->exec.heterogeneous;
+
+  const bool uses_lazy_fetch =
+      plan_state_->allow_lazy_fetch_ &&
+      has_lazy_fetched_columns(getColLazyFetchInfo(ra_exe_unit.target_exprs));
+
+  std::map<ExecutorDeviceType, ExecutorDispatchMode> devices_dispatch_modes;
+
+  for (const auto& dt_query_desc : query_mem_descs) {
+    ExecutorDispatchMode dispatch_mode{ExecutorDispatchMode::KernelPerFragment};
+
+    if (dt_query_desc.first == ExecutorDeviceType::GPU && eo.allow_multifrag &&
+        ((!config_->exec.heterogeneous.enable_heterogeneous_execution &&
+          !uses_lazy_fetch) ||
+         is_agg)) {
+      dispatch_mode = ExecutorDispatchMode::MultifragmentKernel;
+    } else if (dt_query_desc.first == ExecutorDeviceType::CPU &&
+               table_infos.size() == (size_t)1 &&
+               config_->exec.group_by.enable_cpu_multifrag_kernels &&
+               !ra_exe_unit.partitioned_aggregation &&
+               (query_mem_descs.at(dt_query_desc.first)->getQueryDescriptionType() ==
+                    QueryDescriptionType::GroupByPerfectHash ||
+                query_mem_descs.at(dt_query_desc.first)->getQueryDescriptionType() ==
+                    QueryDescriptionType::GroupByBaselineHash)) {
+      // Right now, we don't have any heuristics to determine the perfect number of
+      // kernels we want to execute on CPU and we simply create a kernel per fragment. But
+      // there are some extreme cases when output buffer significanly exceeds fragment
+      // size and then we have few problems:
+      //  1. Output buffer initialization and reduction time exceeds fragment processing
+      //     time, so it's more profitable to use a single thread for processing.
+      //  2. We might simply run out of memory due to many huge hash tables and even
+      //  bigger
+      //     hash table created later for the reduction.
+      // We need more comprehensive processing costs and memory consumption evaluation
+      // here. For now, detect a simple groupby case when output hash table is bigger than
+      // input table. For this case we use a single multifragment kernel to force
+      // single-threaded execution with no reduction required.
+      size_t input_size = table_infos.front().info.getNumTuples();
+      size_t buffer_size = query_mem_descs.at(dt_query_desc.first)->getEntryCount();
+      constexpr size_t threshold_ratio = 2;
+      if (table_infos.front().info.fragments.size() > 1 &&
+          buffer_size * threshold_ratio >= input_size) {
+        LOG(INFO) << "Enabling multifrag kernels for CPU due to big output hash "
+                     "table (input_size is "
+                  << input_size << " rows, output buffer is " << buffer_size
+                  << " entries).";
+        dispatch_mode = ExecutorDispatchMode::MultifragmentKernel;
+      }
+    }
+    devices_dispatch_modes[dt_query_desc.first] = dispatch_mode;
+  }
+
+  if (devices_dispatch_modes.size() == 1) {  // One device -> fragmentID
+    exe_policy = std::make_unique<policy::FragmentIDAssignmentExecutionPolicy>(
+        devices_dispatch_modes.begin()->first, devices_dispatch_modes);
+  } else {
+    CHECK(cfg.enable_heterogeneous_execution);
+    if (config_->exec.enable_cost_model && ra_exe_unit.cost_model != nullptr &&
+        !ra_exe_unit.templs.empty()) {
+      size_t bytes = 0;
+      // TODO(bagrorg): how can we get bytes estimation more correctly?
+      for (const auto& e : table_infos) {
+        auto t = e.info;
+        for (const auto& f : t.fragments) {
+          for (const auto& [k, v] : f.getChunkMetadataMapPhysical()) {
+            bytes += v->numBytes();
+          }
+        }
+      }
+      LOG(DEBUG1) << "Cost Model enabled, making prediction for templates "
+                  << toString(ra_exe_unit.templs) << " for size " << bytes;
+
+      costmodel::QueryInfo qi = {ra_exe_unit.templs, bytes};
+      try {
+        exe_policy = ra_exe_unit.cost_model->predict(qi, devices_dispatch_modes);
+        return exe_policy;
+      } catch (costmodel::CostModelException& e) {
+        LOG(DEBUG1) << "Cost model got an exception: " << e.what();
+      }
+    } else if (cfg.forced_heterogeneous_distribution) {
+      std::map<ExecutorDeviceType, unsigned> distribution{
+          {ExecutorDeviceType::CPU, eo.forced_cpu_proportion},
+          {ExecutorDeviceType::GPU, eo.forced_gpu_proportion}};
+      exe_policy = std::make_unique<policy::ProportionBasedExecutionPolicy>(
+          std::move(distribution), devices_dispatch_modes);
+    } else {
+      exe_policy =
+          std::make_unique<policy::RoundRobinExecutionPolicy>(devices_dispatch_modes);
+    }
+  }
+  return exe_policy;
+}
+
 hdk::ResultSetTable Executor::executeWorkUnitImpl(
     size_t& max_groups_buffer_entry_guess,
     const bool is_agg,
@@ -2103,9 +2172,9 @@ hdk::ResultSetTable Executor::executeWorkUnitImpl(
     DataProvider* data_provider,
     ColumnCacheMap& column_cache) {
   INJECT_TIMER(Exec_executeWorkUnit);
-  auto [exe_policy, fallback_device] = getExecutionPolicyForTargets(
-      ra_exe_unit, co.device_type, query_infos, max_groups_buffer_entry_guess, eo);
-
+  auto device_types_for_query = getDeviceTypesForQuery(
+      ra_exe_unit, query_infos, co.device_type, max_groups_buffer_entry_guess, eo);
+  CHECK_GT(device_types_for_query.size(), size_t(0));
   int8_t crt_min_byte_width{MAX_BYTE_WIDTH_SUPPORTED};
   do {
     SharedKernelContext shared_context(query_infos);
@@ -2123,7 +2192,7 @@ hdk::ResultSetTable Executor::executeWorkUnitImpl(
         query_comp_descs_owned;
     std::map<ExecutorDeviceType, std::unique_ptr<QueryMemoryDescriptor>>
         query_mem_descs_owned;
-    for (auto dt : exe_policy->devices()) {
+    for (auto dt : device_types_for_query) {
       auto query_comp_desc_owned = std::make_unique<QueryCompilationDescriptor>();
       query_comp_desc_owned->setUseGroupByBufferDesc(co.use_groupby_buffer_desc);
       std::unique_ptr<QueryMemoryDescriptor> query_mem_desc_owned;
@@ -2160,11 +2229,15 @@ hdk::ResultSetTable Executor::executeWorkUnitImpl(
         query_mem_desc_owned.reset(new QueryMemoryDescriptor(
             data_mgr_, config_, 0, QueryDescriptionType::Projection, false));
       }
-
-      query_comp_descs_owned.insert(std::make_pair(dt, std::move(query_comp_desc_owned)));
-      query_mem_descs_owned.insert(std::make_pair(dt, std::move(query_mem_desc_owned)));
+      const ExecutorDeviceType compiled_for_dt{query_comp_desc_owned->getDeviceType()};
+      query_comp_descs_owned[compiled_for_dt] = std::move(query_comp_desc_owned);
+      query_mem_descs_owned[compiled_for_dt] = std::move(query_mem_desc_owned);
     }
 
+    const auto exe_policy =
+        getExecutionPolicy(is_agg, query_mem_descs_owned, ra_exe_unit, query_infos, eo);
+    const ExecutorDeviceType fallback_device{
+        exe_policy->hasDevice(co.device_type) ? co.device_type : ExecutorDeviceType::CPU};
     if (eo.just_explain) {
       return {executeExplain(*query_comp_descs_owned.at(fallback_device))};
     }
@@ -2174,8 +2247,15 @@ hdk::ResultSetTable Executor::executeWorkUnitImpl(
     }
 
     if (!eo.just_validate) {
-      int available_cpus = cpu_threads();
-      auto available_gpus = get_available_gpus(data_mgr_);
+      size_t devices_count{0};
+      for (const auto dt_mode : exe_policy->getExecutionModes()) {
+        if (dt_mode.first == ExecutorDeviceType::CPU) {
+          devices_count += cpu_threads();
+        } else {
+          devices_count += get_available_gpus(data_mgr_).size();
+        }
+      }
+      CHECK_GT(devices_count, size_t(0));
 
       try {
         std::vector<std::unique_ptr<ExecutionKernel>> kernels;
@@ -2185,13 +2265,11 @@ hdk::ResultSetTable Executor::executeWorkUnitImpl(
                                 query_infos,
                                 eo,
                                 co,
-                                is_agg,
                                 allow_single_frag_table_opt,
                                 query_comp_descs_owned,
                                 query_mem_descs_owned,
                                 exe_policy.get(),
-                                available_gpus,
-                                available_cpus);
+                                devices_count);
         launchKernels(shared_context, std::move(kernels), fallback_device, co);
       } catch (QueryExecutionError& e) {
         if (eo.with_dynamic_watchdog && interrupted_.load() &&
@@ -2566,19 +2644,6 @@ std::unordered_map<int, const hdk::ir::BinOper*> Executor::getInnerTabIdToJoinCo
   return id_to_cond;
 }
 
-namespace {
-
-bool has_lazy_fetched_columns(const std::vector<ColumnLazyFetchInfo>& fetched_cols) {
-  for (const auto& col : fetched_cols) {
-    if (col.is_lazily_fetched) {
-      return true;
-    }
-  }
-  return false;
-}
-
-}  // namespace
-
 std::vector<std::unique_ptr<ExecutionKernel>> Executor::createKernels(
     SharedKernelContext& shared_context,
     const RelAlgExecutionUnit& ra_exe_unit,
@@ -2586,15 +2651,13 @@ std::vector<std::unique_ptr<ExecutionKernel>> Executor::createKernels(
     const std::vector<InputTableInfo>& table_infos,
     const ExecutionOptions& eo,
     const CompilationOptions& co,
-    const bool is_agg,
     const bool allow_single_frag_table_opt,
     const std::map<ExecutorDeviceType, std::unique_ptr<QueryCompilationDescriptor>>&
         query_comp_descs,
     const std::map<ExecutorDeviceType, std::unique_ptr<QueryMemoryDescriptor>>&
         query_mem_descs,
-    policy::ExecutionPolicy* policy,
-    std::unordered_set<int>& available_gpus,
-    int& available_cpus) {
+    const policy::ExecutionPolicy* policy,
+    const size_t device_count) {
   std::vector<std::unique_ptr<ExecutionKernel>> execution_kernels;
 
   QueryFragmentDescriptor fragment_descriptor(
@@ -2604,62 +2667,6 @@ std::vector<std::unique_ptr<ExecutionKernel>> Executor::createKernels(
       eo.gpu_input_mem_limit_percent,
       eo.outer_fragment_indices);
   CHECK(!ra_exe_unit.input_descs.empty());
-  const bool uses_lazy_fetch =
-      plan_state_->allow_lazy_fetch_ &&
-      has_lazy_fetched_columns(getColLazyFetchInfo(ra_exe_unit.target_exprs));
-  const int device_count = config_->exec.heterogeneous.enable_heterogeneous_execution
-                               ? available_cpus + available_gpus.size()
-                               : deviceCount(query_mem_descs.begin()->first);
-  CHECK_GT(device_count, 0);
-  for (const auto& intended_dt_itr :
-       query_comp_descs) {  // Decide on optimal dispatch mode per device type
-    // Keep in mind that the query intended for GPU may fallback to CPU!
-    // We will select dispatch modes based on conditions of actual devices, but we will
-    // modify the mode of the intended device. See usage of scheduleSingleFragment() and
-    // execution_kernels_per_device_.
-    const ExecutorDeviceType intended_dt = intended_dt_itr.first;
-    const ExecutorDeviceType actual_dt = intended_dt_itr.second->getDeviceType();
-    LOG(INFO) << "Query was inteded for " << intended_dt << ", will actually run on "
-              << actual_dt;
-
-    if (actual_dt == ExecutorDeviceType::GPU && eo.allow_multifrag &&
-        (!uses_lazy_fetch || is_agg)) {
-      policy->devices_dispatch_modes.at(intended_dt) =
-          ExecutorDispatchMode::MultifragmentKernel;
-    } else if (actual_dt == ExecutorDeviceType::CPU && table_infos.size() == (size_t)1 &&
-               config_->exec.group_by.enable_cpu_multifrag_kernels &&
-               !ra_exe_unit.partitioned_aggregation &&
-               (query_mem_descs.at(intended_dt)->getQueryDescriptionType() ==
-                    QueryDescriptionType::GroupByPerfectHash ||
-                query_mem_descs.at(intended_dt)->getQueryDescriptionType() ==
-                    QueryDescriptionType::GroupByBaselineHash)) {
-      // Right now, we don't have any heuristics to determine the perfect number of
-      // kernels we want to execute on CPU and we simply create a kernel per fragment. But
-      // there are some extreme cases when output buffer significanly exceeds fragment
-      // size and then we have few problems:
-      //  1. Output buffer initialization and reduction time exceeds fragment processing
-      //     time, so it's more profitable to use a single thread for processing.
-      //  2. We might simply run out of memory due to many huge hash tables and even
-      //  bigger
-      //     hash table created later for the reduction.
-      // We need more comprehensive processing costs and memory consumption evaluation
-      // here. For now, detect a simple groupby case when output hash table is bigger than
-      // input table. For this case we use a single multifragment kernel to force
-      // single-threaded execution with no reduction required.
-      size_t input_size = table_infos.front().info.getNumTuples();
-      size_t buffer_size = query_mem_descs.at(intended_dt)->getEntryCount();
-      constexpr size_t threshold_ratio = 2;
-      if (table_infos.front().info.fragments.size() > 1 &&
-          buffer_size * threshold_ratio >= input_size) {
-        LOG(INFO) << "Enabling multifrag kernels for CPU due to big output hash "
-                     "table (input_size is "
-                  << input_size << " rows, output buffer is " << buffer_size
-                  << " entries).";
-        policy->devices_dispatch_modes.at(intended_dt) =
-            ExecutorDispatchMode::MultifragmentKernel;
-      }
-    }
-  }
 
   fragment_descriptor.buildFragmentKernelMap(
       ra_exe_unit, shared_context.getFragOffsets(), policy, this, co.codegen_traits_desc);
@@ -2673,20 +2680,20 @@ std::vector<std::unique_ptr<ExecutionKernel>> Executor::createKernels(
                           device_count);
   }
 
-  for (const auto& intended_dt_itr : query_mem_descs) {
-    if (policy->devices_dispatch_modes.at(intended_dt_itr.first) ==
+  for (const auto& dt_query_desc : query_mem_descs) {
+    if (policy->getExecutionMode(dt_query_desc.first) ==
         ExecutorDispatchMode::KernelPerFragment) {
-      VLOG(1) << "Creating one execution kernel per fragment";
-      VLOG(1) << intended_dt_itr.second->toString();
+      VLOG(1) << "Dispatching one execution kernel per fragment";
+      VLOG(1) << dt_query_desc.second->toString();
       if (allow_single_frag_table_opt &&
-          (intended_dt_itr.second->getQueryDescriptionType() ==
+          (dt_query_desc.second->getQueryDescriptionType() ==
            QueryDescriptionType::Projection) &&
           table_infos.size() == 1) {
         const auto max_frag_size =
             table_infos.front().info.getFragmentNumTuplesUpperBound();
-        if (max_frag_size < intended_dt_itr.second->getEntryCount()) {
+        if (max_frag_size < dt_query_desc.second->getEntryCount()) {
           LOG(INFO) << "Lowering scan limit from "
-                    << intended_dt_itr.second->getEntryCount()
+                    << dt_query_desc.second->getEntryCount()
                     << " to match max fragment size " << max_frag_size
                     << " for kernel per fragment execution path.";
           throw CompilationRetryNewScanLimit(max_frag_size);
@@ -2724,7 +2731,7 @@ std::vector<std::unique_ptr<ExecutionKernel>> Executor::createKernels(
                                           *query_comp_descs.at(device_type).get(),
                                           *query_mem_descs.at(device_type).get(),
                                           frag_list,
-                                          policy->devices_dispatch_modes.at(device_type),
+                                          policy->getExecutionMode(device_type),
                                           rowid_lookup_key));
 
     ++frag_list_idx;

--- a/omniscidb/QueryEngine/Execute.cpp
+++ b/omniscidb/QueryEngine/Execute.cpp
@@ -2790,66 +2790,109 @@ std::vector<std::unique_ptr<ExecutionKernel>> Executor::createHeterogeneousKerne
 
   CHECK(!ra_exe_unit.input_descs.empty());
 
+  const bool use_multifrag_kernel = eo.allow_multifrag && is_agg;
+
   fragment_descriptor.buildFragmentKernelMap(ra_exe_unit,
                                              shared_context.getFragOffsets(),
                                              policy,
                                              available_cpus + available_gpus.size(),
-                                             false, /*multifrag policy unsupported yet*/
+                                             use_multifrag_kernel,
                                              this,
                                              co.codegen_traits_desc);
 
-  if (allow_single_frag_table_opt && query_mem_descs.count(ExecutorDeviceType::GPU) &&
-      (query_mem_descs.at(ExecutorDeviceType::GPU)->getQueryDescriptionType() ==
-       QueryDescriptionType::Projection) &&
-      table_infos.size() == 1) {
-    const auto max_frag_size = table_infos.front().info.getFragmentNumTuplesUpperBound();
-    if (max_frag_size < query_mem_descs.at(ExecutorDeviceType::GPU)->getEntryCount()) {
-      LOG(INFO) << "Lowering scan limit from "
-                << query_mem_descs.at(ExecutorDeviceType::GPU)->getEntryCount()
-                << " to match max fragment size " << max_frag_size
-                << " for kernel per fragment execution path.";
-      throw CompilationRetryNewScanLimit(max_frag_size);
+  if (use_multifrag_kernel) {
+    LOG(INFO) << "use_multifrag_kernel=" << use_multifrag_kernel;
+    size_t frag_list_idx{0};
+    auto multifrag_heterogeneous_kernel_dispatch =
+        [&ra_exe_unit,
+         &execution_kernels,
+         &column_fetcher,
+         &co,
+         &eo,
+         &frag_list_idx,
+         &query_comp_descs,
+         &query_mem_descs](const int device_id,
+                           const FragmentsList& frag_list,
+                           const int64_t rowid_lookup_key,
+                           const ExecutorDeviceType device_type) {
+          if (!frag_list.size()) {
+            return;
+          }
+          CHECK_GE(device_id, 0);
+
+          execution_kernels.emplace_back(std::make_unique<ExecutionKernel>(
+              ra_exe_unit,
+              device_type,
+              device_id,
+              co,
+              eo,
+              column_fetcher,
+              *query_comp_descs.at(device_type).get(),
+              *query_mem_descs.at(device_type).get(),
+              frag_list,
+              device_type == ExecutorDeviceType::CPU
+                  ? ExecutorDispatchMode::KernelPerFragment
+                  : ExecutorDispatchMode::MultifragmentKernel,
+              rowid_lookup_key));
+
+          ++frag_list_idx;
+        };
+    fragment_descriptor.assignFragsToMultiHeterogeneousDispatch(
+        multifrag_heterogeneous_kernel_dispatch, ra_exe_unit);
+  } else {
+    if (allow_single_frag_table_opt && query_mem_descs.count(ExecutorDeviceType::GPU) &&
+        (query_mem_descs.at(ExecutorDeviceType::GPU)->getQueryDescriptionType() ==
+         QueryDescriptionType::Projection) &&
+        table_infos.size() == 1) {
+      const auto max_frag_size =
+          table_infos.front().info.getFragmentNumTuplesUpperBound();
+      if (max_frag_size < query_mem_descs.at(ExecutorDeviceType::GPU)->getEntryCount()) {
+        LOG(INFO) << "Lowering scan limit from "
+                  << query_mem_descs.at(ExecutorDeviceType::GPU)->getEntryCount()
+                  << " to match max fragment size " << max_frag_size
+                  << " for kernel per fragment execution path.";
+        throw CompilationRetryNewScanLimit(max_frag_size);
+      }
     }
+
+    size_t frag_list_idx{0};
+    auto fragment_per_kernel_dispatch = [&ra_exe_unit,
+                                         &execution_kernels,
+                                         &column_fetcher,
+                                         &co,
+                                         &eo,
+                                         &frag_list_idx,
+                                         &query_comp_descs,
+                                         &query_mem_descs](
+                                            const int device_id,
+                                            const FragmentsList& frag_list,
+                                            const int64_t rowid_lookup_key,
+                                            const ExecutorDeviceType device_type) {
+      if (!frag_list.size()) {
+        return;
+      }
+      CHECK_GE(device_id, 0);
+      CHECK(query_comp_descs.count(device_type));
+      CHECK(query_mem_descs.count(device_type));
+
+      execution_kernels.emplace_back(
+          std::make_unique<ExecutionKernel>(ra_exe_unit,
+                                            device_type,
+                                            device_id,
+                                            co,
+                                            eo,
+                                            column_fetcher,
+                                            *query_comp_descs.at(device_type).get(),
+                                            *query_mem_descs.at(device_type).get(),
+                                            frag_list,
+                                            ExecutorDispatchMode::KernelPerFragment,
+                                            rowid_lookup_key));
+      ++frag_list_idx;
+    };
+
+    fragment_descriptor.assignFragsToKernelDispatch(fragment_per_kernel_dispatch,
+                                                    ra_exe_unit);
   }
-
-  size_t frag_list_idx{0};
-  auto fragment_per_kernel_dispatch = [&ra_exe_unit,
-                                       &execution_kernels,
-                                       &column_fetcher,
-                                       &co,
-                                       &eo,
-                                       &frag_list_idx,
-                                       &query_comp_descs,
-                                       &query_mem_descs](
-                                          const int device_id,
-                                          const FragmentsList& frag_list,
-                                          const int64_t rowid_lookup_key,
-                                          const ExecutorDeviceType device_type) {
-    if (!frag_list.size()) {
-      return;
-    }
-    CHECK_GE(device_id, 0);
-    CHECK(query_comp_descs.count(device_type));
-    CHECK(query_mem_descs.count(device_type));
-
-    execution_kernels.emplace_back(
-        std::make_unique<ExecutionKernel>(ra_exe_unit,
-                                          device_type,
-                                          device_id,
-                                          co,
-                                          eo,
-                                          column_fetcher,
-                                          *query_comp_descs.at(device_type).get(),
-                                          *query_mem_descs.at(device_type).get(),
-                                          frag_list,
-                                          ExecutorDispatchMode::KernelPerFragment,
-                                          rowid_lookup_key));
-    ++frag_list_idx;
-  };
-
-  fragment_descriptor.assignFragsToKernelDispatch(fragment_per_kernel_dispatch,
-                                                  ra_exe_unit);
-
   return execution_kernels;
 }
 

--- a/omniscidb/QueryEngine/Execute.h
+++ b/omniscidb/QueryEngine/Execute.h
@@ -485,29 +485,10 @@ class Executor : public StringDictionaryProxyProvider {
   std::unordered_map<int, const hdk::ir::BinOper*> getInnerTabIdToJoinCond() const;
 
   /**
-   * Determines execution dispatch mode and required fragments for a given query step,
-   * then creates kernels to execute the query and returns them for launch.
-   */
-  std::vector<std::unique_ptr<ExecutionKernel>> createKernels(
-      SharedKernelContext& shared_context,
-      const RelAlgExecutionUnit& ra_exe_unit,
-      ColumnFetcher& column_fetcher,
-      const std::vector<InputTableInfo>& table_infos,
-      const ExecutionOptions& eo,
-      const CompilationOptions& co,
-      const bool is_agg,
-      const bool allow_single_frag_table_opt,
-      const QueryCompilationDescriptor& query_comp_desc,
-      const QueryMemoryDescriptor& query_mem_desc,
-      policy::ExecutionPolicy* policy,
-      std::unordered_set<int>& available_gpus,
-      int& available_cpus);
-
-  /**
    * @brief Exprimental execution dispatch mode for heterogeneous kernel submission.
    *
    */
-  std::vector<std::unique_ptr<ExecutionKernel>> createHeterogeneousKernels(
+  std::vector<std::unique_ptr<ExecutionKernel>> createKernels(
       SharedKernelContext& shared_context,
       const RelAlgExecutionUnit& ra_exe_unit,
       ColumnFetcher& column_fetcher,

--- a/omniscidb/QueryEngine/Execute.h
+++ b/omniscidb/QueryEngine/Execute.h
@@ -473,6 +473,23 @@ class Executor : public StringDictionaryProxyProvider {
                                size_t& max_groups_buffer_entry_guess,
                                const ExecutionOptions& eo);
 
+  std::set<ExecutorDeviceType> getAvailableDeviceTypes() const;
+
+  std::set<ExecutorDeviceType> getDeviceTypesForQuery(
+      const RelAlgExecutionUnit& ra_exe_unit,
+      const std::vector<InputTableInfo>& table_infos,
+      const ExecutorDeviceType requested_dt,
+      size_t& max_groups_buffer_entry_guess,
+      const ExecutionOptions& eo);
+
+  std::unique_ptr<policy::ExecutionPolicy> getExecutionPolicy(
+      const bool is_agg,
+      const std::map<ExecutorDeviceType, std::unique_ptr<QueryMemoryDescriptor>>&
+          query_mem_descs,
+      const RelAlgExecutionUnit& ra_exe_unit,
+      const std::vector<InputTableInfo>& table_infos,
+      const ExecutionOptions& eo);
+
   hdk::ResultSetTable collectAllDeviceResults(
       SharedKernelContext& shared_context,
       const RelAlgExecutionUnit& ra_exe_unit,
@@ -495,15 +512,13 @@ class Executor : public StringDictionaryProxyProvider {
       const std::vector<InputTableInfo>& table_infos,
       const ExecutionOptions& eo,
       const CompilationOptions& co,
-      const bool is_agg,
       const bool allow_single_frag_table_opt,
       const std::map<ExecutorDeviceType, std::unique_ptr<QueryCompilationDescriptor>>&
           query_comp_descs,
       const std::map<ExecutorDeviceType, std::unique_ptr<QueryMemoryDescriptor>>&
           query_mem_descs,
-      policy::ExecutionPolicy* policy,
-      std::unordered_set<int>& available_gpus,
-      int& available_cpus);
+      const policy::ExecutionPolicy* policy,
+      const size_t device_count);
 
   /**
    * Launches execution kernels created by `createKernels` asynchronously using a thread

--- a/omniscidb/QueryEngine/RelAlgExecutor.cpp
+++ b/omniscidb/QueryEngine/RelAlgExecutor.cpp
@@ -432,7 +432,8 @@ std::shared_ptr<const ExecutionResult> RelAlgExecutor::execute(
     try {
       executeStep(seq.step(i), co, fixed_eo, queue_time_ms);
     } catch (const QueryMustRunOnCpu&) {
-      CHECK(co.device_type == ExecutorDeviceType::GPU);
+      CHECK(config_.exec.heterogeneous.enable_heterogeneous_execution ||
+            co.device_type == ExecutorDeviceType::GPU);
       if (!config_.exec.heterogeneous.allow_query_step_cpu_retry) {
         throw;
       }

--- a/omniscidb/Tests/ArrowBasedExecuteTest.cpp
+++ b/omniscidb/Tests/ArrowBasedExecuteTest.cpp
@@ -17740,6 +17740,7 @@ int main(int argc, char** argv) {
   auto config = std::make_shared<Config>();
 
   g_is_test_env = true;
+  bool should_run_heterogen{false};
 
   std::cout << "Starting ExecuteTest" << std::endl;
 
@@ -17819,6 +17820,10 @@ int main(int argc, char** argv) {
                          ->implicit_value(true),
                      "Materialize all inner tables for joins.");
   desc.add_options()(
+      "heterogen-test",
+      po::value<bool>(&should_run_heterogen)->default_value(false)->implicit_value(true),
+      "Perform test on GPU & CPU, split data 50/50.");
+  desc.add_options()(
       "test-help",
       "Print all ExecuteTest specific options (for gtest options use `--help`).");
 
@@ -17853,6 +17858,12 @@ int main(int argc, char** argv) {
   config->exec.enable_interop = false;
 
   init(config);
+  if (should_run_heterogen) {
+    config->exec.heterogeneous.enable_heterogeneous_execution = true;
+    config->exec.heterogeneous.forced_heterogeneous_distribution = true;
+    config->exec.heterogeneous.forced_gpu_proportion = 50;
+    config->exec.heterogeneous.forced_cpu_proportion = 50;
+  }
 
   int err{0};
   try {


### PR DESCRIPTION
This patch integrates the device multifragment policy (currently disabled) in its proper form for heterogeneous kernels, that is (depending on query):
- CPU: kernel per fragment
- GPU: kernel per N fragments

