### PR TITLE
Use explicit types in LLVM Loads

### DIFF
--- a/omniscidb/QueryEngine/ColumnIR.cpp
+++ b/omniscidb/QueryEngine/ColumnIR.cpp
@@ -277,7 +277,7 @@ llvm::Value* CodeGenerator::codegenRowId(const hdk::ir::ColumnVar* col_var,
         frag_off_ptr,
         cgen_state_->llInt(int32_t(col_var->rteIdx())));
     auto rowid_offset_lv = cgen_state_->ir_builder_.CreateLoad(
-        input_off_ptr->getType()->getPointerElementType(), input_off_ptr);
+        get_int_type(64, cgen_state_->context_), input_off_ptr);
     rowid_lv = cgen_state_->ir_builder_.CreateAdd(rowid_lv, rowid_offset_lv);
   }
   if (table_generation.start_rowid > 0) {
@@ -429,9 +429,8 @@ llvm::Value* CodeGenerator::posArg(const hdk::ir::Expr* expr) const {
     const auto hash_pos_it = cgen_state_->scan_idx_to_hash_pos_.find(col_var->rteIdx());
     CHECK(hash_pos_it != cgen_state_->scan_idx_to_hash_pos_.end());
     if (hash_pos_it->second->getType()->isPointerTy()) {
-      CHECK(hash_pos_it->second->getType()->getPointerElementType()->isIntegerTy(32));
       llvm::Value* result = cgen_state_->ir_builder_.CreateLoad(
-          hash_pos_it->second->getType()->getPointerElementType(), hash_pos_it->second);
+          get_int_type(32, cgen_state_->context_), hash_pos_it->second);
       result = cgen_state_->ir_builder_.CreateSExt(
           result, get_int_type(64, cgen_state_->context_));
       return result;

--- a/omniscidb/QueryEngine/Execute.cpp
+++ b/omniscidb/QueryEngine/Execute.cpp
@@ -3792,7 +3792,7 @@ void Executor::preloadFragOffsets(const std::vector<InputDescriptor>& input_desc
     } else {
       if (frag_count > 1) {
         cgen_state_->frag_offsets_.push_back(cgen_state_->ir_builder_.CreateLoad(
-            frag_off_ptr->getType()->getPointerElementType(), frag_off_ptr));
+            get_int_type(64, cgen_state_->context_), frag_off_ptr));
       } else {
         cgen_state_->frag_offsets_.push_back(nullptr);
       }

--- a/omniscidb/QueryEngine/IRCodegen.cpp
+++ b/omniscidb/QueryEngine/IRCodegen.cpp
@@ -659,11 +659,11 @@ std::vector<JoinLoop> Executor::buildJoinLoops(
             JoinLoopDomain domain{{0}};
             auto* arg = get_arg_by_name(cgen_state_->row_func_, "num_rows_per_scan");
             const auto rows_per_scan_ptr = cgen_state_->ir_builder_.CreateGEP(
-                arg->getType()->getScalarType()->getPointerElementType(),
+                get_int_type(64, cgen_state_->context_),
                 arg,
                 cgen_state_->llInt(int32_t(level_idx + 1)));
             domain.upper_bound = cgen_state_->ir_builder_.CreateLoad(
-                rows_per_scan_ptr->getType()->getPointerElementType(),
+                get_int_type(64, cgen_state_->context_),
                 rows_per_scan_ptr,
                 "num_rows_per_scan");
             return domain;
@@ -1274,8 +1274,7 @@ llvm::Value* Executor::arrayLoopCodegen(const hdk::ir::Expr* array_expr,
   cgen_state_->ir_builder_.CreateBr(array_loop_head);
   cgen_state_->ir_builder_.SetInsertPoint(array_loop_head);
   CHECK(array_len);
-  auto array_idx = cgen_state_->ir_builder_.CreateLoad(
-      array_idx_ptr->getType()->getPointerElementType(), array_idx_ptr);
+  auto array_idx = cgen_state_->ir_builder_.CreateLoad(ret_ty, array_idx_ptr);
   auto bound_check =
       cgen_state_->ir_builder_.CreateICmp(llvm::ICmpInst::ICMP_SLT, array_idx, array_len);
   auto array_loop_body = llvm::BasicBlock::Create(

--- a/omniscidb/QueryEngine/RowFuncBuilder.cpp
+++ b/omniscidb/QueryEngine/RowFuncBuilder.cpp
@@ -1364,7 +1364,7 @@ llvm::Value* RowFuncBuilder::getAdditionalLiteral(const int32_t off) {
       LL_BUILDER.CreateGEP(bit_cast->getType()->getScalarType()->getPointerElementType(),
                            bit_cast,
                            LL_INT(off));
-  return LL_BUILDER.CreateLoad(gep->getType()->getPointerElementType(), gep);
+  return LL_BUILDER.CreateLoad(get_int_type(64, LL_CONTEXT), gep);
 }
 
 std::vector<llvm::Value*> RowFuncBuilder::codegenAggArg(const hdk::ir::Expr* target_expr,

--- a/omniscidb/QueryEngine/ScalarCodeGenerator.cpp
+++ b/omniscidb/QueryEngine/ScalarCodeGenerator.cpp
@@ -116,8 +116,7 @@ ScalarCodeGenerator::CompiledExpression ScalarCodeGenerator::compile(
     std::vector<llvm::Value*> loaded_args = {wrapper_scalar_expr_func->arg_begin() + 1};
     for (size_t i = 2; i < wrapper_arg_types.size(); ++i) {
       auto* value = wrapper_scalar_expr_func->arg_begin() + i;
-      loaded_args.push_back(
-          b.CreateLoad(value->getType()->getPointerElementType(), value));
+      loaded_args.push_back(b.CreateLoad(arg_types[i - 1], value));
     }
     auto error_lv = b.CreateCall(scalar_expr_func, loaded_args);
     b.CreateStore(error_lv, wrapper_scalar_expr_func->arg_begin());

--- a/omniscidb/QueryEngine/WindowFunctionIR.cpp
+++ b/omniscidb/QueryEngine/WindowFunctionIR.cpp
@@ -345,7 +345,8 @@ llvm::Value* Executor::codegenAggregateWindowState(const CompilationOptions& co)
   }
   if (window_func->kind() == hdk::ir::WindowFunctionKind::Count) {
     return cgen_state_->ir_builder_.CreateLoad(
-        aggregate_state->getType()->getPointerElementType(), aggregate_state);
+        get_int_type(window_func_type->size() * 8, cgen_state_->context_),
+        aggregate_state);
   }
   if (window_func_type->isFp32()) {
     return cgen_state_->emitCall("load_float", {aggregate_state});
@@ -353,6 +354,7 @@ llvm::Value* Executor::codegenAggregateWindowState(const CompilationOptions& co)
     return cgen_state_->emitCall("load_double", {aggregate_state});
   } else {
     return cgen_state_->ir_builder_.CreateLoad(
-        aggregate_state->getType()->getPointerElementType(), aggregate_state);
+        get_int_type(window_func_type->size() * 8, cgen_state_->context_),
+        aggregate_state);
   }
 }


### PR DESCRIPTION
In preparation for switching to opaque pointers, remove pointer type accesses from various loads. 