### PR TITLE
Use opaque pointers

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,15 +31,15 @@ RUN apt-get update && apt-get install -y \
 # LLVM
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     apt-add-repository \
-        'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy main' && \
+        'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main' && \
     apt-get update && apt-get install -y \
-        llvm-15 \
-        llvm-15-dev \
-        clang-15 \
-        libclang-15-dev \
+        llvm-16 \
+        llvm-16-dev \
+        clang-16 \
+        libclang-16-dev \
         --
 
-ENV PATH=/usr/lib/llvm-15/bin${PATH:+:${PATH}}
+ENV PATH=/usr/lib/llvm-16/bin${PATH:+:${PATH}}
 
 # Dependencies
 RUN apt-get update && apt-get install -y \

--- a/docker/Dockerfile.l0
+++ b/docker/Dockerfile.l0
@@ -12,7 +12,7 @@ RUN mkdir /intel-gpu-drivers && cd /intel-gpu-drivers && \
 
 RUN cd /intel-gpu-drivers && dpkg -i *.deb
 
-RUN git clone -b llvm_release_150 https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git && \
+RUN git clone -b llvm_release_160 https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git && \
     mkdir SPIRV-LLVM-Translator/build && cd SPIRV-LLVM-Translator/build && \
     cmake -Wno-dev .. && make llvm-spirv -j`nproc` && make install
 

