### PR TITLE
Update to LLVM 15 and Support LLVM 16 on Windows

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -11,7 +11,6 @@ on:
       cuda_compiler_version:
         type: string
 
-
     outputs:
       cache-suffix:
         value: ${{ jobs.build.outputs.cache-suffix }}
@@ -76,6 +75,10 @@ jobs:
 
       - name: Configure and build
         run: |
+          $vswhere = "$(${env:ProgramFiles(x86)})\Microsoft Visual Studio\Installer\vswhere.exe"
+          $path = & $vswhere -property installationPath
+          & $path\VC\Auxiliary\Build\vcvarsall.bat x64
+          $env:VSINSTALLDIR = $path
           & $env:CONDA\condabin\conda.bat info
           & $env:CONDA\condabin\conda.bat list -n omnisci-dev
           & $env:CONDA\condabin\conda.bat run --no-capture-output -n omnisci-dev omniscidb\scripts\conda\build.bat ${{ inputs.options }}
@@ -96,4 +99,3 @@ jobs:
             build/*.log
             build/CMakeCache.txt
             build/CMakeFiles/*.log
-

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -43,20 +43,28 @@ jobs:
           Get-PSDrive
 
       - name: Restore Conda env cache
-        id: conda-cache
-        uses: actions/cache@v3
+        id: restore-conda-cache
+        uses: actions/cache/restore@v3
         with:
           path: |
             ${{ env.CONDA_ENV_PATH }}
-          key: ${{ env.RUN_STAMP }}-conda-${{ hashFiles('omniscidb/scripts/mapd-deps-conda-windows-env.yml') }}-${{ env.DATE }}
+          key: ${{ env.RUN_STAMP }}-conda-windows-${{ hashFiles('omniscidb/scripts/mapd-deps-conda-windows-env.yml') }}-${{ env.DATE }}
           restore-keys: |
-            ${{ env.RUN_STAMP }}-conda-${{ hashFiles('omniscidb/scripts/mapd-deps-conda-windows-env.yml') }}-
+            ${{ env.RUN_STAMP }}-conda-windows-${{ hashFiles('omniscidb/scripts/mapd-deps-conda-windows-env.yml') }}-
 
       - name: Update Conda env
         if: steps.conda-cache.cache-hit != 'true'
         run: |
           & $env:CONDA\condabin\conda.bat update conda
           & $env:CONDA\condabin\conda.bat env update -f omniscidb/scripts/mapd-deps-conda-windows-env.yml
+
+      - name: Save Conda env cache
+        id: save-conda-cache
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            ${{ env.CONDA_ENV_PATH }}
+          key: ${{ env.RUN_STAMP }}-conda-windows-${{ hashFiles('omniscidb/scripts/mapd-deps-conda-windows-env.yml') }}-${{ env.DATE }}
 
       - name: Restore Maven cache
         uses: actions/cache@v3

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -1,10 +1,10 @@
 name: Reusable test action on windows
 on:
-  workflow_call: 
+  workflow_call:
     inputs:
       name:
         type: string
-        default: 'gcc-cpu'
+        default: "gcc-cpu"
       cache-suffix:
         type: string
         required: true
@@ -32,14 +32,16 @@ jobs:
           dir
 
       - name: Restore Conda env cache
-        uses: actions/cache@v3
+        id: restore-conda-cache
+        uses: actions/cache/restore@v3
         with:
           path: |
             ${{ env.CONDA_ENV_PATH }}
-          key: ${{ env.RUN_STAMP }}-conda-${{ hashFiles('omniscidb/scripts/mapd-deps-conda-windows-env.yml') }}-${{ inputs.cache-suffix }}
+          key: ${{ env.RUN_STAMP }}-conda-windows-${{ hashFiles('omniscidb/scripts/mapd-deps-conda-windows-env.yml') }}-${{ env.DATE }}
+          restore-keys: |
+            ${{ env.RUN_STAMP }}-conda-windows-${{ hashFiles('omniscidb/scripts/mapd-deps-conda-windows-env.yml') }}-
 
       - name: Run sanity tests
         if: inputs.test == 'sanity'
         run: |
           & $env:CONDA\condabin\conda.bat run --no-capture-output -n omnisci-dev omniscidb/scripts/conda/test.bat
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,9 @@ include_directories(${Boost_INCLUDE_DIR})
 find_package(TBB REQUIRED)
 add_definitions("-DTBB_PREVIEW_TASK_GROUP_EXTENSIONS=1")
 
+# Profiler
+set(PROFILER_LIBS "")
+
 # Cost Model
 option(ENABLE_DWARF_BENCH "Enable Dwarf Bench" OFF)
 if(ENABLE_DWARF_BENCH)

--- a/omniscidb/QueryEngine/Compiler/HelperFunctions.cpp
+++ b/omniscidb/QueryEngine/Compiler/HelperFunctions.cpp
@@ -17,8 +17,11 @@
 #include <llvm/Analysis/MemorySSA.h>
 #include <llvm/IR/IRPrintingPasses.h>
 #include <llvm/IR/Instructions.h>
+#include <llvm/IR/PassManager.h>
 #include <llvm/IR/Verifier.h>
 #include <llvm/Passes/PassBuilder.h>
+#include <llvm/Passes/StandardInstrumentations.h>
+#include <llvm/Support/Path.h>
 #include <llvm/Transforms/IPO.h>
 #include <llvm/Transforms/IPO/AlwaysInliner.h>
 #include <llvm/Transforms/IPO/GlobalOpt.h>
@@ -37,9 +40,8 @@
 #include <llvm/Transforms/Utils/BasicBlockUtils.h>
 #include <llvm/Transforms/Utils/Cloning.h>
 #include <llvm/Transforms/Utils/Mem2Reg.h>
-#include "llvm/IR/PassManager.h"
-#include "llvm/Passes/StandardInstrumentations.h"
-#include "llvm/Support/Path.h"
+
+#include <optional>
 
 #include "QueryEngine/Compiler/Exceptions.h"
 #include "QueryEngine/Optimization/AnnotateInternalFunctionsPass.h"
@@ -188,7 +190,11 @@ void optimize_ir(llvm::Function* query_func,
 
   llvm::PassBuilder PB(nullptr,
                        llvm::PipelineTuningOptions(),
+#if LLVM_VERSION_MAJOR > 15
+                       std::nullopt,
+#else
                        llvm::None,
+#endif
                        (co.dump_llvm_ir_after_each_pass == 2) ? &PIC : nullptr);
   llvm::LoopAnalysisManager LAM;
   llvm::FunctionAnalysisManager FAM;

--- a/omniscidb/QueryEngine/Compiler/HelperFunctions.cpp
+++ b/omniscidb/QueryEngine/Compiler/HelperFunctions.cpp
@@ -212,7 +212,11 @@ void optimize_ir(llvm::Function* query_func,
   llvm::ModulePassManager MPM;
   llvm::FunctionPassManager FPM;
   if (co.dump_llvm_ir_after_each_pass) {
+#if LLVM_VERSION_MAJOR > 15
+    llvm::StandardInstrumentations SI(llvm_module->getContext(), false);
+#else
     llvm::StandardInstrumentations SI(false);
+#endif
     SI.registerCallbacks(PIC);
     DUMP_MODULE(llvm_module, ir_dump_dir + "IR_UNOPT");
   }

--- a/omniscidb/scripts/mapd-deps-conda-windows-env.yml
+++ b/omniscidb/scripts/mapd-deps-conda-windows-env.yml
@@ -18,7 +18,7 @@ dependencies:
   - arrow-cpp  11.0
   - pyarrow    11.0
   - pandas     1.5.3
-  - llvmdev     14.*
+  - llvmdev     15.*
   - openjdk     20.*
   - tbb-devel
   - cython
@@ -26,7 +26,7 @@ dependencies:
   - fmt
   - maven
   - boost-cpp
-  - clangdev   14.*
+  - clangdev   15.*
   - llvm
   - double-conversion
   - snappy


### PR DESCRIPTION
Updates CI to use LLVM 15 and adds build support for LLVM 16.

For CI, the main change is to set VSINSTALLDIR so LLVM picks it up for proper linking. To do this, I use the `vswhere.exe` application which is installed with visual studio. Presumably this will survive version updates. I also modified the cache getters/setters as the cache was not being used in the build step, previously. Finally, my initial plan was to go to LLVM 16 but I ran into some opaque pointer issues even with my workarounds, so we're at LLVM 15 but I kept the commits to add build support for 16. 

Interestingly my first run through the tests failed because I hit the same relocatable section error we've been seeing, so unfortunately LLVM 15 isn't fixing that one. Maybe 16 will. 