### PR TITLE
Replace dictionary proxies with nested dictionaries 03/N

### DIFF
--- a/omniscidb/QueryEngine/JoinHashTable/HashJoin.cpp
+++ b/omniscidb/QueryEngine/JoinHashTable/HashJoin.cpp
@@ -343,8 +343,10 @@ const StringDictionaryProxy::IdMap* HashJoin::translateInnerToOuterStrDictProxie
   const bool translate_dictionary =
       inner_outer_proxies.first && inner_outer_proxies.second;
   if (translate_dictionary) {
-    const auto inner_dict_id = inner_outer_proxies.first->getDictionary()->getDictId();
-    const auto outer_dict_id = inner_outer_proxies.second->getDictionary()->getDictId();
+    const auto inner_dict_id =
+        inner_outer_proxies.first->getBaseDictionary()->getDictId();
+    const auto outer_dict_id =
+        inner_outer_proxies.second->getBaseDictionary()->getDictId();
     CHECK_NE(inner_dict_id, outer_dict_id);
     return executor->getIntersectionStringProxyTranslationMap(
         inner_outer_proxies.first,
@@ -406,7 +408,7 @@ CompositeKeyInfo HashJoin::getCompositeKeyInfo(
       CHECK(sd_inner_proxy && sd_outer_proxy);
       sd_inner_proxy_per_key.push_back(sd_inner_proxy);
       sd_outer_proxy_per_key.push_back(sd_outer_proxy);
-      cache_key_chunks_for_column.push_back(sd_outer_proxy->getGeneration());
+      cache_key_chunks_for_column.push_back(sd_outer_proxy->getBaseGeneration());
     } else {
       sd_inner_proxy_per_key.emplace_back();
       sd_outer_proxy_per_key.emplace_back();
@@ -436,8 +438,8 @@ HashJoin::translateCompositeStrDictProxies(const CompositeKeyInfo& composite_key
       CHECK(inner_proxy);
       CHECK(outer_proxy);
 
-      CHECK_NE(inner_proxy->getDictionary()->getDictId(),
-               outer_proxy->getDictionary()->getDictId());
+      CHECK_NE(inner_proxy->getBaseDictionary()->getDictId(),
+               outer_proxy->getBaseDictionary()->getDictId());
       proxy_translation_maps.emplace_back(
           executor->getIntersectionStringProxyTranslationMap(
               inner_proxy, outer_proxy, executor->getRowSetMemoryOwner()));

--- a/omniscidb/QueryEngine/Visitors/TransientStringLiteralsVisitor.h
+++ b/omniscidb/QueryEngine/Visitors/TransientStringLiteralsVisitor.h
@@ -57,7 +57,7 @@ class TransientStringLiteralsVisitor : public hdk::ir::ExprVisitor<void> {
     }
     auto uoper_dict_id = uoper_type->as<hdk::ir::ExtDictionaryType>()->dictId();
     auto operand_dict_id = operand_type->as<hdk::ir::ExtDictionaryType>()->dictId();
-    if (uoper_dict_id != sdp_->getDictionary()->getDictId()) {
+    if (uoper_dict_id != sdp_->getBaseDictionary()->getDictId()) {
       // If we are not casting to our dictionary (sdp_
       return;
     }

--- a/omniscidb/ResultSet/ResultSet.cpp
+++ b/omniscidb/ResultSet/ResultSet.cpp
@@ -851,7 +851,7 @@ const std::vector<std::string> ResultSet::getStringDictionaryPayloadCopy(
     const int dict_id) const {
   const auto sdp = row_set_mem_owner_->getOrAddStringDictProxy(dict_id);
   CHECK(sdp);
-  return sdp->getDictionary()->copyStrings();
+  return sdp->getBaseDictionary()->copyStrings();
 }
 
 const std::pair<std::vector<int32_t>, std::vector<std::string>>

--- a/omniscidb/ResultSet/RowSetMemoryOwner.h
+++ b/omniscidb/ResultSet/RowSetMemoryOwner.h
@@ -182,7 +182,7 @@ class RowSetMemoryOwner final : public SimpleAllocator, boost::noncopyable {
     std::lock_guard<std::mutex> lock(state_mutex_);
     auto it = str_dict_proxy_owned_.find(dict_id);
     if (it != str_dict_proxy_owned_.end()) {
-      CHECK_EQ(it->second->getDictionary(), str_dict.get());
+      CHECK_EQ(it->second->getBaseDictionary(), str_dict.get());
       it->second->updateGeneration(generation);
       return it->second.get();
     }
@@ -197,8 +197,8 @@ class RowSetMemoryOwner final : public SimpleAllocator, boost::noncopyable {
       const StringDictionaryProxy* source_proxy,
       const StringDictionaryProxy* dest_proxy) {
     std::lock_guard<std::mutex> lock(state_mutex_);
-    const auto map_key = std::make_pair(source_proxy->getDictionary()->getDictId(),
-                                        dest_proxy->getDictionary()->getDictId());
+    const auto map_key = std::make_pair(source_proxy->getBaseDictionary()->getDictId(),
+                                        dest_proxy->getBaseDictionary()->getDictId());
     auto it = str_proxy_intersection_translation_maps_owned_.find(map_key);
     if (it == str_proxy_intersection_translation_maps_owned_.end()) {
       it = str_proxy_intersection_translation_maps_owned_
@@ -214,8 +214,8 @@ class RowSetMemoryOwner final : public SimpleAllocator, boost::noncopyable {
       const StringDictionaryProxy* source_proxy,
       StringDictionaryProxy* dest_proxy) {
     std::lock_guard<std::mutex> lock(state_mutex_);
-    const auto map_key = std::make_pair(source_proxy->getDictionary()->getDictId(),
-                                        dest_proxy->getDictionary()->getDictId());
+    const auto map_key = std::make_pair(source_proxy->getBaseDictionary()->getDictId(),
+                                        dest_proxy->getBaseDictionary()->getDictId());
     auto it = str_proxy_union_translation_maps_owned_.find(map_key);
     if (it == str_proxy_union_translation_maps_owned_.end()) {
       it = str_proxy_union_translation_maps_owned_

--- a/omniscidb/StringDictionary/StringDictionaryProxy.cpp
+++ b/omniscidb/StringDictionary/StringDictionaryProxy.cpp
@@ -637,11 +637,11 @@ size_t StringDictionaryProxy::transientLookupBulkParallelUnlocked(
   return num_strings_not_found;
 }
 
-StringDictionary* StringDictionaryProxy::getDictionary() const noexcept {
+StringDictionary* StringDictionaryProxy::getBaseDictionary() const noexcept {
   return string_dict_.get();
 }
 
-int64_t StringDictionaryProxy::getGeneration() const noexcept {
+int64_t StringDictionaryProxy::getBaseGeneration() const noexcept {
   return generation_;
 }
 

--- a/omniscidb/StringDictionary/StringDictionaryProxy.h
+++ b/omniscidb/StringDictionary/StringDictionaryProxy.h
@@ -46,8 +46,8 @@ class StringDictionaryProxy {
 
   // enum SetOp { kUnion = 0, kIntersection };
 
-  StringDictionary* getDictionary() const noexcept;
-  int64_t getGeneration() const noexcept;
+  StringDictionary* getBaseDictionary() const noexcept;
+  int64_t getBaseGeneration() const noexcept;
 
   /**
    * @brief Executes read-only lookup of a vector of strings and returns a vector of their

--- a/omniscidb/Tests/StringDictionaryTest.cpp
+++ b/omniscidb/Tests/StringDictionaryTest.cpp
@@ -716,13 +716,13 @@ TEST(StringDictionaryProxy, BuildUnionTranslationMapToPartialOverlapProxy) {
   StringDictionaryProxy dest_sdp(dest_sd, dest_sd->storageEntryCount());
   const auto transient_source_strings = add_strings_numeric_range(
       source_sdp, num_source_transient_entries, source_transient_start_val);
-  ASSERT_EQ(source_sdp.getDictionary()->getDictId(), 1);
+  ASSERT_EQ(source_sdp.getBaseDictionary()->getDictId(), 1);
   ASSERT_EQ(source_sdp.storageEntryCount(), num_source_persisted_entries);
   ASSERT_EQ(source_sdp.transientEntryCount(), num_source_transient_entries);
 
   const auto transient_dest_strings = add_strings_numeric_range(
       dest_sdp, num_dest_transient_entries, dest_transient_start_val);
-  ASSERT_EQ(dest_sdp.getDictionary()->getDictId(), 2);
+  ASSERT_EQ(dest_sdp.getBaseDictionary()->getDictId(), 2);
   ASSERT_EQ(dest_sdp.storageEntryCount(), num_dest_persisted_entries);
   ASSERT_EQ(dest_sdp.transientEntryCount(), num_dest_transient_entries);
 


### PR DESCRIPTION
Rename `StringDictionaryProxy::getDictionary` and `StringDictionaryProxy::getGeneration` to match the following nested dictionary API.