### PR TITLE
Introduce per-thread memory pools for lock-free aloocations in quantile.

### DIFF
--- a/omniscidb/Shared/SimpleAllocator.h
+++ b/omniscidb/Shared/SimpleAllocator.h
@@ -22,4 +22,12 @@ class SimpleAllocator {
 
  public:
   virtual int8_t* allocate(const size_t num_bytes, const size_t thread_idx = 0) = 0;
+  // This allocation method is supposed to be used by execution kernels for allocating
+  // small memory batches. Callers are responsible for not using the same thread_idx
+  // values from different threads. This enables lock-free thread local memory pools
+  // usage for better performance. Implementations are likely to fallback to a regular
+  // allocation for big memory chunks and for thread indexes exceeding cpu_count().
+  virtual int8_t* allocateSmallMtNoLock(size_t size, size_t thread_idx = 0) {
+    return allocate(size);
+  }
 };


### PR DESCRIPTION
In this patch, I'm trying to improve memory allocations for quantile aggregate. Currently, memory is allocated through the `RowSetMemoryOwner::allocate` method that locks a mutex for each call.

In the proposed code I use `tbb::this_task_arena::current_thread_index` to identify the thread, then allocate 10MB chunk of memory for it and subsequent allocations go with no synchronization at all until we run out of memory for this thread.

Perf results are really flaky for this test. I use 1005 server and run H2O GroupBy Q6 query on the 5GB dataset, making 9 query runs in the same process. The main branch shows 0.65-1.0s result, and the median is 0.75. With the patch, I have 0.55-0.9s, and the median is 0.63. The profit is not as big as I hoped it would be, but this query actually computes multiple aggregates and has two execution steps, so the kernel's speed-up is more significant.

No synchronization at all on memory allocation is achieved by a guarantee from a caller that the same thead_idx isn't used by different threads. This is achieved by always running kernels through TBB on a single TBB task arena, but the code would break if we started using quantile out of TBB context or with multiple task arenas.

I can add mutexes to per-thread memory pools to make it much safer. Misuse of the per-thread allocation would then just cause slow cod rather than memory corruption. But this would reduce the gain of the patch roughly by half for the Q6.