### PR TITLE
Replace dictionary proxies with nested dictionaries 05/N

### DIFF
--- a/omniscidb/QueryEngine/StringOpsIR.cpp
+++ b/omniscidb/QueryEngine/StringOpsIR.cpp
@@ -206,7 +206,7 @@ llvm::Value* CodeGenerator::codegenDictLike(const hdk::ir::ExprPtr like_arg,
       dict_like_arg_type->as<hdk::ir::ExtDictionaryType>()->dictId(),
       executor()->getRowSetMemoryOwner(),
       true);
-  if (sdp->storageEntryCount() > 200000000) {
+  if (sdp->entryCount() > 200000000) {
     return nullptr;
   }
   const auto& pattern_type = pattern->type();
@@ -324,7 +324,7 @@ llvm::Value* CodeGenerator::codegenDictStrCmp(const hdk::ir::ExprPtr lhs,
       executor()->getRowSetMemoryOwner(),
       true);
 
-  if (sdp->storageEntryCount() > 200000000) {
+  if (sdp->entryCount() > 200000000) {
     std::runtime_error("Cardinality for string dictionary is too high");
     return nullptr;
   }
@@ -413,7 +413,7 @@ llvm::Value* CodeGenerator::codegenDictRegexp(const hdk::ir::ExprPtr pattern_arg
   const auto dict_id = dict_regexp_arg_type->as<hdk::ir::ExtDictionaryType>()->dictId();
   const auto sdp = executor()->getStringDictionaryProxy(
       dict_id, executor()->getRowSetMemoryOwner(), true);
-  if (sdp->storageEntryCount() > 15000000) {
+  if (sdp->entryCount() > 15000000) {
     return nullptr;
   }
   const auto& pattern_type = pattern->type();

--- a/omniscidb/ResultSet/ResultSet.cpp
+++ b/omniscidb/ResultSet/ResultSet.cpp
@@ -237,8 +237,12 @@ std::string ResultSet::getStrScalarVal(const ScalarTargetValue& current_scalar,
     if (col_type->isExtDictionary()) {
       const int32_t dict_id = col_type->as<hdk::ir::ExtDictionaryType>()->dictId();
       const auto sdp = getStringDictionaryProxy(dict_id);
-      oss << "idx:" << ((sdp->storageEntryCount()) ? current_scalar : "null") << ", str:"
-          << "\"" << sdp->getString(boost::get<int64_t>(current_scalar)) << "\"";
+      const auto string_id = boost::get<int64_t>(current_scalar);
+      oss << "idx:"
+          << ((string_id == inline_int_null_value<int32_t>()) ? "null"
+                                                              : std::to_string(string_id))
+          << ", str:"
+          << "\"" << sdp->getString(string_id) << "\"";
     } else {
       if ((col_type->isInt64() &&
            boost::get<int64_t>(current_scalar) == std::numeric_limits<int64_t>::min()) ||

--- a/omniscidb/StringDictionary/StringDictionaryProxy.h
+++ b/omniscidb/StringDictionary/StringDictionaryProxy.h
@@ -146,17 +146,6 @@ class StringDictionaryProxy {
   IdMap buildUnionTranslationMapToOtherProxy(StringDictionaryProxy* dest_proxy) const;
 
   /**
-   * @brief Returns the number of string entries in the underlying string dictionary,
-   * at this proxy's generation_ if it is set/valid, otherwise just the current
-   * size of the dictionary
-   *
-   * @return size_t Number of entries in the string dictionary
-   * (at this proxy's generation if set)
-   *
-   */
-  size_t storageEntryCount() const;
-
-  /**
    * @brief Returns the number of transient string entries for this proxy,
    *
    * @return size_t Number of transient string entries for this proxy
@@ -211,6 +200,17 @@ class StringDictionaryProxy {
   void eachStringSerially(StringDictionary::StringCallback&) const;
 
  private:
+  /**
+   * @brief Returns the number of string entries in the underlying string dictionary,
+   * at this proxy's generation_ if it is set/valid, otherwise just the current
+   * size of the dictionary
+   *
+   * @return size_t Number of entries in the string dictionary
+   * (at this proxy's generation if set)
+   *
+   */
+  size_t storageEntryCount() const;
+
   std::string getStringUnlocked(const int32_t string_id) const;
   size_t transientEntryCountUnlocked() const;
   size_t entryCountUnlocked() const;

--- a/omniscidb/Tests/StringDictionaryTest.cpp
+++ b/omniscidb/Tests/StringDictionaryTest.cpp
@@ -717,13 +717,15 @@ TEST(StringDictionaryProxy, BuildUnionTranslationMapToPartialOverlapProxy) {
   const auto transient_source_strings = add_strings_numeric_range(
       source_sdp, num_source_transient_entries, source_transient_start_val);
   ASSERT_EQ(source_sdp.getBaseDictionary()->getDictId(), 1);
-  ASSERT_EQ(source_sdp.storageEntryCount(), num_source_persisted_entries);
+  ASSERT_EQ(source_sdp.getBaseDictionary()->storageEntryCount(),
+            num_source_persisted_entries);
   ASSERT_EQ(source_sdp.transientEntryCount(), num_source_transient_entries);
 
   const auto transient_dest_strings = add_strings_numeric_range(
       dest_sdp, num_dest_transient_entries, dest_transient_start_val);
   ASSERT_EQ(dest_sdp.getBaseDictionary()->getDictId(), 2);
-  ASSERT_EQ(dest_sdp.storageEntryCount(), num_dest_persisted_entries);
+  ASSERT_EQ(dest_sdp.getBaseDictionary()->storageEntryCount(),
+            num_dest_persisted_entries);
   ASSERT_EQ(dest_sdp.transientEntryCount(), num_dest_transient_entries);
 
   const auto id_map = source_sdp.buildUnionTranslationMapToOtherProxy(&dest_sdp);


### PR DESCRIPTION
Make `StringDictionaryProxy::storageEntryCount` private. This is done because its semantics differ from `StringDictionary::storageEntryCount`. 