### PR TITLE
Replace dictionary proxies with nested dictionaries 02/N

### DIFF
--- a/omniscidb/QueryEngine/JoinHashTable/HashJoin.cpp
+++ b/omniscidb/QueryEngine/JoinHashTable/HashJoin.cpp
@@ -343,8 +343,8 @@ const StringDictionaryProxy::IdMap* HashJoin::translateInnerToOuterStrDictProxie
   const bool translate_dictionary =
       inner_outer_proxies.first && inner_outer_proxies.second;
   if (translate_dictionary) {
-    const auto inner_dict_id = inner_outer_proxies.first->getDictId();
-    const auto outer_dict_id = inner_outer_proxies.second->getDictId();
+    const auto inner_dict_id = inner_outer_proxies.first->getDictionary()->getDictId();
+    const auto outer_dict_id = inner_outer_proxies.second->getDictionary()->getDictId();
     CHECK_NE(inner_dict_id, outer_dict_id);
     return executor->getIntersectionStringProxyTranslationMap(
         inner_outer_proxies.first,
@@ -436,7 +436,8 @@ HashJoin::translateCompositeStrDictProxies(const CompositeKeyInfo& composite_key
       CHECK(inner_proxy);
       CHECK(outer_proxy);
 
-      CHECK_NE(inner_proxy->getDictId(), outer_proxy->getDictId());
+      CHECK_NE(inner_proxy->getDictionary()->getDictId(),
+               outer_proxy->getDictionary()->getDictId());
       proxy_translation_maps.emplace_back(
           executor->getIntersectionStringProxyTranslationMap(
               inner_proxy, outer_proxy, executor->getRowSetMemoryOwner()));

--- a/omniscidb/QueryEngine/Visitors/TransientStringLiteralsVisitor.h
+++ b/omniscidb/QueryEngine/Visitors/TransientStringLiteralsVisitor.h
@@ -57,7 +57,7 @@ class TransientStringLiteralsVisitor : public hdk::ir::ExprVisitor<void> {
     }
     auto uoper_dict_id = uoper_type->as<hdk::ir::ExtDictionaryType>()->dictId();
     auto operand_dict_id = operand_type->as<hdk::ir::ExtDictionaryType>()->dictId();
-    if (uoper_dict_id != sdp_->getDictId()) {
+    if (uoper_dict_id != sdp_->getDictionary()->getDictId()) {
       // If we are not casting to our dictionary (sdp_
       return;
     }

--- a/omniscidb/ResultSet/RowSetMemoryOwner.cpp
+++ b/omniscidb/ResultSet/RowSetMemoryOwner.cpp
@@ -54,8 +54,7 @@ StringDictionaryProxy* RowSetMemoryOwner::getOrAddStringDictProxy(
     DictRef literal_dict_ref(DictRef::invalidDbId, DictRef::literalsDictId);
     std::shared_ptr<StringDictionary> tsd =
         std::make_shared<StringDictionary>(literal_dict_ref, g_cache_string_hash);
-    lit_str_dict_proxy_ =
-        std::make_shared<StringDictionaryProxy>(tsd, literal_dict_ref.dictId, 0);
+    lit_str_dict_proxy_ = std::make_shared<StringDictionaryProxy>(tsd, 0);
   }
   return lit_str_dict_proxy_.get();
 }

--- a/omniscidb/ResultSet/RowSetMemoryOwner.h
+++ b/omniscidb/ResultSet/RowSetMemoryOwner.h
@@ -143,9 +143,8 @@ class RowSetMemoryOwner final : public SimpleAllocator, boost::noncopyable {
       return it->second.get();
     }
     it = str_dict_proxy_owned_
-             .emplace(
-                 dict_id,
-                 std::make_shared<StringDictionaryProxy>(str_dict, dict_id, generation))
+             .emplace(dict_id,
+                      std::make_shared<StringDictionaryProxy>(str_dict, generation))
              .first;
     return it->second.get();
   }

--- a/omniscidb/StringDictionary/StringDictionaryProxy.h
+++ b/omniscidb/StringDictionary/StringDictionaryProxy.h
@@ -39,11 +39,7 @@ class StringDictionaryProxy {
  public:
   StringDictionaryProxy(StringDictionaryProxy const&) = delete;
   StringDictionaryProxy const& operator=(StringDictionaryProxy const&) = delete;
-  StringDictionaryProxy(std::shared_ptr<StringDictionary> sd,
-                        const int32_t string_dict_id,
-                        const int64_t generation);
-
-  int32_t getDictId() const noexcept { return string_dict_id_; };
+  StringDictionaryProxy(std::shared_ptr<StringDictionary> sd, const int64_t generation);
 
   bool operator==(StringDictionaryProxy const&) const;
   bool operator!=(StringDictionaryProxy const&) const;
@@ -237,7 +233,6 @@ class StringDictionaryProxy {
   IdMap buildIntersectionTranslationMapToOtherProxyUnlocked(
       const StringDictionaryProxy* dest_proxy) const;
   std::shared_ptr<StringDictionary> string_dict_;
-  const int32_t string_dict_id_;
   TransientMap transient_str_to_int_;
   // Holds pointers into transient_str_to_int_
   std::vector<std::string const*> transient_string_vec_;

--- a/omniscidb/Tests/StringDictionaryBenchmark.cpp
+++ b/omniscidb/Tests/StringDictionaryBenchmark.cpp
@@ -133,7 +133,6 @@ std::shared_ptr<StringDictionaryProxy> create_str_proxy(const int32_t dict_id,
   auto string_dict = create_str_dict(dict_id, materialize_hashes);
   std::shared_ptr<StringDictionaryProxy> string_proxy =
       std::make_shared<StringDictionaryProxy>(string_dict,
-                                              dict_id, /* string_dict_id */
                                               string_dict->storageEntryCount());
   return string_proxy;
 }
@@ -145,7 +144,6 @@ std::shared_ptr<StringDictionaryProxy> create_and_populate_str_proxy(
   auto string_dict = create_and_populate_str_dict(dict_id, materialize_hashes, strings);
   std::shared_ptr<StringDictionaryProxy> string_proxy =
       std::make_shared<StringDictionaryProxy>(string_dict,
-                                              dict_id, /* string_dict_id */
                                               string_dict->storageEntryCount());
   return string_proxy;
 }

--- a/omniscidb/Tests/StringDictionaryTest.cpp
+++ b/omniscidb/Tests/StringDictionaryTest.cpp
@@ -269,8 +269,7 @@ TEST(StringDictionaryProxy, GetOrAddTransient) {
 
   // Now make proxy from dictionary
 
-  StringDictionaryProxy string_dict_proxy(
-      string_dict, 1 /* string_dict_id */, string_dict->storageEntryCount());
+  StringDictionaryProxy string_dict_proxy(string_dict, string_dict->storageEntryCount());
 
   {
     // First iteration is identical to first of the StringDictionary GetOrAddBulk test,
@@ -350,8 +349,7 @@ static std::shared_ptr<StringDictionary> create_and_fill_dictionary() {
 TEST(StringDictionaryProxy, GetOrAddTransientBulk) {
   auto string_dict = create_and_fill_dictionary();
 
-  StringDictionaryProxy string_dict_proxy(
-      string_dict, 1 /* string_dict_id */, string_dict->storageEntryCount());
+  StringDictionaryProxy string_dict_proxy(string_dict, string_dict->storageEntryCount());
   {
     // First iteration is identical to first of the StringDictionary GetOrAddBulk test,
     // and results should be the same
@@ -403,8 +401,7 @@ TEST(StringDictionaryProxy, GetOrAddTransientBulk) {
 TEST(StringDictionaryProxy, GetTransientBulk) {
   auto string_dict = create_and_fill_dictionary();
 
-  StringDictionaryProxy string_dict_proxy(
-      string_dict, 1 /* string_dict_id */, string_dict->storageEntryCount());
+  StringDictionaryProxy string_dict_proxy(string_dict, string_dict->storageEntryCount());
   {
     // First iteration is identical to first of the StryingDictionaryProxy
     // GetOrAddTransientBulk test, and results should be the same
@@ -475,11 +472,9 @@ TEST(StringDictionaryProxy, BuildIntersectionTranslationMapToOtherProxy) {
     // Should get back all INVALID_STR_IDs
     std::shared_ptr<StringDictionaryProxy> source_string_dict_proxy =
         std::make_shared<StringDictionaryProxy>(source_string_dict,
-                                                1 /* string_dict_id */,
                                                 source_string_dict->storageEntryCount());
     std::shared_ptr<StringDictionaryProxy> dest_string_dict_proxy =
         std::make_shared<StringDictionaryProxy>(dest_string_dict,
-                                                2 /* string_dict_id */,
                                                 dest_string_dict->storageEntryCount());
     const auto str_proxy_translation_map =
         source_string_dict_proxy->buildIntersectionTranslationMapToOtherProxy(
@@ -508,11 +503,9 @@ TEST(StringDictionaryProxy, BuildIntersectionTranslationMapToOtherProxy) {
 
     std::shared_ptr<StringDictionaryProxy> source_string_dict_proxy =
         std::make_shared<StringDictionaryProxy>(source_string_dict,
-                                                1 /* string_dict_id */,
                                                 source_string_dict->storageEntryCount());
     std::shared_ptr<StringDictionaryProxy> dest_string_dict_proxy =
         std::make_shared<StringDictionaryProxy>(dest_string_dict,
-                                                2 /* string_dict_id */,
                                                 dest_string_dict->storageEntryCount());
 
     constexpr int32_t num_source_proxy_transient_ids{64};
@@ -589,11 +582,9 @@ TEST(StringDictionaryProxy, BuildUnionTranslationMapToEmptyProxy) {
     // destination proxy
     std::shared_ptr<StringDictionaryProxy> source_string_dict_proxy =
         std::make_shared<StringDictionaryProxy>(source_string_dict,
-                                                1 /* string_dict_id */,
                                                 source_string_dict->storageEntryCount());
     std::shared_ptr<StringDictionaryProxy> dest_string_dict_proxy =
         std::make_shared<StringDictionaryProxy>(dest_string_dict,
-                                                2 /* string_dict_id */,
                                                 dest_string_dict->storageEntryCount());
     const auto str_proxy_translation_map =
         source_string_dict_proxy->buildUnionTranslationMapToOtherProxy(
@@ -721,19 +712,17 @@ TEST(StringDictionaryProxy, BuildUnionTranslationMapToPartialOverlapProxy) {
       dest_sd, num_dest_persisted_entries, dest_persisted_start_val);
   ASSERT_EQ(dest_sd->storageEntryCount(), num_dest_persisted_entries);
 
-  StringDictionaryProxy source_sdp(
-      source_sd, 1 /* string_dict_id */, source_sd->storageEntryCount());
-  StringDictionaryProxy dest_sdp(
-      dest_sd, 2 /* string_dict_id */, dest_sd->storageEntryCount());
+  StringDictionaryProxy source_sdp(source_sd, source_sd->storageEntryCount());
+  StringDictionaryProxy dest_sdp(dest_sd, dest_sd->storageEntryCount());
   const auto transient_source_strings = add_strings_numeric_range(
       source_sdp, num_source_transient_entries, source_transient_start_val);
-  ASSERT_EQ(source_sdp.getDictId(), 1);
+  ASSERT_EQ(source_sdp.getDictionary()->getDictId(), 1);
   ASSERT_EQ(source_sdp.storageEntryCount(), num_source_persisted_entries);
   ASSERT_EQ(source_sdp.transientEntryCount(), num_source_transient_entries);
 
   const auto transient_dest_strings = add_strings_numeric_range(
       dest_sdp, num_dest_transient_entries, dest_transient_start_val);
-  ASSERT_EQ(dest_sdp.getDictId(), 2);
+  ASSERT_EQ(dest_sdp.getDictionary()->getDictId(), 2);
   ASSERT_EQ(dest_sdp.storageEntryCount(), num_dest_persisted_entries);
   ASSERT_EQ(dest_sdp.transientEntryCount(), num_dest_transient_entries);
 


### PR DESCRIPTION
Remove StringDictionaryProxy::getDictId and get the id from a base dictionary instead. This is required because later proxy will be replaced with a nested dict where `getDictId` method returns the outer dict id, not the base one.