### PR TITLE
Get rid of frag count overhead in prepareKernelParams

### DIFF
--- a/omniscidb/BufferProvider/BufferProvider.h
+++ b/omniscidb/BufferProvider/BufferProvider.h
@@ -34,6 +34,17 @@ class BufferProvider {
                             const int8_t* host_ptr,
                             const size_t num_bytes,
                             const int device_id) const = 0;
+
+  virtual void copyToDeviceAsyncIfPossible(int8_t* device_ptr,
+                                           const int8_t* host_ptr,
+                                           const size_t num_bytes,
+                                           const int device_id) const = 0;
+
+  virtual void copyToDeviceAsync(int8_t* device_ptr,
+                                 const int8_t* host_ptr,
+                                 const size_t num_bytes,
+                                 const int device_id) const = 0;
+  virtual void synchronizeStream(const int device_id) const = 0;
   virtual void copyFromDevice(int8_t* host_ptr,
                               const int8_t* device_ptr,
                               const size_t num_bytes,

--- a/omniscidb/CudaMgr/CudaMgr.h
+++ b/omniscidb/CudaMgr/CudaMgr.h
@@ -95,6 +95,14 @@ class CudaMgr : public GpuMgr {
                         const int8_t* host_ptr,
                         const size_t num_bytes,
                         const int device_num) override;
+
+  void copyHostToDeviceAsync(int8_t* device_ptr,
+                             const int8_t* host_ptr,
+                             const size_t num_bytes,
+                             const int device_num) override;
+
+  void synchronizeStream(const int device_num) override;
+
   void copyDeviceToHost(int8_t* host_ptr,
                         const int8_t* device_ptr,
                         const size_t num_bytes,
@@ -116,6 +124,8 @@ class CudaMgr : public GpuMgr {
                     const unsigned char uc,
                     const size_t num_bytes,
                     const int device_num) override;
+
+  bool canLoadAsync() const override { return async_data_load_available; };
 
   size_t getMinSharedMemoryPerBlockForAllDevices() const override {
     return min_shared_memory_per_block_for_all_devices;
@@ -268,6 +278,7 @@ class CudaMgr : public GpuMgr {
   void checkError(CUresult cu_result) const;
 
   int gpu_driver_version_;
+  CUstream stream_;
 #endif
 
   int device_count_;
@@ -277,8 +288,8 @@ class CudaMgr : public GpuMgr {
   std::vector<DeviceProperties> device_properties_;
   omnisci::DeviceGroup device_group_;
   std::vector<CUcontext> device_contexts_;
-
   mutable std::mutex device_cleanup_mutex_;
+  static constexpr bool async_data_load_available{true};
 };
 
 }  // Namespace CudaMgr_Namespace

--- a/omniscidb/CudaMgr/CudaMgrNoCuda.cpp
+++ b/omniscidb/CudaMgr/CudaMgrNoCuda.cpp
@@ -35,6 +35,18 @@ void CudaMgr::copyHostToDevice(int8_t* device_ptr,
                                const int device_num) {
   CHECK(false);
 }
+
+void CudaMgr::copyHostToDeviceAsync(int8_t* device_ptr,
+                                    const int8_t* host_ptr,
+                                    const size_t num_bytes,
+                                    const int device_num) {
+  CHECK(false);
+}
+
+void CudaMgr::synchronizeStream(const int device_num) {
+  CHECK(false);
+}
+
 void CudaMgr::copyDeviceToHost(int8_t* host_ptr,
                                const int8_t* device_ptr,
                                const size_t num_bytes,

--- a/omniscidb/DataMgr/Allocators/GpuAllocator.cpp
+++ b/omniscidb/DataMgr/Allocators/GpuAllocator.cpp
@@ -46,6 +46,12 @@ Data_Namespace::AbstractBuffer* GpuAllocator::allocGpuAbstractBuffer(
   return ab;
 }
 
+Data_Namespace::AbstractBuffer* GpuAllocator::allocGpuAbstractBuffer(
+    const size_t num_bytes) {
+  CHECK(buffer_provider_);
+  return GpuAllocator::allocGpuAbstractBuffer(buffer_provider_, num_bytes, device_id_);
+}
+
 int8_t* GpuAllocator::alloc(const size_t num_bytes) {
   CHECK(buffer_provider_);
   owned_buffers_.emplace_back(

--- a/omniscidb/DataMgr/Allocators/GpuAllocator.h
+++ b/omniscidb/DataMgr/Allocators/GpuAllocator.h
@@ -39,6 +39,8 @@ class GpuAllocator : public DeviceAllocator {
       const size_t num_bytes,
       const int device_id);
 
+  Data_Namespace::AbstractBuffer* allocGpuAbstractBuffer(const size_t num_bytes);
+
   int8_t* alloc(const size_t num_bytes) override;
 
   void free(Data_Namespace::AbstractBuffer* ab) const override;

--- a/omniscidb/DataMgr/DataMgrBufferProvider.cpp
+++ b/omniscidb/DataMgr/DataMgrBufferProvider.cpp
@@ -40,6 +40,37 @@ void DataMgrBufferProvider::copyToDevice(int8_t* device_ptr,
   gpu_mgr->copyHostToDevice(device_ptr, host_ptr, num_bytes, device_id);
 }
 
+void DataMgrBufferProvider::copyToDeviceAsync(int8_t* device_ptr,
+                                              const int8_t* host_ptr,
+                                              const size_t num_bytes,
+                                              const int device_id) const {
+  CHECK(data_mgr_);
+  const auto gpu_mgr = data_mgr_->getGpuMgr();
+  CHECK(gpu_mgr);
+  gpu_mgr->copyHostToDeviceAsync(device_ptr, host_ptr, num_bytes, device_id);
+}
+
+void DataMgrBufferProvider::copyToDeviceAsyncIfPossible(int8_t* device_ptr,
+                                                        const int8_t* host_ptr,
+                                                        const size_t num_bytes,
+                                                        const int device_id) const {
+  CHECK(data_mgr_);
+  const auto gpu_mgr = data_mgr_->getGpuMgr();
+  CHECK(gpu_mgr);
+  if (gpu_mgr->canLoadAsync()) {
+    gpu_mgr->copyHostToDeviceAsync(device_ptr, host_ptr, num_bytes, device_id);
+  } else {
+    gpu_mgr->copyHostToDevice(device_ptr, host_ptr, num_bytes, device_id);
+  }
+}
+
+void DataMgrBufferProvider::synchronizeStream(const int device_num) const {
+  CHECK(data_mgr_);
+  const auto gpu_mgr = data_mgr_->getGpuMgr();
+  CHECK(gpu_mgr);
+  gpu_mgr->synchronizeStream(device_num);
+}
+
 void DataMgrBufferProvider::copyFromDevice(int8_t* host_ptr,
                                            const int8_t* device_ptr,
                                            const size_t num_bytes,

--- a/omniscidb/DataMgr/DataMgrBufferProvider.h
+++ b/omniscidb/DataMgr/DataMgrBufferProvider.h
@@ -35,6 +35,17 @@ class DataMgrBufferProvider : public BufferProvider {
                     const int8_t* host_ptr,
                     const size_t num_bytes,
                     const int device_id) const override;
+
+  void copyToDeviceAsyncIfPossible(int8_t* device_ptr,
+                                   const int8_t* host_ptr,
+                                   const size_t num_bytes,
+                                   const int device_id) const override;
+
+  void copyToDeviceAsync(int8_t* device_ptr,
+                         const int8_t* host_ptr,
+                         const size_t num_bytes,
+                         const int device_id) const override;
+  void synchronizeStream(const int device_id) const override;
   void copyFromDevice(int8_t* host_ptr,
                       const int8_t* device_ptr,
                       const size_t num_bytes,

--- a/omniscidb/DataMgr/GpuMgr.h
+++ b/omniscidb/DataMgr/GpuMgr.h
@@ -32,6 +32,14 @@ struct GpuMgr {
                                 const int8_t* host_ptr,
                                 const size_t num_bytes,
                                 const int device_num) = 0;
+
+  virtual void copyHostToDeviceAsync(int8_t* device_ptr,
+                                     const int8_t* host_ptr,
+                                     const size_t num_bytes,
+                                     const int device_num) = 0;
+
+  virtual void synchronizeStream(const int device_num) = 0;
+
   virtual void copyDeviceToHost(int8_t* host_ptr,
                                 const int8_t* device_ptr,
                                 const size_t num_bytes,
@@ -63,6 +71,8 @@ struct GpuMgr {
   virtual uint32_t getGridSize() const = 0;
   virtual uint32_t getMinEUNumForAllDevices() const = 0;
   virtual bool hasSharedMemoryAtomicsSupport() const = 0;
+  virtual bool canLoadAsync() const = 0;
+
   // TODO: hasFP64Support implementations do not account for different device capabilities
   virtual bool hasFP64Support() const { return true; };
   virtual size_t getMinSharedMemoryPerBlockForAllDevices() const = 0;

--- a/omniscidb/L0Mgr/L0Mgr.h
+++ b/omniscidb/L0Mgr/L0Mgr.h
@@ -199,7 +199,16 @@ void* allocate_device_mem(const size_t num_bytes, L0Device& device);
 class L0Manager : public GpuMgr {
  public:
   L0Manager();
-
+  void copyHostToDeviceAsync(int8_t* device_ptr,
+                             const int8_t* host_ptr,
+                             const size_t num_bytes,
+                             const int device_num) override {
+    CHECK(false);
+  }
+  void synchronizeStream(const int device_num) override {
+    LOG(WARNING)
+        << "L0 has no async data transfer enabled, synchronizeStream() has no effect";
+  }
   void copyHostToDevice(int8_t* device_ptr,
                         const int8_t* host_ptr,
                         const size_t num_bytes,
@@ -225,7 +234,7 @@ class L0Manager : public GpuMgr {
                     const unsigned char uc,
                     const size_t num_bytes,
                     const int device_num) override;
-
+  bool canLoadAsync() const override { return async_data_load_available; };
   void synchronizeDevices() const override;
   GpuMgrPlatform getPlatform() const override { return GpuMgrPlatform::L0; }
   int getDeviceCount() const override {
@@ -252,6 +261,7 @@ class L0Manager : public GpuMgr {
 
  private:
   std::vector<std::shared_ptr<L0Driver>> drivers_;
+  static constexpr bool async_data_load_available{false};
 };
 
 }  // namespace l0

--- a/omniscidb/QueryEngine/QueryExecutionContext.h
+++ b/omniscidb/QueryEngine/QueryExecutionContext.h
@@ -125,7 +125,16 @@ class QueryExecutionContext : boost::noncopyable {
     KERN_PARAM_COUNT,
   };
 
-  std::vector<int8_t*> prepareKernelParams(
+  size_t getKernelParamsAllocSize(
+      const std::vector<std::vector<const int8_t*>>& col_buffers,
+      const std::vector<int32_t>& error_codes,
+      const size_t literals_sz,
+      const std::vector<std::vector<int64_t>>& num_rows,
+      const std::vector<std::vector<uint64_t>>& frag_offsets,
+      const size_t init_agg_vals_sz,
+      const size_t hash_table_count) const;
+
+  std::pair<std::vector<int8_t*>, Data_Namespace::AbstractBuffer*> prepareKernelParams(
       const std::vector<std::vector<const int8_t*>>& col_buffers,
       const std::vector<int8_t>& literal_buff,
       const std::vector<std::vector<int64_t>>& num_rows,


### PR DESCRIPTION
Imagine you read CSVs into a table (e.g., 80Mil. rows) and you want to "try" to reduce materialization overhead, so you pick a small fragment size (e.g., 40k) or you somehow managed to operate on arrow chunks directly (roughly 50k rows, zero copy for CPU). You know that you are in a heterogeneous setting, so devices can actually share a workload since there are many fragments and you can also do multifragment on GPU. You do not expect any issues. That is until you try to run 8 subsequent group by count on GPU each on a different column. You will likely find out that **fetching a column** and **preparing kernel parameters** gradually takes more and more time and at 8th run each of them takes **over 400ms (30% of the whole query)**. A new bottleneck emerges due to a higher fragment count,  which leads to more metadata being passed (i.e., more allocations and data transfers). This might have been OK if it wasn't for  **preparing kernel parameters** being **per kernel (i.e., step) overhead**. This wasn't an issue because no one would do 40k fragment size on GPU :), but in a heterogeneous setup it might be the case.

This PR does one allocation for all of the kernel parameters and fills the memory by asynchronous (for CUDA) data transfer calls. Why async? Well, why not, we have potentially many independent data transfers that need to be ready only before kernel launch. This PR reduces **preparing kernel parameters** overhead to basically only data transfers (which in practice almost always becomes **0ms**). 

That is, in the example above (8 subsequent group bys) the gradual increase of **preparing kernel parameters** overhead is eliminated.

- The main benefit of course comes from one allocation instead of linear-to-frag-count allocations.
- Maybe this small introduction to async data transfer capability might also be useful elsewhere.
- Also since kernel parameters do not live past `launchGpuCode()` and now they are a single buffer, we can now easily free it, instead of piling up all those allocations.