--- a/omniscidb/QueryEngine/ArrayIR.cpp
+++ b/omniscidb/QueryEngine/ArrayIR.cpp
@@ -142,9 +142,8 @@ std::vector<llvm::Value*> CodeGenerator::codegenArrayExpr(
         codegen_traits_desc.local_addr_space_) {
       allocated_target_buffer = ir_builder.CreateAddrSpaceCast(
           allocated_target_buffer,
-          llvm::PointerType::get(
-              allocated_target_buffer->getType()->getPointerElementType(),
-              co.codegen_traits_desc.local_addr_space_),
+          llvm::PointerType::get(cgen_state_->context_,
+                                 co.codegen_traits_desc.local_addr_space_),
           "allocated.target.buffer.cast");
     }
   } else {

--- a/omniscidb/QueryEngine/CMakeLists.txt
+++ b/omniscidb/QueryEngine/CMakeLists.txt
@@ -189,11 +189,6 @@ set(hdk_default_runtime_functions_module_dependencies
     GroupByRuntime.cpp
     TopKRuntime.cpp)
 
-list(APPEND DISABLE_OPAQUE_POINTERS_CMD "")
-if(${LLVM_PACKAGE_VERSION} VERSION_GREATER_EQUAL "15")
-    list(APPEND DISABLE_OPAQUE_POINTERS_CMD "-Xclang" "-no-opaque-pointers")
-endif()
-
 # Adds a custom command for producing llvm bitcode modules out of a .cpp source.
 # Any additional arguments are treated as clang args and bypassed as-is.
 function(precompile_llvm_module SOURCE_FILE SUFFIX)
@@ -204,7 +199,7 @@ function(precompile_llvm_module SOURCE_FILE SUFFIX)
         DEPENDS ${hdk_default_runtime_functions_module_dependencies} ${SOURCE_FILE}
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${result_module_name}
         COMMAND ${llvm_clangpp_cmd}
-        ARGS -std=c++17 ${RT_OPT_FLAGS} ${ARGN} -c -emit-llvm ${DISABLE_OPAQUE_POINTERS_CMD}
+        ARGS -std=c++17 ${RT_OPT_FLAGS} ${ARGN} -c -emit-llvm
         ${CLANG_SDK_INC} ${CLANG_CRT_INC} ${MAPD_DEFINITIONS} -DEXECUTE_INCLUDE
         -o ${CMAKE_CURRENT_BINARY_DIR}/${result_module_name}
         -I ${CMAKE_CURRENT_SOURCE_DIR}/../
@@ -281,7 +276,7 @@ add_custom_command(
         DEPENDS ExtensionFunctions.hpp ExtensionFunctionsArray.hpp ExtensionFunctionsTesting.hpp
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/ExtensionFunctions.ast.raw
         COMMAND ${llvm_clangpp_cmd}
-        ARGS -DNO_BOOST -std=c++17 -fsyntax-only -Xclang -ast-dump -fno-diagnostics-color -Wno-return-type-c-linkage ${DISABLE_OPAQUE_POINTERS_CMD}
+        ARGS -DNO_BOOST -std=c++17 -fsyntax-only -Xclang -ast-dump -fno-diagnostics-color -Wno-return-type-c-linkage
         -I ${CMAKE_CURRENT_SOURCE_DIR}/../ ${CMAKE_CURRENT_SOURCE_DIR}/ExtensionFunctions.hpp > ${CMAKE_CURRENT_BINARY_DIR}/ExtensionFunctions.ast.raw)
 
 add_custom_command(

--- a/omniscidb/QueryEngine/CgenState.h
+++ b/omniscidb/QueryEngine/CgenState.h
@@ -299,9 +299,7 @@ struct CgenState {
                         const std::vector<llvm::Value*>& args);
   llvm::Value* emitCall(const std::string& fname, const std::vector<llvm::Value*>& args);
 
-  size_t getLiteralBufferUsage(const int device_id) {
-    return literal_bytes_[device_id];
-  }
+  size_t getLiteralBufferUsage(const int device_id) { return literal_bytes_[device_id]; }
 
   llvm::Value* castToTypeIn(llvm::Value* val, const size_t bit_width);
 
@@ -328,9 +326,7 @@ struct CgenState {
         llvm::ConstantFP::get(llvm::Type::getDoubleTy(context_), v));
   }
 
-  llvm::ConstantInt* llBool(const bool v) const {
-    return ::ll_bool(v, context_);
-  }
+  llvm::ConstantInt* llBool(const bool v) const { return ::ll_bool(v, context_); }
 
   void emitErrorCheck(llvm::Value* condition, llvm::Value* errorCode, std::string label);
 

--- a/omniscidb/QueryEngine/ColumnIR.cpp
+++ b/omniscidb/QueryEngine/ColumnIR.cpp
@@ -273,7 +273,7 @@ llvm::Value* CodeGenerator::codegenRowId(const hdk::ir::ColumnVar* col_var,
   } else if (col_var->rteIdx() > 0) {
     auto frag_off_ptr = get_arg_by_name(cgen_state_->row_func_, "frag_row_off");
     auto input_off_ptr = cgen_state_->ir_builder_.CreateGEP(
-        frag_off_ptr->getType()->getScalarType()->getPointerElementType(),
+        get_int_type(64, cgen_state_->context_),
         frag_off_ptr,
         cgen_state_->llInt(int32_t(col_var->rteIdx())));
     auto rowid_offset_lv = cgen_state_->ir_builder_.CreateLoad(

--- a/omniscidb/QueryEngine/Compiler/Backend.h
+++ b/omniscidb/QueryEngine/Compiler/Backend.h
@@ -173,7 +173,6 @@ class CUDABackend : public Backend {
 
   static void linkModuleWithLibdevice(const std::unique_ptr<llvm::Module>& ext,
                                       llvm::Module& module,
-                                      llvm::PassManagerBuilder& pass_manager_builder,
                                       const GPUTarget& gpu_target,
                                       llvm::TargetMachine* nvptx_target_machine);
 

--- a/omniscidb/QueryEngine/Compiler/Backend.h
+++ b/omniscidb/QueryEngine/Compiler/Backend.h
@@ -87,6 +87,9 @@ class CodegenTraits {
   llvm::PointerType* localPointerType(llvm::Type* ElementType) const {
     return llvm::PointerType::get(ElementType, local_addr_space_);
   }
+  llvm::PointerType* localOpaquePtr(llvm::LLVMContext& ctx) const {
+    return llvm::PointerType::get(ctx, local_addr_space_);
+  }
   llvm::PointerType* smemPointerType(llvm::Type* ElementType) const {
     return llvm::PointerType::get(ElementType, smem_addr_space_);
   }

--- a/omniscidb/QueryEngine/Compiler/Backend.h
+++ b/omniscidb/QueryEngine/Compiler/Backend.h
@@ -96,6 +96,9 @@ class CodegenTraits {
   llvm::PointerType* globalPointerType(llvm::Type* ElementType) const {
     return llvm::PointerType::get(ElementType, global_addr_space_);
   }
+  llvm::PointerType* globalOpaquePtr(llvm::LLVMContext& ctx) const {
+    return llvm::PointerType::get(ctx, global_addr_space_);
+  }
   llvm::CallingConv::ID callingConv() const { return conv_; }
   llvm::StringRef dataLayout() const {
     return llvm::StringRef(

--- a/omniscidb/QueryEngine/Compiler/HelperFunctions.cpp
+++ b/omniscidb/QueryEngine/Compiler/HelperFunctions.cpp
@@ -55,7 +55,10 @@ namespace compiler {
 std::string mangle_spirv_builtin(const llvm::Function& func) {
   CHECK(func.getName().startswith("__spirv_")) << func.getName().str();
   std::string new_name;
-#if LLVM_VERSION_MAJOR > 14
+#if LLVM_VERSION_MAJOR > 15
+  llvm::mangleOpenClBuiltin(func.getName().str(), func.getArg(0)->getType(), new_name);
+
+#elif LLVM_VERSION_MAJOR > 14
   mangleOpenClBuiltin(
       func.getName().str(), func.getArg(0)->getType(), /*pointer_types=*/{}, new_name);
 #else

--- a/omniscidb/QueryEngine/ConstantIR.cpp
+++ b/omniscidb/QueryEngine/ConstantIR.cpp
@@ -61,7 +61,7 @@ std::vector<llvm::Value*> CodeGenerator::codegen(const hdk::ir::Constant* consta
         }
         return {cgen_state_->llInt(int64_t(0)),
                 llvm::Constant::getNullValue(
-                    cgen_traits.localPointerType(get_int_type(8, cgen_state_->context_))),
+                    cgen_traits.localOpaquePtr(cgen_state_->context_)),
                 cgen_state_->llInt(int32_t(0))};
       }
       const auto& str_const = *constant->value().stringval;
@@ -125,19 +125,15 @@ std::vector<llvm::Value*> CodeGenerator::codegenHoistedConstantsLoads(
   std::string literal_name = "literal_" + std::to_string(lit_off);
   auto lit_buff_query_func_lv = get_arg_by_name(cgen_state_->query_func_, "literals");
   const auto lit_buf_start = cgen_state_->query_func_entry_ir_builder_.CreateGEP(
-      lit_buff_query_func_lv->getType()->getPointerElementType(),
+      get_int_type(8, cgen_state_->context_),
       lit_buff_query_func_lv,
       cgen_state_->llInt(lit_off));
   if (type->isString() && !use_dict_encoding) {
     CHECK_EQ(size_t(4),
              CgenState::literalBytes(CgenState::LiteralValue(std::string(""))));
-    auto off_and_len_ptr = cgen_state_->query_func_entry_ir_builder_.CreateBitCast(
-        lit_buf_start,
-        llvm::PointerType::get(get_int_type(32, cgen_state_->context_),
-                               lit_buf_start->getType()->getPointerAddressSpace()));
     // packed offset + length, 16 bits each
     auto off_and_len = cgen_state_->query_func_entry_ir_builder_.CreateLoad(
-        off_and_len_ptr->getType()->getPointerElementType(), off_and_len_ptr);
+        get_int_type(32, cgen_state_->context_), lit_buf_start);
     auto off_lv = cgen_state_->query_func_entry_ir_builder_.CreateLShr(
         cgen_state_->query_func_entry_ir_builder_.CreateAnd(
             off_and_len, cgen_state_->llInt(int32_t(0xffff0000))),
@@ -147,9 +143,7 @@ std::vector<llvm::Value*> CodeGenerator::codegenHoistedConstantsLoads(
 
     auto var_start = cgen_state_->llInt(int64_t(0));
     auto var_start_address = cgen_state_->query_func_entry_ir_builder_.CreateGEP(
-        lit_buff_query_func_lv->getType()->getScalarType()->getPointerElementType(),
-        lit_buff_query_func_lv,
-        off_lv);
+        get_int_type(8, cgen_state_->context_), lit_buff_query_func_lv, off_lv);
     auto var_length = len_lv;
 
     var_start->setName(literal_name + "_start");
@@ -184,28 +178,19 @@ std::vector<llvm::Value*> CodeGenerator::codegenHoistedConstantsLoads(
     return {var_start_address, var_length};
   }
 
-  llvm::Type* val_ptr_type{nullptr};
+  llvm::Type* val_type{nullptr};
   const auto val_bits = get_bit_width(type);
   CHECK_EQ(size_t(0), val_bits % 8);
   if (type->isInteger() || type->isDecimal() || type->isDateTime() ||
       type->isInterval() || type->isString() || type->isBoolean()) {
-    val_ptr_type =
-        llvm::PointerType::get(llvm::IntegerType::get(cgen_state_->context_, val_bits),
-                               lit_buf_start->getType()->getPointerAddressSpace());
+    val_type = get_int_type(val_bits, cgen_state_->context_);
   } else {
     CHECK(type->isFloatingPoint());
-    val_ptr_type = (type->isFp32())
-                       ? llvm::Type::getFloatPtrTy(
-                             cgen_state_->context_,
-                             lit_buf_start->getType()->getPointerAddressSpace())
-                       : llvm::Type::getDoublePtrTy(
-                             cgen_state_->context_,
-                             lit_buf_start->getType()->getPointerAddressSpace());
+    val_type = (type->isFp32()) ? get_fp_type(32, cgen_state_->context_)
+                                : get_fp_type(64, cgen_state_->context_);
   }
-  auto* bit_cast = cgen_state_->query_func_entry_ir_builder_.CreateBitCast(lit_buf_start,
-                                                                           val_ptr_type);
-  auto lit_lv = cgen_state_->query_func_entry_ir_builder_.CreateLoad(
-      bit_cast->getType()->getPointerElementType(), bit_cast);
+  auto lit_lv =
+      cgen_state_->query_func_entry_ir_builder_.CreateLoad(val_type, lit_buf_start);
   lit_lv->setName(literal_name);
   return {lit_lv};
 }
@@ -226,30 +211,20 @@ std::vector<llvm::Value*> CodeGenerator::codegenHoistedConstantsPlaceholders(
     llvm::Value* var_start = literal_loads[0];
     llvm::Value* var_start_address = literal_loads[1];
     llvm::Value* var_length = literal_loads[2];
-    llvm::PointerType* placeholder0_type =
-        cgen_traits.localPointerType(var_start->getType());
-    auto* int_to_ptr0 =
-        cgen_state_->ir_builder_.CreateIntToPtr(cgen_state_->llInt(0), placeholder0_type);
+    auto int_to_ptr0 = cgen_state_->ir_builder_.CreateIntToPtr(
+        cgen_state_->llInt(0), cgen_traits.localOpaquePtr(cgen_state_->context_));
     auto placeholder0 = cgen_state_->ir_builder_.CreateLoad(
-        int_to_ptr0->getType()->getPointerElementType(),
-        int_to_ptr0,
-        "__placeholder__" + literal_name + "_start");
-    llvm::PointerType* placeholder1_type =
-        cgen_traits.localPointerType(var_start_address->getType());
-    auto* int_to_ptr1 =
-        cgen_state_->ir_builder_.CreateIntToPtr(cgen_state_->llInt(0), placeholder1_type);
+        var_start->getType(), int_to_ptr0, "__placeholder__" + literal_name + "_start");
+    auto int_to_ptr1 = cgen_state_->ir_builder_.CreateIntToPtr(
+        cgen_state_->llInt(0), cgen_traits.localOpaquePtr(cgen_state_->context_));
     auto placeholder1 = cgen_state_->ir_builder_.CreateLoad(
-        int_to_ptr1->getType()->getPointerElementType(),
+        var_start_address->getType(),
         int_to_ptr1,
         "__placeholder__" + literal_name + "_start_address");
-    llvm::PointerType* placeholder2_type =
-        cgen_traits.localPointerType(var_length->getType());
-    auto* int_to_ptr2 =
-        cgen_state_->ir_builder_.CreateIntToPtr(cgen_state_->llInt(0), placeholder2_type);
+    auto int_to_ptr2 = cgen_state_->ir_builder_.CreateIntToPtr(
+        cgen_state_->llInt(0), cgen_traits.localOpaquePtr(cgen_state_->context_));
     auto placeholder2 = cgen_state_->ir_builder_.CreateLoad(
-        int_to_ptr2->getType()->getPointerElementType(),
-        int_to_ptr2,
-        "__placeholder__" + literal_name + "_length");
+        var_length->getType(), int_to_ptr2, "__placeholder__" + literal_name + "_length");
 
     cgen_state_->row_func_hoisted_literals_[placeholder0] = {lit_off, 0};
     cgen_state_->row_func_hoisted_literals_[placeholder1] = {lit_off, 1};
@@ -264,22 +239,16 @@ std::vector<llvm::Value*> CodeGenerator::codegenHoistedConstantsPlaceholders(
     llvm::Value* var_start_address = literal_loads[0];
     llvm::Value* var_length = literal_loads[1];
 
-    llvm::PointerType* placeholder0_type =
-        cgen_traits.localPointerType(var_start_address->getType());
-    auto* int_to_ptr0 =
-        cgen_state_->ir_builder_.CreateIntToPtr(cgen_state_->llInt(0), placeholder0_type);
+    auto* int_to_ptr0 = cgen_state_->ir_builder_.CreateIntToPtr(
+        cgen_state_->llInt(0), cgen_traits.localOpaquePtr(cgen_state_->context_));
     auto placeholder0 = cgen_state_->ir_builder_.CreateLoad(
-        int_to_ptr0->getType()->getPointerElementType(),
+        var_start_address->getType(),
         int_to_ptr0,
         "__placeholder__" + literal_name + "_start_address");
-    llvm::PointerType* placeholder1_type =
-        cgen_traits.localPointerType(var_length->getType());
-    auto* int_to_ptr1 =
-        cgen_state_->ir_builder_.CreateIntToPtr(cgen_state_->llInt(0), placeholder1_type);
+    auto* int_to_ptr1 = cgen_state_->ir_builder_.CreateIntToPtr(
+        cgen_state_->llInt(0), cgen_traits.localOpaquePtr(cgen_state_->context_));
     auto placeholder1 = cgen_state_->ir_builder_.CreateLoad(
-        int_to_ptr1->getType()->getPointerElementType(),
-        int_to_ptr1,
-        "__placeholder__" + literal_name + "_length");
+        var_length->getType(), int_to_ptr1, "__placeholder__" + literal_name + "_length");
 
     cgen_state_->row_func_hoisted_literals_[placeholder0] = {lit_off, 0};
     cgen_state_->row_func_hoisted_literals_[placeholder1] = {lit_off, 1};
@@ -291,11 +260,9 @@ std::vector<llvm::Value*> CodeGenerator::codegenHoistedConstantsPlaceholders(
   llvm::Value* to_return_lv = literal_loads[0];
 
   auto* int_to_ptr = cgen_state_->ir_builder_.CreateIntToPtr(
-      cgen_state_->llInt(0), cgen_traits.localPointerType(to_return_lv->getType()));
-  auto placeholder0 =
-      cgen_state_->ir_builder_.CreateLoad(int_to_ptr->getType()->getPointerElementType(),
-                                          int_to_ptr,
-                                          "__placeholder__" + literal_name);
+      cgen_state_->llInt(0), cgen_traits.localOpaquePtr(cgen_state_->context_));
+  auto placeholder0 = cgen_state_->ir_builder_.CreateLoad(
+      to_return_lv->getType(), int_to_ptr, "__placeholder__" + literal_name);
 
   cgen_state_->row_func_hoisted_literals_[placeholder0] = {lit_off, 0};
 

--- a/omniscidb/QueryEngine/DynamicWatchdog.cpp
+++ b/omniscidb/QueryEngine/DynamicWatchdog.cpp
@@ -40,7 +40,9 @@ extern "C" RUNTIME_EXPORT uint64_t dynamic_watchdog_init(unsigned ms_budget) {
 
   if (ms_budget == static_cast<unsigned>(DW_DEADLINE)) {
     if (dw_abort.load()) {
-      { return 0LL; }
+      {
+        return 0LL;
+      }
     }
     return dw_cycle_start + dw_cycle_budget;
   }

--- a/omniscidb/QueryEngine/Execute.cpp
+++ b/omniscidb/QueryEngine/Execute.cpp
@@ -156,11 +156,6 @@ Executor::Executor(const ExecutorId executor_id,
     , temporary_tables_(nullptr)
     , input_table_info_cache_(this)
     , thread_id_(logger::thread_id()) {
-#if LLVM_VERSION_MAJOR > 14
-  // temporarily disable opaque pointers
-  context_->setOpaquePointers(false);
-#endif
-
   if (executor_id_ > INVALID_EXECUTOR_ID - 1) {
     throw std::runtime_error("Too many executors!");
   }

--- a/omniscidb/QueryEngine/Execute.cpp
+++ b/omniscidb/QueryEngine/Execute.cpp
@@ -3789,33 +3789,6 @@ llvm::Value* Executor::castToFP(llvm::Value* value,
   return value;
 }
 
-llvm::Value* Executor::castToIntPtrTyIn(llvm::Value* val, const size_t bitWidth) {
-  AUTOMATIC_IR_METADATA(cgen_state_.get());
-  CHECK(val->getType()->isPointerTy());
-
-  const auto val_ptr_type = static_cast<llvm::PointerType*>(val->getType());
-  const auto val_type = val_ptr_type->getPointerElementType();
-  size_t val_width = 0;
-  if (val_type->isIntegerTy()) {
-    val_width = val_type->getIntegerBitWidth();
-  } else {
-    if (val_type->isFloatTy()) {
-      val_width = 32;
-    } else {
-      CHECK(val_type->isDoubleTy());
-      val_width = 64;
-    }
-  }
-  CHECK_LT(size_t(0), val_width);
-  if (bitWidth == val_width) {
-    return val;
-  }
-  return cgen_state_->ir_builder_.CreateBitCast(
-      val,
-      llvm::PointerType::get(get_int_type(bitWidth, cgen_state_->context_),
-                             val->getType()->getPointerAddressSpace()));
-}
-
 #define EXECUTE_INCLUDE
 #include "ArrayOps.cpp"
 #include "DateAdd.cpp"

--- a/omniscidb/QueryEngine/Execute.h
+++ b/omniscidb/QueryEngine/Execute.h
@@ -825,7 +825,6 @@ class Executor : public StringDictionaryProxyProvider {
   llvm::Value* castToFP(llvm::Value*,
                         const hdk::ir::Type* from_type,
                         const hdk::ir::Type* to_type);
-  llvm::Value* castToIntPtrTyIn(llvm::Value* val, const size_t bit_width);
 
   FragmentSkipStatus canSkipFragmentForFpQual(const hdk::ir::BinOper* comp_expr,
                                               const hdk::ir::ColumnVar* lhs_col,

--- a/omniscidb/QueryEngine/ExtensionsIR.cpp
+++ b/omniscidb/QueryEngine/ExtensionsIR.cpp
@@ -346,7 +346,7 @@ llvm::Value* CodeGenerator::codegenFunctionOper(
         codegen_traits_desc.local_addr_space_) {
       buffer_ret = cgen_state_->ir_builder_.CreateAddrSpaceCast(
           buffer_ret,
-          llvm::PointerType::get(buffer_ret->getType()->getPointerElementType(),
+          llvm::PointerType::get(cgen_state_->context_,
                                  codegen_traits_desc.local_addr_space_),
           "buffer.ret.cast");
     }
@@ -411,7 +411,7 @@ CodeGenerator::beginArgsNullcheck(const hdk::ir::FunctionOper* function_oper,
           codegen_traits_desc.local_addr_space_) {
         null_array_alloca = cgen_state_->ir_builder_.CreateAddrSpaceCast(
             null_array_alloca,
-            llvm::PointerType::get(null_array_alloca->getType()->getPointerElementType(),
+            llvm::PointerType::get(cgen_state_->context_,
                                    codegen_traits_desc.local_addr_space_),
             "null.array.alloca.cast");
       }

--- a/omniscidb/QueryEngine/GpuSharedMemoryUtils.cpp
+++ b/omniscidb/QueryEngine/GpuSharedMemoryUtils.cpp
@@ -225,43 +225,6 @@ void GpuSharedMemCodeBuilder::codegenReduction(const CompilationOptions& co) {
   llvm::ReturnInst::Create(context_, bb_exit);
 }
 
-namespace {
-// given a particular destination ptr to the beginning of an entry, this function creates
-// proper cast for a specific slot index.
-// it also assumes these pointers are within shared memory address space (3)
-llvm::Value* codegen_smem_dest_slot_ptr(llvm::LLVMContext& context,
-                                        const QueryMemoryDescriptor& query_mem_desc,
-                                        llvm::IRBuilder<>& ir_builder,
-                                        const size_t slot_idx,
-                                        const TargetInfo& target_info,
-                                        const compiler::CodegenTraits& traits,
-                                        llvm::Value* dest_byte_stream,
-                                        llvm::Value* byte_offset) {
-  const auto type = get_compact_type(target_info);
-  const auto slot_bytes = query_mem_desc.getPaddedSlotWidthBytes(slot_idx);
-  auto ptr_type = [&context, &traits](const size_t slot_bytes,
-                                      const hdk::ir::Type* type) {
-    if (slot_bytes == sizeof(int32_t)) {
-      return traits.smemPointerType(llvm::Type::getInt32Ty(context));
-    } else {
-      CHECK(slot_bytes == sizeof(int64_t));
-      return traits.smemPointerType(llvm::Type::getInt64Ty(context));
-    }
-    UNREACHABLE() << "Invalid slot size encountered: " << std::to_string(slot_bytes);
-    return traits.smemPointerType(llvm::Type::getInt32Ty(context));
-  };
-
-  const auto casted_dest_slot_address = ir_builder.CreatePointerCast(
-      ir_builder.CreateGEP(
-          dest_byte_stream->getType()->getScalarType()->getPointerElementType(),
-          dest_byte_stream,
-          byte_offset),
-      ptr_type(slot_bytes, type),
-      "dest_slot_adr_" + std::to_string(slot_idx));
-  return casted_dest_slot_address;
-}
-}  // namespace
-
 /**
  * This function generates code to initialize the shared memory buffer, the way we
  * initialize the group by output buffer on the host. Similar to the reduction function,
@@ -318,14 +281,8 @@ void GpuSharedMemCodeBuilder::codegenInitialization() {
          slot_idx++) {
       const auto slot_size = fixup_query_mem_desc.getPaddedSlotWidthBytes(slot_idx);
 
-      auto casted_dest_slot_address = codegen_smem_dest_slot_ptr(context_,
-                                                                 fixup_query_mem_desc,
-                                                                 ir_builder,
-                                                                 slot_idx,
-                                                                 target_info,
-                                                                 traits_,
-                                                                 dest_byte_stream,
-                                                                 byte_offset_ll);
+      auto casted_dest_slot_address = ir_builder.CreateGEP(
+          get_int_type(8, context_), dest_byte_stream, byte_offset_ll);
 
       llvm::Value* init_value_ll = nullptr;
       if (slot_size == sizeof(int32_t)) {

--- a/omniscidb/QueryEngine/IRCodegen.cpp
+++ b/omniscidb/QueryEngine/IRCodegen.cpp
@@ -1252,7 +1252,7 @@ llvm::Value* Executor::arrayLoopCodegen(const hdk::ir::Expr* array_expr,
       co.codegen_traits_desc.local_addr_space_) {
     array_idx_ptr = cgen_state_->ir_builder_.CreateAddrSpaceCast(
         array_idx_ptr,
-        llvm::PointerType::get(array_idx_ptr->getType()->getPointerElementType(),
+        llvm::PointerType::get(cgen_state_->context_,
                                co.codegen_traits_desc.local_addr_space_),
         "array.idx.ptrcast");
   }

--- a/omniscidb/QueryEngine/LoopControlFlow/JoinLoop.cpp
+++ b/omniscidb/QueryEngine/LoopControlFlow/JoinLoop.cpp
@@ -95,9 +95,7 @@ llvm::BasicBlock* JoinLoop::codegen(
             co.codegen_traits_desc.local_addr_space_) {
           iteration_counter_ptr = builder.CreateAddrSpaceCast(
               iteration_counter_ptr,
-              llvm::PointerType::get(
-                  iteration_counter_ptr->getType()->getPointerElementType(),
-                  co.codegen_traits_desc.local_addr_space_),
+              llvm::PointerType::get(context, co.codegen_traits_desc.local_addr_space_),
               "iteration.counter.ptr.cast");
         }
         llvm::Value* found_an_outer_match_ptr{nullptr};
@@ -109,9 +107,7 @@ llvm::BasicBlock* JoinLoop::codegen(
               co.codegen_traits_desc.local_addr_space_) {
             found_an_outer_match_ptr = builder.CreateAddrSpaceCast(
                 found_an_outer_match_ptr,
-                llvm::PointerType::get(
-                    found_an_outer_match_ptr->getType()->getPointerElementType(),
-                    co.codegen_traits_desc.local_addr_space_),
+                llvm::PointerType::get(context, co.codegen_traits_desc.local_addr_space_),
                 "found.an.outer.match.ptr.cast");
           }
           builder.CreateStore(ll_bool(false, context), found_an_outer_match_ptr);
@@ -121,9 +117,7 @@ llvm::BasicBlock* JoinLoop::codegen(
               co.codegen_traits_desc.local_addr_space_) {
             current_condition_match_ptr = builder.CreateAddrSpaceCast(
                 current_condition_match_ptr,
-                llvm::PointerType::get(
-                    current_condition_match_ptr->getType()->getPointerElementType(),
-                    co.codegen_traits_desc.local_addr_space_),
+                llvm::PointerType::get(context, co.codegen_traits_desc.local_addr_space_),
                 "current.condition.match.ptr.cast");
           }
         }

--- a/omniscidb/QueryEngine/LoopControlFlow/JoinLoop.cpp
+++ b/omniscidb/QueryEngine/LoopControlFlow/JoinLoop.cpp
@@ -146,20 +146,18 @@ llvm::BasicBlock* JoinLoop::codegen(
           CHECK(iteration_domain.values_buffer->getType()->isPointerTy());
           const auto ptr_type =
               static_cast<llvm::PointerType*>(iteration_domain.values_buffer->getType());
-          if (ptr_type->getPointerElementType()->isArrayTy()) {
+          if (iteration_domain.values_buffer_is_array) {
             iteration_val = builder.CreateGEP(
                 iteration_domain.values_buffer->getType()
                     ->getScalarType()
                     ->getPointerElementType(),
                 iteration_domain.values_buffer,
                 std::vector<llvm::Value*>{
-                    llvm::ConstantInt::get(get_int_type(64, context), 0),
+                    llvm::ConstantInt::get(get_int_type(32, context), 0),
                     iteration_counter},
                 "ub_iter_counter_" + join_loop.name_);
           } else {
-            iteration_val = builder.CreateGEP(iteration_domain.values_buffer->getType()
-                                                  ->getScalarType()
-                                                  ->getPointerElementType(),
+            iteration_val = builder.CreateGEP(get_int_type(32, context),
                                               iteration_domain.values_buffer,
                                               iteration_counter,
                                               "ub_iter_counter_" + join_loop.name_);

--- a/omniscidb/QueryEngine/LoopControlFlow/JoinLoop.h
+++ b/omniscidb/QueryEngine/LoopControlFlow/JoinLoop.h
@@ -47,6 +47,7 @@ struct JoinLoopDomain {
     llvm::Value* slot_lookup_result;  // for Singleton
   };
   llvm::Value* values_buffer;  // used for Set
+  bool values_buffer_is_array{false};
 };
 
 // Any join is logically a loop. Hash joins just limit the domain of iteration,

--- a/omniscidb/QueryEngine/NativeCodegen.cpp
+++ b/omniscidb/QueryEngine/NativeCodegen.cpp
@@ -1100,7 +1100,7 @@ void Executor::createErrorCheckControlFlow(
           error_code_arg_val = ir_builder.CreateAddrSpaceCast(
               error_code_arg,
               llvm::PointerType::get(
-                  error_code_arg->getType()->getPointerElementType(),
+                  cgen_state_->context_,
                   record_error_code_func->getArg(1)->getType()->getPointerAddressSpace()),
               "checkflow.error.cast");
         }
@@ -1945,7 +1945,7 @@ bool Executor::compileBody(const RelAlgExecutionUnit& ra_exe_unit,
           co.codegen_traits_desc.local_addr_space_) {
         loop_done = cgen_state_->ir_builder_.CreateAddrSpaceCast(
             loop_done,
-            llvm::PointerType::get(loop_done->getType()->getPointerElementType(),
+            llvm::PointerType::get(cgen_state_->context_,
                                    co.codegen_traits_desc.local_addr_space_),
             "loop.done.cast");
       }

--- a/omniscidb/QueryEngine/NativeCodegen.cpp
+++ b/omniscidb/QueryEngine/NativeCodegen.cpp
@@ -2043,12 +2043,12 @@ std::vector<llvm::Value*> generate_column_heads_load(const int num_columns,
 
   std::vector<llvm::Value*> col_heads;
   for (int col_id = 0; col_id <= max_col_local_id; ++col_id) {
-    auto* gep = ir_builder.CreateGEP(
-        byte_stream_arg->getType()->getScalarType()->getPointerElementType(),
+    auto gep = llvm::dyn_cast<llvm::GEPOperator>(ir_builder.CreateGEP(
+        llvm::PointerType::get(ctx, byte_stream_arg->getType()->getPointerAddressSpace()),
         byte_stream_arg,
-        llvm::ConstantInt::get(llvm::Type::getInt32Ty(ctx), col_id));
-    col_heads.emplace_back(
-        ir_builder.CreateLoad(gep->getType()->getPointerElementType(), gep));
+        llvm::ConstantInt::get(llvm::Type::getInt32Ty(ctx), col_id)));
+    CHECK(gep);
+    col_heads.emplace_back(ir_builder.CreateLoad(gep->getSourceElementType(), gep));
   }
   return col_heads;
 }

--- a/omniscidb/QueryEngine/NativeCodegen.cpp
+++ b/omniscidb/QueryEngine/NativeCodegen.cpp
@@ -553,47 +553,47 @@ void set_row_func_argnames(llvm::Function* row_func,
 
   if (agg_col_count) {
     for (size_t i = 0; i < agg_col_count; ++i) {
-      arg_it->setName("out");
+      arg_it->setName("out");  // i64*
       ++arg_it;
     }
   } else {
-    arg_it->setName("group_by_buff");
+    arg_it->setName("group_by_buff");  // i64*
     ++arg_it;
-    arg_it->setName("varlen_output_buff");
+    arg_it->setName("varlen_output_buff");  // i64*
     ++arg_it;
-    arg_it->setName("crt_matched");
+    arg_it->setName("crt_matched");  // i32*
     ++arg_it;
-    arg_it->setName("total_matched");
+    arg_it->setName("total_matched");  // i32*
     ++arg_it;
-    arg_it->setName("old_total_matched");
+    arg_it->setName("old_total_matched");  // i32*
     ++arg_it;
-    arg_it->setName("max_matched");
+    arg_it->setName("max_matched");  // i32
     ++arg_it;
   }
 
-  arg_it->setName("agg_init_val");
+  arg_it->setName("agg_init_val");  // i64*
   ++arg_it;
 
-  arg_it->setName("pos");
+  arg_it->setName("pos");  // i64
   ++arg_it;
 
-  arg_it->setName("frag_row_off");
+  arg_it->setName("frag_row_off");  // i64*
   ++arg_it;
 
-  arg_it->setName("num_rows_per_scan");
+  arg_it->setName("num_rows_per_scan");  // i64*
   ++arg_it;
 
   if (hoist_literals) {
-    arg_it->setName("literals");
+    arg_it->setName("literals");  // i8*
     ++arg_it;
   }
 
   for (size_t i = 0; i < in_col_count; ++i) {
-    arg_it->setName("col_buf" + std::to_string(i));
+    arg_it->setName("col_buf" + std::to_string(i));  // i8*
     ++arg_it;
   }
 
-  arg_it->setName("join_hash_tables");
+  arg_it->setName("join_hash_tables");  // i64*
 }
 
 llvm::Function* create_row_function(const size_t in_col_count,

--- a/omniscidb/QueryEngine/Optimization/AnnotateInternalFunctionsPass.h
+++ b/omniscidb/QueryEngine/Optimization/AnnotateInternalFunctionsPass.h
@@ -65,7 +65,13 @@ class AnnotateInternalFunctionsPass
           fcn->addFnAttr(attr);
         }
       } else if (isReadOnlyFunction(fcn->getName())) {
-        fcn->addFnAttr(llvm::Attribute::ReadOnly);
+        for (size_t i = 0; i < fcn->arg_size(); i++) {
+          const auto arg = fcn->getArg(i);
+          CHECK(arg);
+          if (arg->getType()->isPointerTy()) {
+            fcn->addParamAttr(i, llvm::Attribute::ReadOnly);
+          }
+        }
       }
     }
 

--- a/omniscidb/QueryEngine/QueryTemplateGenerator.cpp
+++ b/omniscidb/QueryEngine/QueryTemplateGenerator.cpp
@@ -1002,10 +1002,12 @@ class NonGroupedQueryTemplateGenerator : public QueryTemplateGenerator {
         auto col_idx = llvm::ConstantInt::get(i32_type, i);
         if (gpu_smem_context.isSharedMemoryUsed()) {
           auto target_addr = llvm::GetElementPtrInst::CreateInBounds(
-              smem_output_buffer->getType()->getPointerElementType(),
+              llvm::PointerType::get(
+                  mod->getContext(),
+                  smem_output_buffer->getType()->getPointerAddressSpace()),
               smem_output_buffer,
               col_idx,
-              "",
+              "smem_output_buffer_ptr",
               bb_exit);
           // TODO: generalize this once we want to support other types of aggregate
           // functions besides COUNT.

--- a/omniscidb/QueryEngine/QueryTemplateGenerator.cpp
+++ b/omniscidb/QueryEngine/QueryTemplateGenerator.cpp
@@ -32,15 +32,6 @@
 
 namespace {
 
-inline llvm::Type* get_pointer_element_type(llvm::Value* value) {
-  CHECK(value);
-  auto type = value->getType();
-  CHECK(type && type->isPointerTy());
-  auto pointer_type = llvm::dyn_cast<llvm::PointerType>(type);
-  CHECK(pointer_type);
-  return pointer_type->getPointerElementType();
-}
-
 template <class Attributes>
 llvm::Function* default_func_builder(llvm::Module* mod, const std::string& name) {
   using namespace llvm;
@@ -380,29 +371,29 @@ class QueryTemplateGenerator {
     query_func_ptr->setAttributes(query_func_pal);
 
     llvm::Function::arg_iterator query_arg_it = query_func_ptr->arg_begin();
-    byte_stream = &*query_arg_it;
+    byte_stream = &*query_arg_it;  // i8**
     byte_stream->setName("byte_stream");
     if (hoist_literals) {
-      literals = &*(++query_arg_it);
+      literals = &*(++query_arg_it);  // i8*
       literals->setName("literals");
     }
-    row_count_ptr = &*(++query_arg_it);
+    row_count_ptr = &*(++query_arg_it);  // i64*
     row_count_ptr->setName("row_count_ptr");
-    frag_row_off_ptr = &*(++query_arg_it);
+    frag_row_off_ptr = &*(++query_arg_it);  // i64*
     frag_row_off_ptr->setName("frag_row_off_ptr");
-    max_matched_ptr = &*(++query_arg_it);
+    max_matched_ptr = &*(++query_arg_it);  // i32*
     max_matched_ptr->setName("max_matched_ptr");
-    agg_init_val = &*(++query_arg_it);
+    agg_init_val = &*(++query_arg_it);  // i64*
     agg_init_val->setName("agg_init_val");
-    output_buffers = &*(++query_arg_it);
+    output_buffers = &*(++query_arg_it);  // i64**
     output_buffers->setName("result_buffers");
-    frag_idx = &*(++query_arg_it);
+    frag_idx = &*(++query_arg_it);  // i32
     frag_idx->setName("frag_idx");
-    join_hash_tables = &*(++query_arg_it);
+    join_hash_tables = &*(++query_arg_it);  // i64*
     join_hash_tables->setName("join_hash_tables");
-    total_matched = &*(++query_arg_it);
+    total_matched = &*(++query_arg_it);  // i32*
     total_matched->setName("total_matched");
-    error_code = &*(++query_arg_it);
+    error_code = &*(++query_arg_it);  // i32*
     error_code->setName("error_code");
 
     bb_entry = llvm::BasicBlock::Create(mod->getContext(), ".entry", query_func_ptr, 0);
@@ -417,7 +408,7 @@ class QueryTemplateGenerator {
 
   virtual void generateEntryBlock() {
     CHECK(!row_count);
-    row_count = new llvm::LoadInst(get_pointer_element_type(row_count_ptr),
+    row_count = new llvm::LoadInst(get_int_type(64, mod->getContext()),
                                    row_count_ptr,
                                    "row_count",
                                    false,
@@ -559,7 +550,7 @@ class GroupByQueryTemplateGenerator : public QueryTemplateGenerator {
 
     CHECK(row_func_call_args && !row_func_call_args->max_matched);
     row_func_call_args->max_matched =
-        new llvm::LoadInst(get_pointer_element_type(max_matched_ptr),
+        new llvm::LoadInst(get_int_type(32, mod->getContext()),
                            max_matched_ptr,
                            "max_matched",
                            false,
@@ -613,22 +604,19 @@ class GroupByQueryTemplateGenerator : public QueryTemplateGenerator {
     group_buff_idx_call->setAttributes(group_buff_idx_pal);
     llvm::Value* group_buff_idx = group_buff_idx_call;
 
-    const llvm::PointerType* Ty =
-        llvm::dyn_cast<llvm::PointerType>(output_buffers->getType());
-    CHECK(Ty);
-
     CHECK(row_func_call_args && !row_func_call_args->varlen_output_buffer);
     if (query_mem_desc.hasVarlenOutput()) {
       // make the varlen buffer the _first_ 8 byte value in the group by buffers double
       // ptr, and offset the group by buffers index by 8 bytes
       auto varlen_output_buffer_gep = llvm::GetElementPtrInst::Create(
-          Ty->getPointerElementType(),
+          llvm::PointerType::get(mod->getContext(),
+                                 output_buffers->getType()->getPointerAddressSpace()),
           output_buffers,
           llvm::ConstantInt::get(llvm::Type::getInt32Ty(mod->getContext()), 0),
-          "",
+          "varlen_output_buffers_array_ptr",
           bb_entry);
       row_func_call_args->varlen_output_buffer =
-          new llvm::LoadInst(get_pointer_element_type(varlen_output_buffer_gep),
+          new llvm::LoadInst(varlen_output_buffer_gep->getSourceElementType(),
                              varlen_output_buffer_gep,
                              "varlen_output_buffer",
                              false,
@@ -649,8 +637,13 @@ class GroupByQueryTemplateGenerator : public QueryTemplateGenerator {
     CHECK(!pos_start_i64);
     pos_start_i64 = new llvm::SExtInst(pos_start, i64_type, "pos_start_i64", bb_entry);
     llvm::GetElementPtrInst* group_by_buffers_gep = llvm::GetElementPtrInst::Create(
-        Ty->getPointerElementType(), output_buffers, group_buff_idx, "", bb_entry);
-    col_buffer = new llvm::LoadInst(get_pointer_element_type(group_by_buffers_gep),
+        llvm::PointerType::get(mod->getContext(),
+                               output_buffers->getType()->getPointerAddressSpace()),
+        output_buffers,
+        group_buff_idx,
+        "group_by_buffers_array_ptr",
+        bb_entry);
+    col_buffer = new llvm::LoadInst(group_by_buffers_gep->getSourceElementType(),
                                     group_by_buffers_gep,
                                     "col_buffer",
                                     false,
@@ -727,7 +720,7 @@ class GroupByQueryTemplateGenerator : public QueryTemplateGenerator {
     llvm::ICmpInst* loop_or_exit = new llvm::ICmpInst(
         *bb_forbody, llvm::ICmpInst::ICMP_SLT, pos_inc, row_count, "loop_or_exit");
     if (check_scan_limit) {
-      auto crt_matched = new llvm::LoadInst(get_pointer_element_type(crt_matched_ptr),
+      auto crt_matched = new llvm::LoadInst(get_int_type(32, mod->getContext()),
                                             crt_matched_ptr,
                                             "crt_matched",
                                             false,
@@ -735,12 +728,12 @@ class GroupByQueryTemplateGenerator : public QueryTemplateGenerator {
       auto filter_match = llvm::BasicBlock::Create(
           mod->getContext(), "filter_match", query_func_ptr, bb_crit_edge);
       CHECK(row_func_call_args && row_func_call_args->old_total_matched_ptr);
-      llvm::Value* new_total_matched = new llvm::LoadInst(
-          get_pointer_element_type(row_func_call_args->old_total_matched_ptr),
-          row_func_call_args->old_total_matched_ptr,
-          "old_total_matched",
-          false,
-          filter_match);
+      llvm::Value* new_total_matched =
+          new llvm::LoadInst(get_int_type(32, mod->getContext()),
+                             row_func_call_args->old_total_matched_ptr,
+                             "old_total_matched",
+                             false,
+                             filter_match);
       new_total_matched = llvm::BinaryOperator::CreateAdd(
           new_total_matched, crt_matched, "new_total_matched", filter_match);
       CHECK(new_total_matched);
@@ -878,14 +871,14 @@ class NonGroupedQueryTemplateGenerator : public QueryTemplateGenerator {
 
       for (size_t i = 0; i < aggr_col_count; ++i) {
         auto idx_lv = llvm::ConstantInt::get(i32_type, i);
-        auto agg_init_gep = llvm::GetElementPtrInst::CreateInBounds(
-            agg_init_val->getType()->getPointerElementType(),
-            agg_init_val,
-            idx_lv,
-            "agg_init_val_" + std::to_string(i),
-            bb_entry);
+        auto agg_init_gep =
+            llvm::GetElementPtrInst::CreateInBounds(get_int_type(64, mod->getContext()),
+                                                    agg_init_val,
+                                                    idx_lv,
+                                                    "agg_init_val_" + std::to_string(i),
+                                                    bb_entry);
         auto agg_init_val = new llvm::LoadInst(
-            get_pointer_element_type(agg_init_gep), agg_init_gep, "", false, bb_entry);
+            get_int_type(64, mod->getContext()), agg_init_gep, "", false, bb_entry);
         agg_init_val->setAlignment(LLVM_ALIGN(8));
         agg_init_val_vec.push_back(agg_init_val);
         auto init_val_st =
@@ -938,12 +931,8 @@ class NonGroupedQueryTemplateGenerator : public QueryTemplateGenerator {
     row_process_params.insert(
         row_process_params.end(), result_ptr_vec.begin(), result_ptr_vec.end());
     if (is_estimate_query) {
-      row_process_params.push_back(
-          new llvm::LoadInst(get_pointer_element_type(output_buffers),
-                             output_buffers,
-                             "max_matched",
-                             false,
-                             bb_forbody));
+      row_process_params.push_back(new llvm::LoadInst(
+          output_buffers->getType(), output_buffers, "max_matched", false, bb_forbody));
     }
     row_process_params.push_back(agg_init_val);
     row_process_params.push_back(pos);
@@ -974,7 +963,7 @@ class NonGroupedQueryTemplateGenerator : public QueryTemplateGenerator {
   virtual void generateCriticalEdgeBlock() override {
     if (!is_estimate_query) {
       for (size_t i = 0; i < aggr_col_count; ++i) {
-        auto result = new llvm::LoadInst(get_pointer_element_type(result_ptr_vec[i]),
+        auto result = new llvm::LoadInst(get_int_type(64, mod->getContext()),
                                          result_ptr_vec[i],
                                          ".pre.result",
                                          false,
@@ -1028,13 +1017,17 @@ class NonGroupedQueryTemplateGenerator : public QueryTemplateGenerator {
                                  bb_exit);
         } else {
           auto out_gep = llvm::GetElementPtrInst::CreateInBounds(
-              output_buffers->getType()->getPointerElementType(),
+              llvm::PointerType::get(mod->getContext(),
+                                     output_buffers->getType()->getPointerAddressSpace()),
               output_buffers,
               col_idx,
-              "",
+              "output_buffers_array_ptr",
               bb_exit);
-          auto col_buffer = new llvm::LoadInst(
-              get_pointer_element_type(out_gep), out_gep, "", false, bb_exit);
+          auto col_buffer = new llvm::LoadInst(out_gep->getSourceElementType(),
+                                               out_gep,
+                                               "output_buffer_ptr",
+                                               false,
+                                               bb_exit);
           col_buffer->setAlignment(LLVM_ALIGN(8));
           auto slot_idx = llvm::BinaryOperator::CreateAdd(
               group_buff_idx,
@@ -1042,11 +1035,7 @@ class NonGroupedQueryTemplateGenerator : public QueryTemplateGenerator {
               "",
               bb_exit);
           auto target_addr = llvm::GetElementPtrInst::CreateInBounds(
-              col_buffer->getType()->getPointerElementType(),
-              col_buffer,
-              slot_idx,
-              "",
-              bb_exit);
+              result_vec[i]->getType(), col_buffer, slot_idx, "target_addr_ptr", bb_exit);
           llvm::StoreInst* result_st =
               new llvm::StoreInst(result_vec[i], target_addr, false, bb_exit);
           result_st->setAlignment(LLVM_ALIGN(8));
@@ -1065,13 +1054,14 @@ class NonGroupedQueryTemplateGenerator : public QueryTemplateGenerator {
         // optimization. This can be relaxed if necessary
         for (size_t i = 0; i < aggr_col_count; i++) {
           auto out_gep = llvm::GetElementPtrInst::CreateInBounds(
-              output_buffers->getType()->getPointerElementType(),
+              llvm::PointerType::get(mod->getContext(),
+                                     output_buffers->getType()->getPointerAddressSpace()),
               output_buffers,
               llvm::ConstantInt::get(i32_type, i),
-              "",
+              "agg_col_ptr_" + std::to_string(i),
               bb_exit);
           auto gmem_output_buffer =
-              new llvm::LoadInst(get_pointer_element_type(out_gep),
+              new llvm::LoadInst(out_gep->getSourceElementType(),
                                  out_gep,
                                  "gmem_output_buffer_" + std::to_string(i),
                                  false,

--- a/omniscidb/QueryEngine/ResultSetReductionCodegen.cpp
+++ b/omniscidb/QueryEngine/ResultSetReductionCodegen.cpp
@@ -222,15 +222,18 @@ void translate_body(const std::vector<std::unique_ptr<Instruction>>& body,
     llvm::Value* translated{nullptr};
     if (auto gep = dynamic_cast<const GetElementPtr*>(instr_ptr)) {
       auto* base = mapped_value(gep->base(), m);
-      translated = cgen_state->ir_builder_.CreateGEP(
-          base->getType()->getScalarType()->getPointerElementType(),
-          base,
-          mapped_value(gep->index(), m),
-          gep->label());
+      auto base_pointee_type = pointee_type(gep->base()->type());
+      translated =
+          cgen_state->ir_builder_.CreateGEP(llvm_type(base_pointee_type, ctx, co),
+                                            base,
+                                            mapped_value(gep->index(), m),
+                                            gep->label());
     } else if (auto load = dynamic_cast<const Load*>(instr_ptr)) {
       auto* value = mapped_value(load->source(), m);
+      // LLVM doesn't allow pointer types anymore, but our reduction JIT still uses them
+      auto value_pointee_type = pointee_type(load->source()->type());
       translated = cgen_state->ir_builder_.CreateLoad(
-          value->getType()->getPointerElementType(), value, load->label());
+          llvm_type(value_pointee_type, ctx, co), value, load->label());
     } else if (auto icmp = dynamic_cast<const ICmp*>(instr_ptr)) {
       translated = cgen_state->ir_builder_.CreateICmp(llvm_predicate(icmp->predicate()),
                                                       mapped_value(icmp->lhs(), m),
@@ -273,16 +276,9 @@ void translate_body(const std::vector<std::unique_ptr<Instruction>>& body,
     } else if (auto alloca = dynamic_cast<const Alloca*>(instr_ptr)) {
       translated = cgen_state->ir_builder_.CreateAlloca(
           llvm_type(pointee_type(alloca->type()), ctx, co),
+          co.codegen_traits_desc.local_addr_space_,
           mapped_value(alloca->array_size(), m),
           alloca->label());
-      if (translated->getType()->getPointerAddressSpace() !=
-          co.codegen_traits_desc.local_addr_space_) {
-        translated = cgen_state->ir_builder_.CreateAddrSpaceCast(
-            translated,
-            llvm::PointerType::get(translated->getType()->getPointerElementType(),
-                                   co.codegen_traits_desc.local_addr_space_),
-            "translated.cast");
-      }
     } else if (auto memcpy = dynamic_cast<const MemCpy*>(instr_ptr)) {
       cgen_state->ir_builder_.CreateMemCpy(mapped_value(memcpy->dest(), m),
                                            LLVM_MAYBE_ALIGN(0),

--- a/omniscidb/QueryEngine/RowFuncBuilder.cpp
+++ b/omniscidb/QueryEngine/RowFuncBuilder.cpp
@@ -1160,7 +1160,7 @@ void RowFuncBuilder::codegenEstimator(std::stack<llvm::BasicBlock*>& array_loops
       co.codegen_traits_desc.local_addr_space_) {
     estimator_key_lv = LL_BUILDER.CreateAddrSpaceCast(
         estimator_key_lv,
-        llvm::PointerType::get(estimator_key_lv->getType()->getPointerElementType(),
+        llvm::PointerType::get(executor_->cgen_state_->context_,
                                cgen_traits.getLocalAddrSpace()),
         "estimator.key.lv.cast");
   }

--- a/omniscidb/QueryEngine/RowFuncBuilder.cpp
+++ b/omniscidb/QueryEngine/RowFuncBuilder.cpp
@@ -1130,7 +1130,8 @@ llvm::Value* RowFuncBuilder::codegenAggColumnPtr(
       }
       auto offset = LL_BUILDER.CreateAdd(agg_out_idx, LL_INT(col_off));
       auto agg_out_ptr = std::get<0>(agg_out_ptr_w_idx);
-      agg_col_ptr = LL_BUILDER.CreateGEP(agg_out_ptr->getType(), agg_out_ptr, offset);
+      agg_col_ptr = LL_BUILDER.CreateGEP(
+          get_int_type(chosen_bytes * 8, LL_CONTEXT), agg_out_ptr, offset);
     }
   } else {
     size_t col_off = query_mem_desc.getColOnlyOffInBytes(agg_out_off);

--- a/omniscidb/QueryEngine/RowFuncBuilder.cpp
+++ b/omniscidb/QueryEngine/RowFuncBuilder.cpp
@@ -444,7 +444,7 @@ std::tuple<llvm::Value*, llvm::Value*> RowFuncBuilder::codegenGroupBy(
         co.codegen_traits_desc.local_addr_space_) {
       group_key = LL_BUILDER.CreateAddrSpaceCast(
           group_key,
-          llvm::PointerType::get(group_key->getType()->getPointerElementType(),
+          llvm::PointerType::get(executor_->cgen_state_->context_,
                                  co.codegen_traits_desc.local_addr_space_),
           "group.key.cast");
     }
@@ -493,9 +493,7 @@ std::tuple<llvm::Value*, llvm::Value*> RowFuncBuilder::codegenGroupBy(
       LL_BUILDER.CreateStore(
           group_expr_lv,
           LL_BUILDER.CreateGEP(
-              group_key->getType()->getScalarType()->getPointerElementType(),
-              group_key,
-              LL_INT(subkey_idx++)));
+              group_expr_lv->getType(), group_key, LL_INT(subkey_idx++)));
     }
   }
   if (query_mem_desc.getQueryDescriptionType() ==
@@ -755,10 +753,10 @@ llvm::Function* RowFuncBuilder::codegenPerfectHashFunction(const CompilationOpti
   CHECK_GT(ra_exe_unit_.groupby_exprs.size(), size_t(1));
   compiler::CodegenTraits cgen_traits =
       compiler::CodegenTraits::get(co.codegen_traits_desc);
-  auto ft = llvm::FunctionType::get(get_int_type(32, LL_CONTEXT),
-                                    std::vector<llvm::Type*>{cgen_traits.localPointerType(
-                                        get_int_type(64, LL_CONTEXT))},
-                                    false);
+  auto ft = llvm::FunctionType::get(
+      get_int_type(32, LL_CONTEXT),
+      std::vector<llvm::Type*>{cgen_traits.localOpaquePtr(LL_CONTEXT)},
+      false);
   auto key_hash_func = llvm::Function::Create(ft,
                                               llvm::Function::ExternalLinkage,
                                               "perfect_key_hash",
@@ -1115,9 +1113,7 @@ llvm::Value* RowFuncBuilder::codegenAggColumnPtr(
       }
       byte_offset->setName("out_byte_off_target_" + std::to_string(target_idx));
       auto output_ptr = LL_BUILDER.CreateGEP(
-          output_buffer_byte_stream->getType()->getScalarType()->getPointerElementType(),
-          output_buffer_byte_stream,
-          byte_offset);
+          get_int_type(8, LL_CONTEXT), output_buffer_byte_stream, byte_offset);
       agg_col_ptr = LL_BUILDER.CreateBitCast(
           output_ptr,
           llvm::PointerType::get(get_int_type((chosen_bytes << 3), LL_CONTEXT),
@@ -1147,15 +1143,9 @@ llvm::Value* RowFuncBuilder::codegenAggColumnPtr(
     size_t col_off = query_mem_desc.getColOnlyOffInBytes(agg_out_off);
     CHECK_EQ(size_t(0), col_off % chosen_bytes);
     col_off /= chosen_bytes;
-    auto* bit_cast = LL_BUILDER.CreateBitCast(
-        std::get<0>(agg_out_ptr_w_idx),
-        llvm::PointerType::get(
-            get_int_type((chosen_bytes << 3), LL_CONTEXT),
-            std::get<0>(agg_out_ptr_w_idx)->getType()->getPointerAddressSpace()));
+    auto agg_out_ptr = std::get<0>(agg_out_ptr_w_idx);
     agg_col_ptr = LL_BUILDER.CreateGEP(
-        bit_cast->getType()->getScalarType()->getPointerElementType(),
-        bit_cast,
-        LL_INT(col_off));
+        get_int_type(chosen_bytes * 8, LL_CONTEXT), agg_out_ptr, LL_INT(col_off));
   }
   CHECK(agg_col_ptr);
   return agg_col_ptr;
@@ -1198,9 +1188,7 @@ void RowFuncBuilder::codegenEstimator(std::stack<llvm::BasicBlock*>& array_loops
     LL_BUILDER.CreateStore(
         estimator_arg_comp_lv,
         LL_BUILDER.CreateGEP(
-            estimator_key_lv->getType()->getScalarType()->getPointerElementType(),
-            estimator_key_lv,
-            LL_INT(subkey_idx++)));
+            estimator_arg_comp_lv->getType(), estimator_key_lv, LL_INT(subkey_idx++)));
   }
   const auto bitmap = LL_BUILDER.CreateBitCast(
       &*ROW_FUNC->arg_begin(),

--- a/omniscidb/QueryEngine/RowFuncBuilder.cpp
+++ b/omniscidb/QueryEngine/RowFuncBuilder.cpp
@@ -1342,10 +1342,7 @@ llvm::Value* RowFuncBuilder::getAdditionalLiteral(const int32_t off) {
       lit_buff_lv,
       llvm::PointerType::get(get_int_type(64, LL_CONTEXT),
                              lit_buff_lv->getType()->getPointerAddressSpace()));
-  auto* gep =
-      LL_BUILDER.CreateGEP(bit_cast->getType()->getScalarType()->getPointerElementType(),
-                           bit_cast,
-                           LL_INT(off));
+  auto* gep = LL_BUILDER.CreateGEP(get_int_type(64, LL_CONTEXT), bit_cast, LL_INT(off));
   return LL_BUILDER.CreateLoad(get_int_type(64, LL_CONTEXT), gep);
 }
 

--- a/omniscidb/QueryEngine/TargetExprBuilder.cpp
+++ b/omniscidb/QueryEngine/TargetExprBuilder.cpp
@@ -324,12 +324,13 @@ void TargetExprCodegen::codegenAggregate(
       executor->cgen_state_->emitExternalCall(
           "agg_count_distinct_array_" + numeric_type_name(elem_type),
           llvm::Type::getVoidTy(LL_CONTEXT),
-          {is_group_by ? LL_BUILDER.CreateGEP(std::get<0>(agg_out_ptr_w_idx)
-                                                  ->getType()
-                                                  ->getScalarType()
-                                                  ->getPointerElementType(),
-                                              std::get<0>(agg_out_ptr_w_idx),
-                                              LL_INT(col_off))
+          {is_group_by ? LL_BUILDER.CreateGEP(
+                             llvm::PointerType::get(LL_CONTEXT,
+                                                    std::get<0>(agg_out_ptr_w_idx)
+                                                        ->getType()
+                                                        ->getPointerAddressSpace()),
+                             std::get<0>(agg_out_ptr_w_idx),
+                             LL_INT(col_off))
                        : agg_out_vec[slot_index],
            target_lvs[target_lv_idx],
            code_generator.posArg(arg_expr),

--- a/omniscidb/QueryEngine/TargetExprBuilder.cpp
+++ b/omniscidb/QueryEngine/TargetExprBuilder.cpp
@@ -403,9 +403,7 @@ void TargetExprCodegen::codegenAggregate(
       str_target_lv = target_lvs.front();
     }
     std::vector<llvm::Value*> agg_args{
-        executor->castToIntPtrTyIn((is_group_by ? agg_col_ptr : agg_out_vec[slot_index]),
-                                   (data_collect_agg ? sizeof(void*) : agg_chosen_bytes)
-                                       << 3),
+        is_group_by ? agg_col_ptr : agg_out_vec[slot_index],
         (is_simple_count_target && !arg_expr)
             ? (agg_chosen_bytes == sizeof(int32_t) ? LL_INT(int32_t(0))
                                                    : LL_INT(int64_t(0)))
@@ -784,8 +782,7 @@ void TargetExprCodegenBuilder::codegenMultiSlotSampleExpressions(
                                                         first_sample_expr.target_idx);
   } else {
     CHECK_LT(static_cast<size_t>(first_sample_expr.base_slot_index), agg_out_vec.size());
-    agg_col_ptr =
-        executor->castToIntPtrTyIn(agg_out_vec[first_sample_expr.base_slot_index], 64);
+    agg_col_ptr = agg_out_vec[first_sample_expr.base_slot_index];
   }
 
   auto sample_cas_lv =

--- a/omniscidb/QueryEngine/TargetExprBuilder.cpp
+++ b/omniscidb/QueryEngine/TargetExprBuilder.cpp
@@ -192,9 +192,7 @@ void TargetExprCodegen::codegen(
                 get_int_type((chosen_bytes << 3), LL_CONTEXT),
                 std::get<0>(agg_out_ptr_w_idx)->getType()->getPointerAddressSpace()));
         agg_col_ptr = LL_BUILDER.CreateGEP(
-            bit_cast->getType()->getScalarType()->getPointerElementType(),
-            bit_cast,
-            offset);
+            get_int_type((chosen_bytes << 3), LL_CONTEXT), bit_cast, offset);
       } else {
         col_off = query_mem_desc.getColOnlyOffInBytes(slot_index);
         CHECK_EQ(size_t(0), col_off % chosen_bytes);
@@ -205,9 +203,7 @@ void TargetExprCodegen::codegen(
                 get_int_type((chosen_bytes << 3), LL_CONTEXT),
                 std::get<0>(agg_out_ptr_w_idx)->getType()->getPointerAddressSpace()));
         agg_col_ptr = LL_BUILDER.CreateGEP(
-            bit_cast->getType()->getScalarType()->getPointerElementType(),
-            bit_cast,
-            LL_INT(col_off));
+            get_int_type((chosen_bytes << 3), LL_CONTEXT), bit_cast, LL_INT(col_off));
       }
     }
 

--- a/omniscidb/Tests/L0MgrExecuteTest.cpp
+++ b/omniscidb/Tests/L0MgrExecuteTest.cpp
@@ -157,7 +157,12 @@ std::unique_ptr<llvm::Module> read_gen_module_from_bc(const std::string& bc_file
 std::string mangle_spirv_builtin(const llvm::Function& func) {
   CHECK(func.getName().startswith("__spirv_"));
   std::string new_name;
+#if LLVM_VERSION_MAJOR > 14
+  mangleOpenClBuiltin(
+      func.getName().str(), func.getArg(0)->getType(), /*pointer_types=*/{}, new_name);
+#else
   mangleOpenClBuiltin(func.getName().str(), func.getArg(0)->getType(), new_name);
+#endif
   return new_name;
 }
 }  // namespace

--- a/omniscidb/Tests/L0MgrExecuteTest.cpp
+++ b/omniscidb/Tests/L0MgrExecuteTest.cpp
@@ -31,7 +31,8 @@ std::string SPIRVExecuteTest::generateSimpleSPIRV() {
   module->setTargetTriple("spir64-unknown-unknown");
   IRBuilder<> builder(ctx);
 
-  std::vector<Type*> args{Type::getFloatPtrTy(ctx, 1), Type::getFloatPtrTy(ctx, 1)};
+  std::vector<Type*> args{PointerType::get(ctx, 1),
+                          PointerType::get(ctx, 1)};  // float*, float*
   FunctionType* f_type = FunctionType::get(Type::getVoidTy(ctx), args, false);
   Function* f = Function::Create(
       f_type, GlobalValue::LinkageTypes::ExternalLinkage, "plus1", module.get());
@@ -53,11 +54,9 @@ std::string SPIRVExecuteTest::generateSimpleSPIRV() {
   Constant* onef = ConstantFP::get(ctx, APFloat(1.f));
   Value* idx = builder.CreateCall(get_global_idj, zero, "idx");
   auto argit = f->args().begin();
-  Value* firstElemSrc =
-      builder.CreateGEP(argit->getType()->getPointerElementType(), argit, idx, "src.idx");
+  Value* firstElemSrc = builder.CreateGEP(Type::getFloatTy(ctx), argit, idx, "src.idx");
   ++argit;
-  Value* firstElemDst =
-      builder.CreateGEP(argit->getType()->getPointerElementType(), argit, idx, "dst.idx");
+  Value* firstElemDst = builder.CreateGEP(Type::getFloatTy(ctx), argit, idx, "dst.idx");
   Value* ldSrc = builder.CreateLoad(Type::getFloatTy(ctx), firstElemSrc, "ld");
   Value* result = builder.CreateFAdd(ldSrc, onef, "foo");
   builder.CreateStore(result, firstElemDst);
@@ -174,7 +173,8 @@ TEST_F(SPIRVExecuteTest, SPIRVBuiltins) {
   auto module = read_gen_module_from_bc(genx_path, ctx);
   IRBuilder<> builder(ctx);
 
-  std::vector<Type*> args{Type::getFloatPtrTy(ctx, 1), Type::getFloatPtrTy(ctx, 1)};
+  std::vector<Type*> args{PointerType::get(ctx, 1),
+                          PointerType::get(ctx, 1)};  // float*, float*
   FunctionType* f_type = FunctionType::get(Type::getVoidTy(ctx), args, false);
   Function* f = Function::Create(
       f_type, GlobalValue::LinkageTypes::ExternalLinkage, "plus1", module.get());
@@ -189,11 +189,9 @@ TEST_F(SPIRVExecuteTest, SPIRVBuiltins) {
   Constant* onef = ConstantFP::get(ctx, APFloat(1.f));
   Value* idx = builder.CreateCall(posfn, zero, "idx");
   auto argit = f->args().begin();
-  Value* firstElemSrc =
-      builder.CreateGEP(argit->getType()->getPointerElementType(), argit, idx, "src.idx");
+  Value* firstElemSrc = builder.CreateGEP(Type::getFloatTy(ctx), argit, idx, "src.idx");
   ++argit;
-  Value* firstElemDst =
-      builder.CreateGEP(argit->getType()->getPointerElementType(), argit, idx, "dst.idx");
+  Value* firstElemDst = builder.CreateGEP(Type::getFloatTy(ctx), argit, idx, "dst.idx");
   Value* ldSrc = builder.CreateLoad(Type::getFloatTy(ctx), firstElemSrc, "ld");
   Value* result = builder.CreateFAdd(ldSrc, onef, "foo");
   builder.CreateStore(result, firstElemDst);

--- a/omniscidb/Tests/L0MgrExecuteTest.cpp
+++ b/omniscidb/Tests/L0MgrExecuteTest.cpp
@@ -27,10 +27,6 @@ std::string SPIRVExecuteTest::generateSimpleSPIRV() {
   using namespace llvm;
   // See source at https://github.com/kurapov-peter/L0Snippets
   LLVMContext ctx;
-#if LLVM_VERSION_MAJOR > 14
-  // temporarily disable opaque pointers
-  ctx.setOpaquePointers(false);
-#endif
   std::unique_ptr<Module> module = std::make_unique<Module>("code_generated", ctx);
   module->setTargetTriple("spir64-unknown-unknown");
   IRBuilder<> builder(ctx);
@@ -161,12 +157,7 @@ std::unique_ptr<llvm::Module> read_gen_module_from_bc(const std::string& bc_file
 std::string mangle_spirv_builtin(const llvm::Function& func) {
   CHECK(func.getName().startswith("__spirv_"));
   std::string new_name;
-#if LLVM_VERSION_MAJOR > 14
-  mangleOpenClBuiltin(
-      func.getName().str(), func.getArg(0)->getType(), /*pointer_types=*/{}, new_name);
-#else
   mangleOpenClBuiltin(func.getName().str(), func.getArg(0)->getType(), new_name);
-#endif
   return new_name;
 }
 }  // namespace

--- a/omniscidb/Tests/L0MgrExecuteTest.cpp
+++ b/omniscidb/Tests/L0MgrExecuteTest.cpp
@@ -156,7 +156,9 @@ std::unique_ptr<llvm::Module> read_gen_module_from_bc(const std::string& bc_file
 std::string mangle_spirv_builtin(const llvm::Function& func) {
   CHECK(func.getName().startswith("__spirv_"));
   std::string new_name;
-#if LLVM_VERSION_MAJOR > 14
+#if LLVM_VERSION_MAJOR > 15
+  llvm::mangleOpenClBuiltin(func.getName().str(), func.getArg(0)->getType(), new_name);
+#elif LLVM_VERSION_MAJOR > 14
   mangleOpenClBuiltin(
       func.getName().str(), func.getArg(0)->getType(), /*pointer_types=*/{}, new_name);
 #else

--- a/omniscidb/Tests/SpirvBuildTest.cpp
+++ b/omniscidb/Tests/SpirvBuildTest.cpp
@@ -27,7 +27,8 @@ TEST(SPIRVBuildTest, TranslateSimple) {
   module->setTargetTriple("spir-unknown-unknown");
   IRBuilder<> builder(ctx);
 
-  std::vector<Type*> args{Type::getFloatPtrTy(ctx, 1), Type::getFloatPtrTy(ctx, 1)};
+  std::vector<Type*> args{PointerType::get(ctx, 1),
+                          PointerType::get(ctx, 1)};  // float*, float*
   FunctionType* f_type = FunctionType::get(Type::getVoidTy(ctx), args, false);
   Function* f = Function::Create(
       f_type, GlobalValue::LinkageTypes::ExternalLinkage, "plus1", module.get());
@@ -49,11 +50,9 @@ TEST(SPIRVBuildTest, TranslateSimple) {
   Constant* onef = ConstantFP::get(ctx, APFloat(1.f));
   Value* idx = builder.CreateCall(get_global_idj, zero, "idx");
   auto argit = f->args().begin();
-  Value* firstElemSrc =
-      builder.CreateGEP(argit->getType()->getPointerElementType(), argit, idx, "src.idx");
+  Value* firstElemSrc = builder.CreateGEP(Type::getFloatTy(ctx), argit, idx, "src.idx");
   ++argit;
-  Value* firstElemDst =
-      builder.CreateGEP(argit->getType()->getPointerElementType(), argit, idx, "dst.idx");
+  Value* firstElemDst = builder.CreateGEP(Type::getFloatTy(ctx), argit, idx, "dst.idx");
   Value* ldSrc = builder.CreateLoad(Type::getFloatTy(ctx), firstElemSrc, "ld");
   Value* result = builder.CreateFAdd(ldSrc, onef, "foo");
   builder.CreateStore(result, firstElemDst);

--- a/omniscidb/Tests/SpirvBuildTest.cpp
+++ b/omniscidb/Tests/SpirvBuildTest.cpp
@@ -23,10 +23,6 @@ TEST(SPIRVBuildTest, TranslateSimple) {
   using namespace llvm;
   // See source at https://github.com/kurapov-peter/L0Snippets
   LLVMContext ctx;
-#if LLVM_VERSION_MAJOR > 14
-  // temporarily disable opaque pointers
-  ctx.setOpaquePointers(false);
-#endif
   std::unique_ptr<Module> module = std::make_unique<Module>("code_generated", ctx);
   module->setTargetTriple("spir-unknown-unknown");
   IRBuilder<> builder(ctx);

--- a/omniscidb/scripts/mapd-deps-conda-dev-env.yml
+++ b/omniscidb/scripts/mapd-deps-conda-dev-env.yml
@@ -20,7 +20,7 @@ dependencies:
   - arrow-cpp  11.0
   - pyarrow    11.0
   - pandas     1.5.3
-  - llvmdev     15.*
+  - llvmdev     16.*
   - openjdk     20.*
   - cmake
   - tbb-devel
@@ -29,7 +29,7 @@ dependencies:
   - fmt
   - maven
   - boost-cpp
-  - clangdev   15.*
+  - clangdev   16.*
   - llvm
   - double-conversion
   - snappy
@@ -45,8 +45,8 @@ dependencies:
   # when cuda is enabled, install also
   # - arrow-cpp=11.0=*cuda
   - binutils
-  - llvm-spirv 15.0.*
-  - libllvmspirv 15.0.*
+  - llvm-spirv 16.0.*
+  - libllvmspirv 16.0.*
   - folly 2022.11.07.00
   - sqlite 3.40.0
   - python 3.9.*


### PR DESCRIPTION
This PR enables opaque pointers under LLVM 15. It removes calls to `getPointerElementType()` and replaces them with either explicit types or untyped (opaque) pointers. Unfortunately, in some instances the type info is hard coded in a different location from the pointer allocation, or from where it is used. This means if we ever change a type, we might get subtle bugs. We should look at adding type info to our frontend or otherwise refactoring in areas where this could occur.

As part of this work I pushed the address space bitcasts into allocation where possible. The opaque pointer static getter includes address space as a required variable, so this should be acceptable. 

I have a few more `getPointerElementType()` calls but they don't seem to be surfaced in the tests, so I am working on how best to handle those. For now, this is a draft. 