### PR TITLE
Reduce query pre-execution steps copies

### DIFF
--- a/omniscidb/ArrowStorage/ArrowStorage.h
+++ b/omniscidb/ArrowStorage/ArrowStorage.h
@@ -170,6 +170,8 @@ class ArrowStorage : public SimpleSchemaProvider, public AbstractDataProvider {
     std::vector<DataFragment> fragments;
     size_t row_count = 0;
     TableStats table_stats;
+    std::shared_ptr<const TableFragmentsInfo> metadata =
+        std::make_shared<TableFragmentsInfo>();
   };
 
   struct DictionaryData {
@@ -243,6 +245,7 @@ class ArrowStorage : public SimpleSchemaProvider, public AbstractDataProvider {
                             size_t num_bytes) const;
   void refragmentTable(TableData& table, const int table_id, const size_t new_frag_size);
   void materializeDictionary(DictionaryData* dict_data);
+  void setTableMetadata(TableData& table, const int table_id) const;
 
   int db_id_;
   int schema_id_;

--- a/omniscidb/ArrowStorage/ArrowStorage.h
+++ b/omniscidb/ArrowStorage/ArrowStorage.h
@@ -73,7 +73,8 @@ class ArrowStorage : public SimpleSchemaProvider, public AbstractDataProvider {
   std::unique_ptr<Data_Namespace::AbstractDataToken> getZeroCopyColumnData(
       const ColumnRef& col_ref) override;
 
-  TableFragmentsInfo getTableMetadata(int db_id, int table_id) const override;
+  std::shared_ptr<const TableFragmentsInfo> getTableMetadata(int db_id,
+                                                             int table_id) const override;
 
   const DictDescriptor* getDictMetadata(int dict_id, bool load_dict = true) override;
 
@@ -217,7 +218,7 @@ class ArrowStorage : public SimpleSchemaProvider, public AbstractDataProvider {
                       std::shared_ptr<arrow::Schema> rhs);
   ChunkStats computeStats(std::shared_ptr<arrow::ChunkedArray> arr,
                           const hdk::ir::Type* type);
-  TableFragmentsInfo getEmptyTableMetadata(int table_id) const;
+  std::shared_ptr<TableFragmentsInfo> getEmptyTableMetadata(int table_id) const;
   void fetchFixedLenData(const TableData& table,
                          size_t frag_idx,
                          size_t col_idx,

--- a/omniscidb/DataMgr/AbstractBufferMgr.h
+++ b/omniscidb/DataMgr/AbstractBufferMgr.h
@@ -103,7 +103,9 @@ class AbstractBufferMgr {
 
   virtual const DictDescriptor* getDictMetadata(int dict_id, bool load_dict = true) = 0;
 
-  virtual TableFragmentsInfo getTableMetadata(int db_id, int table_id) const = 0;
+  virtual std::shared_ptr<const TableFragmentsInfo> getTableMetadata(
+      int db_id,
+      int table_id) const = 0;
 
   // Buffer API
   virtual AbstractBuffer* alloc(const size_t numBytes = 0) = 0;

--- a/omniscidb/DataMgr/BufferMgr/BufferMgr.h
+++ b/omniscidb/DataMgr/BufferMgr/BufferMgr.h
@@ -180,9 +180,10 @@ class BufferMgr : public AbstractBufferMgr {  // implements
     return nullptr;
   }
 
-  TableFragmentsInfo getTableMetadata(int db_id, int table_id) const override {
+  std::shared_ptr<const TableFragmentsInfo> getTableMetadata(int db_id, int table_id)
+      const override {
     UNREACHABLE();
-    return TableFragmentsInfo{};
+    return std::make_shared<TableFragmentsInfo>(TableFragmentsInfo{});
   }
 
   // Buffer API

--- a/omniscidb/DataMgr/DataMgr.cpp
+++ b/omniscidb/DataMgr/DataMgr.cpp
@@ -525,7 +525,8 @@ const DictDescriptor* DataMgr::getDictMetadata(int dict_id, bool load_dict) cons
   return getPersistentStorageMgr()->getDictMetadata(dict_id, load_dict);
 }
 
-TableFragmentsInfo DataMgr::getTableMetadata(int db_id, int table_id) const {
+std::shared_ptr<const TableFragmentsInfo> DataMgr::getTableMetadata(int db_id,
+                                                                    int table_id) const {
   return getPersistentStorageMgr()->getTableMetadata(db_id, table_id);
 }
 

--- a/omniscidb/DataMgr/DataMgr.h
+++ b/omniscidb/DataMgr/DataMgr.h
@@ -214,7 +214,8 @@ class DataMgr {
 
   const DictDescriptor* getDictMetadata(int dict_id, bool load_dict = true) const;
 
-  TableFragmentsInfo getTableMetadata(int db_id, int table_id) const;
+  std::shared_ptr<const TableFragmentsInfo> getTableMetadata(int db_id,
+                                                             int table_id) const;
 
   BufferProvider* getBufferProvider() const { return buffer_provider_.get(); }
 

--- a/omniscidb/DataMgr/DataMgrDataProvider.cpp
+++ b/omniscidb/DataMgr/DataMgrDataProvider.cpp
@@ -35,7 +35,9 @@ DataMgrDataProvider::getZeroCopyColumnData(const ColumnRef& col_ref) {
   return data_mgr_->getZeroCopyColumnData(col_ref);
 }
 
-TableFragmentsInfo DataMgrDataProvider::getTableMetadata(int db_id, int table_id) const {
+std::shared_ptr<const TableFragmentsInfo> DataMgrDataProvider::getTableMetadata(
+    int db_id,
+    int table_id) const {
   return data_mgr_->getTableMetadata(db_id, table_id);
 }
 

--- a/omniscidb/DataMgr/DataMgrDataProvider.h
+++ b/omniscidb/DataMgr/DataMgrDataProvider.h
@@ -38,7 +38,8 @@ class DataMgrDataProvider : public DataProvider {
   std::unique_ptr<Data_Namespace::AbstractDataToken> getZeroCopyColumnData(
       const ColumnRef& col_ref) override;
 
-  TableFragmentsInfo getTableMetadata(int db_id, int table_id) const override;
+  std::shared_ptr<const TableFragmentsInfo> getTableMetadata(int db_id,
+                                                             int table_id) const override;
 
   const DictDescriptor* getDictMetadata(int dict_id,
                                         bool load_dict = true) const override;

--- a/omniscidb/DataMgr/PersistentStorageMgr/PersistentStorageMgr.cpp
+++ b/omniscidb/DataMgr/PersistentStorageMgr/PersistentStorageMgr.cpp
@@ -133,7 +133,9 @@ const DictDescriptor* PersistentStorageMgr::getDictMetadata(int dict_id, bool lo
   return nullptr;
 }
 
-TableFragmentsInfo PersistentStorageMgr::getTableMetadata(int db_id, int table_id) const {
+std::shared_ptr<const TableFragmentsInfo> PersistentStorageMgr::getTableMetadata(
+    int db_id,
+    int table_id) const {
   return getStorageMgrForTableKey({db_id, table_id})->getTableMetadata(db_id, table_id);
 }
 

--- a/omniscidb/DataMgr/PersistentStorageMgr/PersistentStorageMgr.h
+++ b/omniscidb/DataMgr/PersistentStorageMgr/PersistentStorageMgr.h
@@ -56,7 +56,8 @@ class PersistentStorageMgr : public AbstractBufferMgr {
 
   const DictDescriptor* getDictMetadata(int dict_id, bool load_dict = true);
 
-  TableFragmentsInfo getTableMetadata(int db_id, int table_id) const override;
+  std::shared_ptr<const TableFragmentsInfo> getTableMetadata(int db_id,
+                                                             int table_id) const override;
 
   void registerDataProvider(int schema_id, std::shared_ptr<AbstractBufferMgr>);
 

--- a/omniscidb/DataProvider/DataProvider.h
+++ b/omniscidb/DataProvider/DataProvider.h
@@ -41,7 +41,9 @@ class DataProvider {
   virtual std::unique_ptr<Data_Namespace::AbstractDataToken> getZeroCopyColumnData(
       const ColumnRef& col_ref) = 0;
 
-  virtual TableFragmentsInfo getTableMetadata(int db_id, int table_id) const = 0;
+  virtual std::shared_ptr<const TableFragmentsInfo> getTableMetadata(
+      int db_id,
+      int table_id) const = 0;
 
   virtual const DictDescriptor* getDictMetadata(int dict_id,
                                                 bool load_dict = true) const = 0;

--- a/omniscidb/QueryEngine/Descriptors/QueryFragmentDescriptor.cpp
+++ b/omniscidb/QueryEngine/Descriptors/QueryFragmentDescriptor.cpp
@@ -35,7 +35,7 @@ QueryFragmentDescriptor::QueryFragmentDescriptor(
   for (size_t table_idx = 0; table_idx < input_desc_count; ++table_idx) {
     const auto table_ref = ra_exe_unit.input_descs[table_idx].getTableRef();
     if (!selected_tables_fragments_.count(table_ref)) {
-      selected_tables_fragments_[table_ref] = &query_infos[table_idx].info.fragments;
+      selected_tables_fragments_[table_ref] = &query_infos[table_idx].info->fragments;
     }
   }
 
@@ -55,7 +55,7 @@ void QueryFragmentDescriptor::computeAllTablesFragments(
     int table_id = ra_exe_unit.input_descs[tab_idx].getTableId();
     TableRef table_ref{db_id, table_id};
     CHECK_EQ(query_infos[tab_idx].table_id, table_id);
-    const auto& fragments = query_infos[tab_idx].info.fragments;
+    const auto& fragments = query_infos[tab_idx].info->fragments;
     if (!all_tables_fragments.count(table_ref)) {
       all_tables_fragments.insert(std::make_pair(table_ref, &fragments));
     }

--- a/omniscidb/QueryEngine/Execute.h
+++ b/omniscidb/QueryEngine/Execute.h
@@ -348,7 +348,8 @@ class Executor : public StringDictionaryProvider {
 
   const std::shared_ptr<RowSetMemoryOwner> getRowSetMemoryOwner() const;
 
-  TableFragmentsInfo getTableInfo(const int db_id, const int table_id) const;
+  std::shared_ptr<const TableFragmentsInfo> getTableInfo(const int db_id,
+                                                         const int table_id) const;
 
   const TableGeneration& getTableGeneration(int db_id, int table_id) const;
 

--- a/omniscidb/QueryEngine/ExecutionKernel.cpp
+++ b/omniscidb/QueryEngine/ExecutionKernel.cpp
@@ -94,11 +94,11 @@ bool need_to_hold_chunk(const std::list<std::shared_ptr<Chunk_NS::Chunk>>& chunk
 const std::vector<uint64_t>& SharedKernelContext::getFragOffsets() {
   std::lock_guard<std::mutex> lock(all_frag_row_offsets_mutex_);
   if (all_frag_row_offsets_.empty()) {
-    all_frag_row_offsets_.resize(query_infos_.front().info.fragments.size() + 1);
-    for (size_t i = 1; i <= query_infos_.front().info.fragments.size(); ++i) {
+    all_frag_row_offsets_.resize(query_infos_.front().info->fragments.size() + 1);
+    for (size_t i = 1; i <= query_infos_.front().info->fragments.size(); ++i) {
       all_frag_row_offsets_[i] =
           all_frag_row_offsets_[i - 1] +
-          query_infos_.front().info.fragments[i - 1].getNumTuples();
+          query_infos_.front().info->fragments[i - 1].getNumTuples();
     }
   }
   return all_frag_row_offsets_;
@@ -198,7 +198,7 @@ void ExecutionKernel::runImpl(Executor* executor,
         auto data_provider = column_fetcher.getDataProvider();
         CHECK(data_provider);
         auto table_meta = data_provider->getTableMetadata(qi.db_id, qi.table_id);
-        streaming_table_fragment = table_meta.fragments;
+        streaming_table_fragment = table_meta->fragments;
         all_tables_fragments[{qi.db_id, qi.table_id}] = &streaming_table_fragment;
       }
     }

--- a/omniscidb/QueryEngine/ExpressionRange.cpp
+++ b/omniscidb/QueryEngine/ExpressionRange.cpp
@@ -513,7 +513,7 @@ ExpressionRange getLeafColumnRange(const hdk::ir::ColumnVar* col_expr,
       }
       CHECK(ti_idx);
       const auto& query_info = query_infos[*ti_idx].info;
-      if (query_info.getNumTuples() == 0) {
+      if (query_info->getNumTuples() == 0) {
         // The column doesn't contain any values, synthesize an empty range.
         if (col_type->isFloatingPoint()) {
           return col_type->size() == 4 ? ExpressionRange::makeFloatRange(0, -1, false)
@@ -523,12 +523,12 @@ ExpressionRange getLeafColumnRange(const hdk::ir::ColumnVar* col_expr,
       }
       if (col_expr->isVirtual()) {
         CHECK(col_type->isInt64());
-        const int64_t num_tuples = query_info.getNumTuples();
+        const int64_t num_tuples = query_info->getNumTuples();
         return ExpressionRange::makeIntRange(
             0, std::max(num_tuples - 1, int64_t(0)), 0, has_nulls);
       }
 
-      auto& table_stats = query_info.getTableStats();
+      auto& table_stats = query_info->getTableStats();
       auto col_stats_it = table_stats.find(col_id);
       CHECK(col_stats_it != table_stats.end())
           << query_infos[*ti_idx].db_id << ":" << query_infos[*ti_idx].table_id << ":"

--- a/omniscidb/QueryEngine/FromTableReordering.cpp
+++ b/omniscidb/QueryEngine/FromTableReordering.cpp
@@ -235,8 +235,9 @@ std::vector<node_t> get_node_input_permutation(
   // Use the number of tuples in each table to break ties in BFS.
   const auto compare_node = [&table_infos](const node_t lhs_nest_level,
                                            const node_t rhs_nest_level) {
-    return table_infos[lhs_nest_level].info.getNumTuplesUpperBound() <
-           table_infos[rhs_nest_level].info.getNumTuplesUpperBound();
+    CHECK(table_infos[lhs_nest_level].info);
+    return table_infos[lhs_nest_level].info->getNumTuplesUpperBound() <
+           table_infos[rhs_nest_level].info->getNumTuplesUpperBound();
   };
   const auto compare_edge = [&compare_node](const TraversalEdge& lhs_edge,
                                             const TraversalEdge& rhs_edge) {

--- a/omniscidb/QueryEngine/InputMetadata.h
+++ b/omniscidb/QueryEngine/InputMetadata.h
@@ -32,19 +32,20 @@ using TemporaryTables = std::unordered_map<int, hdk::ResultSetTableTokenPtr>;
 struct InputTableInfo {
   int db_id;
   int table_id;
-  TableFragmentsInfo info;
+  std::shared_ptr<const TableFragmentsInfo> info = std::make_shared<TableFragmentsInfo>();
 };
 
 class InputTableInfoCache {
  public:
   InputTableInfoCache(Executor* executor);
 
-  TableFragmentsInfo getTableInfo(int db_id, int table_id);
+  std::shared_ptr<const TableFragmentsInfo> getTableInfo(int db_id, int table_id);
 
   void clear();
 
  private:
-  std::unordered_map<std::pair<int, int>, TableFragmentsInfo> cache_;
+  std::unordered_map<std::pair<int, int>, std::shared_ptr<const TableFragmentsInfo>>
+      cache_;
   Executor* executor_;
 };
 

--- a/omniscidb/QueryEngine/JoinFilterPushDown.cpp
+++ b/omniscidb/QueryEngine/JoinFilterPushDown.cpp
@@ -80,7 +80,8 @@ FilterSelectivity RelAlgExecutor::getFilterSelectivity(
   hdk::ResultSetTable filtered_result;
   const auto table_infos = get_table_infos(input_descs, executor_);
   CHECK_EQ(size_t(1), table_infos.size());
-  const size_t total_rows_upper_bound = table_infos.front().info.getNumTuplesUpperBound();
+  const size_t total_rows_upper_bound =
+      table_infos.front().info->getNumTuplesUpperBound();
   try {
     ColumnCacheMap column_cache;
     filtered_result = executor_->executeWorkUnit(

--- a/omniscidb/QueryEngine/JoinHashTable/BaselineJoinHashTable.cpp
+++ b/omniscidb/QueryEngine/JoinHashTable/BaselineJoinHashTable.cpp
@@ -249,11 +249,11 @@ void BaselineJoinHashTable::reify(const HashType preferred_layout) {
 void BaselineJoinHashTable::reifyWithLayout(const HashType layout) {
   const auto& query_info =
       get_inner_query_info(getInnerDbId(), getInnerTableId(), query_infos_).info;
-  if (query_info.fragments.empty()) {
+  if (query_info->fragments.empty()) {
     return;
   }
 
-  const auto total_entries = 2 * query_info.getNumTuplesUpperBound();
+  const auto total_entries = 2 * query_info->getNumTuplesUpperBound();
   if (total_entries > static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
     throw TooManyHashEntries();
   }
@@ -270,7 +270,7 @@ void BaselineJoinHashTable::reifyWithLayout(const HashType layout) {
   auto entries_per_device = total_entries;
 
   for (int device_id = 0; device_id < device_count_; ++device_id) {
-    const auto fragments = query_info.fragments;
+    const auto fragments = query_info->fragments;
     const auto columns_for_device =
         fetchColumnsForDevice(fragments,
                               device_id,
@@ -310,7 +310,7 @@ void BaselineJoinHashTable::reifyWithLayout(const HashType layout) {
   }
   std::vector<std::future<void>> init_threads;
   for (int device_id = 0; device_id < device_count_; ++device_id) {
-    const auto fragments = query_info.fragments;
+    const auto fragments = query_info->fragments;
     init_threads.push_back(std::async(std::launch::async,
                                       &BaselineJoinHashTable::reifyForDevice,
                                       this,

--- a/omniscidb/QueryEngine/JoinHashTable/HashJoin.cpp
+++ b/omniscidb/QueryEngine/JoinHashTable/HashJoin.cpp
@@ -501,13 +501,10 @@ std::vector<InputTableInfo> getSyntheticInputTableInfo(
   // NOTE(sy): This vector ordering seems to work for now, but maybe we need to
   // review how rte_idx is assigned for ColumnVars. See for example Analyzer.h
   // and RelAlgExecutor.cpp and rte_idx there.
-  std::vector<InputTableInfo> query_infos(phys_table_ids.size());
-  size_t i = 0;
+  std::vector<InputTableInfo> query_infos;
   for (auto [db_id, table_id] : phys_table_ids) {
-    query_infos[i].db_id = db_id;
-    query_infos[i].table_id = table_id;
-    query_infos[i].info = executor->getDataMgr()->getTableMetadata(db_id, table_id);
-    ++i;
+    query_infos.emplace_back(InputTableInfo{
+        db_id, table_id, executor->getDataMgr()->getTableMetadata(db_id, table_id)});
   }
 
   return query_infos;

--- a/omniscidb/QueryEngine/JoinHashTable/PerfectJoinHashTable.cpp
+++ b/omniscidb/QueryEngine/JoinHashTable/PerfectJoinHashTable.cpp
@@ -155,7 +155,7 @@ std::shared_ptr<PerfectJoinHashTable> PerfectJoinHashTable::getInstance(
   if (bucketized_entry_count > executor->getConfig().exec.join.huge_join_hash_threshold) {
     const auto& query_info =
         get_inner_query_info(inner_col->dbId(), inner_col->tableId(), query_infos).info;
-    if (query_info.getNumTuplesUpperBound() * 100 <
+    if (query_info->getNumTuplesUpperBound() * 100 <
         executor->getConfig().exec.join.huge_join_hash_min_load *
             bucketized_entry_count) {
       throw TooManyHashEntries();
@@ -304,10 +304,10 @@ void PerfectJoinHashTable::reify() {
       qual_bin_oper_.get(), executor_->getSchemaProvider(), executor_->temporary_tables_);
   const auto inner_col = cols.first;
   const auto& query_info = getInnerQueryInfo(inner_col).info;
-  if (query_info.fragments.empty()) {
+  if (query_info->fragments.empty()) {
     return;
   }
-  if (query_info.getNumTuplesUpperBound() >
+  if (query_info->getNumTuplesUpperBound() >
       static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
     throw TooManyHashEntries();
   }
@@ -328,7 +328,7 @@ void PerfectJoinHashTable::reify() {
   }
 
   for (int device_id = 0; device_id < device_count_; ++device_id) {
-    fragments_per_device.emplace_back(query_info.fragments);
+    fragments_per_device.emplace_back(query_info->fragments);
     columns_per_device.emplace_back(
         fetchColumnsForDevice(fragments_per_device.back(),
                               device_id,
@@ -723,7 +723,7 @@ ChunkKey PerfectJoinHashTable::genChunkKey(const std::vector<FragmentInfo>& frag
     const auto outer_col = dynamic_cast<const hdk::ir::ColumnVar*>(outer_col_expr);
     CHECK(outer_col);
     const auto& outer_query_info = getInnerQueryInfo(outer_col).info;
-    for (auto& frag : outer_query_info.fragments) {
+    for (auto& frag : outer_query_info->fragments) {
       outer_elem_count = frag.getNumTuples();
     }
     chunk_key.push_back(outer_elem_count);

--- a/omniscidb/QueryEngine/MemoryLayoutBuilder.cpp
+++ b/omniscidb/QueryEngine/MemoryLayoutBuilder.cpp
@@ -636,7 +636,7 @@ int8_t pick_target_compact_width(const RelAlgExecutionUnit& ra_exe_unit,
   if (!compact_width) {
     size_t total_tuples{0};
     for (const auto& qi : query_infos) {
-      total_tuples += qi.info.getNumTuples();
+      total_tuples += qi.info->getNumTuples();
     }
     return total_tuples <= static_cast<size_t>(std::numeric_limits<uint32_t>::max()) ||
                    unnest_array_col_id != std::numeric_limits<int>::min()

--- a/omniscidb/QueryEngine/NativeCodegen.cpp
+++ b/omniscidb/QueryEngine/NativeCodegen.cpp
@@ -984,12 +984,12 @@ void Executor::createErrorCheckControlFlow(
             CHECK_LE(freq_control_knob, 1.0);
             if (!input_table_infos.empty()) {
               const auto& outer_table_info = *input_table_infos.begin();
-              auto num_outer_table_tuples = outer_table_info.info.getNumTuples();
+              auto num_outer_table_tuples = outer_table_info.info->getNumTuples();
               CHECK_GT(outer_table_info.table_id, 0);
-              auto num_frags = outer_table_info.info.fragments.size();
+              auto num_frags = outer_table_info.info->fragments.size();
               if (num_frags > 0) {
                 num_outer_table_tuples =
-                    outer_table_info.info.fragments.begin()->getNumTuples();
+                    outer_table_info.info->fragments.begin()->getNumTuples();
               }
               if (num_outer_table_tuples > 0) {
                 // gridSize * blockSize --> pos_step (idx of the next row per thread)

--- a/omniscidb/QueryEngine/WorkUnitBuilder.cpp
+++ b/omniscidb/QueryEngine/WorkUnitBuilder.cpp
@@ -594,7 +594,7 @@ void WorkUnitBuilder::processUnion(const hdk::ir::LogicalUnion* logical_union) {
                       query_infos.cend(),
                       size_t(0),
                       [](auto max, auto const& query_info) {
-                        return std::max(max, query_info.info.getNumTuples());
+                        return std::max(max, query_info.info->getNumTuples());
                       });
 
   // We expect input ot be an execution point. In this case target

--- a/omniscidb/ResultSetRegistry/ResultSetRegistry.h
+++ b/omniscidb/ResultSetRegistry/ResultSetRegistry.h
@@ -52,7 +52,8 @@ class ResultSetRegistry : public SimpleSchemaProvider,
       const ChunkKey& key,
       size_t num_bytes) override;
 
-  TableFragmentsInfo getTableMetadata(int db_id, int table_id) const override;
+  std::shared_ptr<const TableFragmentsInfo> getTableMetadata(int db_id,
+                                                             int table_id) const override;
 
   const DictDescriptor* getDictMetadata(int dict_id, bool load_dict = true) override;
 

--- a/omniscidb/Tests/ArrowStorageTest.cpp
+++ b/omniscidb/Tests/ArrowStorageTest.cpp
@@ -55,7 +55,7 @@ int getDictId(const hdk::ir::Type* type) {
 
   std::cout << "  Fragments:" << std::endl;
   auto meta = storage.getTableMetadata(TEST_DB_ID, table_id);
-  for (auto& frag : meta.fragments) {
+  for (auto& frag : meta->fragments) {
     std::cout << "    Fragment #" << frag.fragmentId << " - " << frag.getNumTuples()
               << " row(s)" << std::endl;
     for (int col_id = 1; col_id < col_infos.back()->column_id; ++col_id) {
@@ -631,19 +631,19 @@ void checkData(ArrowStorage& storage,
   size_t frag_count = (row_count + fragment_size - 1) / fragment_size;
   auto meta = storage.getTableMetadata(TEST_DB_ID, table_id);
   auto cols = storage.listColumns(TEST_DB_ID, table_id);
-  CHECK_EQ(meta.getNumTuples(), row_count);
-  CHECK_EQ(meta.getPhysicalNumTuples(), row_count);
-  CHECK_EQ(meta.fragments.size(), frag_count);
+  CHECK_EQ(meta->getNumTuples(), row_count);
+  CHECK_EQ(meta->getPhysicalNumTuples(), row_count);
+  CHECK_EQ(meta->fragments.size(), frag_count);
   for (size_t frag_idx = 0; frag_idx < frag_count; ++frag_idx) {
     size_t start_row = frag_idx * fragment_size;
     size_t end_row = std::min(row_count, start_row + fragment_size);
     size_t frag_rows = end_row - start_row;
-    CHECK_EQ(meta.fragments[frag_idx].fragmentId, static_cast<int>(frag_idx + 1));
-    CHECK_EQ(meta.fragments[frag_idx].physicalTableId, table_id);
-    CHECK_EQ(meta.fragments[frag_idx].getNumTuples(), frag_rows);
-    CHECK_EQ(meta.fragments[frag_idx].getPhysicalNumTuples(), frag_rows);
+    CHECK_EQ(meta->fragments[frag_idx].fragmentId, static_cast<int>(frag_idx + 1));
+    CHECK_EQ(meta->fragments[frag_idx].physicalTableId, table_id);
+    CHECK_EQ(meta->fragments[frag_idx].getNumTuples(), frag_rows);
+    CHECK_EQ(meta->fragments[frag_idx].getPhysicalNumTuples(), frag_rows);
 
-    auto chunk_meta_map = meta.fragments[frag_idx].getChunkMetadataMap();
+    auto chunk_meta_map = meta->fragments[frag_idx].getChunkMetadataMap();
     CHECK_EQ(chunk_meta_map.size(), sizeof...(Ts));
     for (int i = 0; i < static_cast<int>(chunk_meta_map.size()); ++i) {
       CHECK_EQ(chunk_meta_map.count(cols[i]->column_id), (size_t)1);

--- a/omniscidb/Tests/FromTableReorderingTest.cpp
+++ b/omniscidb/Tests/FromTableReorderingTest.cpp
@@ -60,8 +60,8 @@ TEST(Ordering, Basic) {
 
     size_t number_of_join_tables{2};
     std::vector<InputTableInfo> viti(number_of_join_tables);
-    viti[0].info.setPhysicalNumTuples(2);
-    viti[1].info.setPhysicalNumTuples(1);
+    const_cast<TableFragmentsInfo*>(viti[0].info.get())->setPhysicalNumTuples(2);
+    const_cast<TableFragmentsInfo*>(viti[1].info.get())->setPhysicalNumTuples(1);
 
     auto input_permutation = get_node_input_permutation(nesting_levels, viti, nullptr);
     decltype(input_permutation) expected_input_permutation{0, 1};
@@ -81,8 +81,8 @@ TEST(Ordering, Basic) {
 
     size_t number_of_join_tables{2};
     std::vector<InputTableInfo> viti(number_of_join_tables);
-    viti[0].info.setPhysicalNumTuples(1);
-    viti[1].info.setPhysicalNumTuples(2);
+    const_cast<TableFragmentsInfo*>(viti[0].info.get())->setPhysicalNumTuples(1);
+    const_cast<TableFragmentsInfo*>(viti[1].info.get())->setPhysicalNumTuples(2);
 
     auto input_permutation = get_node_input_permutation(nesting_levels, viti, nullptr);
     decltype(input_permutation) expected_input_permutation{1, 0};
@@ -121,8 +121,8 @@ TEST(Ordering, Basic) {
 
     size_t number_of_join_tables{2};
     std::vector<InputTableInfo> viti(number_of_join_tables);
-    viti[0].info.setPhysicalNumTuples(2);
-    viti[1].info.setPhysicalNumTuples(1);
+    const_cast<TableFragmentsInfo*>(viti[0].info.get())->setPhysicalNumTuples(2);
+    const_cast<TableFragmentsInfo*>(viti[1].info.get())->setPhysicalNumTuples(1);
 
     auto input_permutation = get_node_input_permutation(nesting_levels, viti, nullptr);
     decltype(input_permutation) expected_input_permutation{0, 1};
@@ -142,8 +142,8 @@ TEST(Ordering, Basic) {
 
     size_t number_of_join_tables{2};
     std::vector<InputTableInfo> viti(number_of_join_tables);
-    viti[0].info.setPhysicalNumTuples(1);
-    viti[1].info.setPhysicalNumTuples(2);
+    const_cast<TableFragmentsInfo*>(viti[0].info.get())->setPhysicalNumTuples(1);
+    const_cast<TableFragmentsInfo*>(viti[1].info.get())->setPhysicalNumTuples(2);
 
     auto input_permutation = get_node_input_permutation(nesting_levels, viti, nullptr);
     decltype(input_permutation) expected_input_permutation{0, 1};
@@ -194,9 +194,9 @@ TEST(Ordering, Triple) {
 
     size_t number_of_join_tables{3};
     std::vector<InputTableInfo> viti(number_of_join_tables);
-    viti[0].info.setPhysicalNumTuples(3);
-    viti[1].info.setPhysicalNumTuples(2);
-    viti[2].info.setPhysicalNumTuples(1);
+    const_cast<TableFragmentsInfo*>(viti[0].info.get())->setPhysicalNumTuples(3);
+    const_cast<TableFragmentsInfo*>(viti[1].info.get())->setPhysicalNumTuples(2);
+    const_cast<TableFragmentsInfo*>(viti[2].info.get())->setPhysicalNumTuples(1);
 
     auto input_permutation = get_node_input_permutation(nesting_levels, viti, nullptr);
     decltype(input_permutation) expected_input_permutation{0, 1, 2};
@@ -221,9 +221,9 @@ TEST(Ordering, Triple) {
 
     size_t number_of_join_tables{3};
     std::vector<InputTableInfo> viti(number_of_join_tables);
-    viti[0].info.setPhysicalNumTuples(1);
-    viti[1].info.setPhysicalNumTuples(2);
-    viti[2].info.setPhysicalNumTuples(3);
+    const_cast<TableFragmentsInfo*>(viti[0].info.get())->setPhysicalNumTuples(1);
+    const_cast<TableFragmentsInfo*>(viti[1].info.get())->setPhysicalNumTuples(2);
+    const_cast<TableFragmentsInfo*>(viti[2].info.get())->setPhysicalNumTuples(3);
 
     auto input_permutation = get_node_input_permutation(nesting_levels, viti, nullptr);
     decltype(input_permutation) expected_input_permutation{2, 1, 0};
@@ -272,9 +272,9 @@ TEST(Ordering, Triple) {
 
     size_t number_of_join_tables{3};
     std::vector<InputTableInfo> viti(number_of_join_tables);
-    viti[0].info.setPhysicalNumTuples(3);
-    viti[1].info.setPhysicalNumTuples(2);
-    viti[2].info.setPhysicalNumTuples(1);
+    const_cast<TableFragmentsInfo*>(viti[0].info.get())->setPhysicalNumTuples(3);
+    const_cast<TableFragmentsInfo*>(viti[1].info.get())->setPhysicalNumTuples(2);
+    const_cast<TableFragmentsInfo*>(viti[2].info.get())->setPhysicalNumTuples(1);
 
     auto input_permutation = get_node_input_permutation(nesting_levels, viti, nullptr);
     decltype(input_permutation) expected_input_permutation{0, 1, 2};
@@ -299,9 +299,9 @@ TEST(Ordering, Triple) {
 
     size_t number_of_join_tables{3};
     std::vector<InputTableInfo> viti(number_of_join_tables);
-    viti[0].info.setPhysicalNumTuples(1);
-    viti[1].info.setPhysicalNumTuples(2);
-    viti[2].info.setPhysicalNumTuples(3);
+    const_cast<TableFragmentsInfo*>(viti[0].info.get())->setPhysicalNumTuples(1);
+    const_cast<TableFragmentsInfo*>(viti[1].info.get())->setPhysicalNumTuples(2);
+    const_cast<TableFragmentsInfo*>(viti[2].info.get())->setPhysicalNumTuples(3);
 
     auto input_permutation = get_node_input_permutation(nesting_levels, viti, nullptr);
     decltype(input_permutation) expected_input_permutation{0, 1, 2};

--- a/omniscidb/Tests/TestDataProvider.h
+++ b/omniscidb/Tests/TestDataProvider.h
@@ -131,10 +131,11 @@ class TestDataProvider : public AbstractDataProvider {
                    numBytes);
   }
 
-  TableFragmentsInfo getTableMetadata(int db_id, int table_id) const override {
+  std::shared_ptr<const TableFragmentsInfo> getTableMetadata(int db_id, int table_id)
+      const override {
     CHECK_EQ(db_id, db_id_);
     CHECK_EQ(tables_.count(table_id), (size_t)1);
-    return tables_.at(table_id).getTableInfo();
+    return std::make_shared<TableFragmentsInfo>(tables_.at(table_id).getTableInfo());
   }
 
   template <typename T>


### PR DESCRIPTION
This PR is another step in making HDK more fragment transparent.

Target case: table with many columns (over 20) split into considerable number of fragments.

Problem: the entire table info (size depends on fragment count) is copied regardless of query-relevant columns.

Solution: since `InputTableInfoCache` is scoped to `executeRelAlgQueryNoRetry()` and the only place where anything is inserted into the cache (and never updated) is `InputTableInfoCache::getTableInfo()` , can't we just const reference it (especially for `computeTableGenerations()` where we only need tuple count)?

Effect: well, we still have to materialize `InputTableInfo` in cache, but we can save on further copies, so **3x faster `Query pre-execution steps`**.