### PR TITLE
Replace dictionary proxies with nested dictionaries 06/N

### DIFF
--- a/omniscidb/ResultSet/ResultSet.cpp
+++ b/omniscidb/ResultSet/ResultSet.cpp
@@ -851,13 +851,6 @@ size_t ResultSet::getOffset() const {
   return drop_first_;
 }
 
-const std::vector<std::string> ResultSet::getStringDictionaryPayloadCopy(
-    const int dict_id) const {
-  const auto sdp = row_set_mem_owner_->getOrAddStringDictProxy(dict_id);
-  CHECK(sdp);
-  return sdp->getBaseDictionary()->copyStrings();
-}
-
 const std::pair<std::vector<int32_t>, std::vector<std::string>>
 ResultSet::getUniqueStringsForDictEncodedTargetCol(const size_t col_idx) const {
   const auto col_type = colType(col_idx);

--- a/omniscidb/ResultSet/ResultSet.h
+++ b/omniscidb/ResultSet/ResultSet.h
@@ -520,8 +520,6 @@ class ResultSet {
     separate_varlen_storage_valid_ = val;
   }
 
-  const std::vector<std::string> getStringDictionaryPayloadCopy(const int dict_id) const;
-
   const std::pair<std::vector<int32_t>, std::vector<std::string>>
   getUniqueStringsForDictEncodedTargetCol(const size_t col_idx) const;
 

--- a/omniscidb/StringDictionary/StringDictionaryProxy.cpp
+++ b/omniscidb/StringDictionary/StringDictionaryProxy.cpp
@@ -653,3 +653,12 @@ bool StringDictionaryProxy::operator==(StringDictionaryProxy const& rhs) const {
 bool StringDictionaryProxy::operator!=(StringDictionaryProxy const& rhs) const {
   return !operator==(rhs);
 }
+
+std::vector<std::string> StringDictionaryProxy::copyStrings() const {
+  auto res = string_dict_->copyStrings();
+  res.reserve(entryCount());
+  for (auto str_ptr : transient_string_vec_) {
+    res.emplace_back(*str_ptr);
+  }
+  return res;
+}

--- a/omniscidb/StringDictionary/StringDictionaryProxy.h
+++ b/omniscidb/StringDictionary/StringDictionaryProxy.h
@@ -180,10 +180,12 @@ class StringDictionaryProxy {
   // in the std::map when new strings are added, but will change in a std::vector.
   using TransientMap = std::map<std::string, int32_t, std::less<>>;
 
-  const std::vector<std::string const*>& getTransientVector() const {
-    return transient_string_vec_;
-  }
+  std::vector<std::string> copyStrings() const;
 
+  // Iterate over transient strings, then non-transients.
+  void eachStringSerially(StringDictionary::StringCallback&) const;
+
+ private:
   // INVALID_STR_ID = -1 is reserved for invalid string_ids.
   // Thus the greatest valid transient string_id is -2.
   static unsigned transientIdToIndex(int32_t const id) {
@@ -196,10 +198,6 @@ class StringDictionaryProxy {
     return static_cast<int32_t>(max_transient_string_id - index);
   }
 
-  // Iterate over transient strings, then non-transients.
-  void eachStringSerially(StringDictionary::StringCallback&) const;
-
- private:
   /**
    * @brief Returns the number of string entries in the underlying string dictionary,
    * at this proxy's generation_ if it is set/valid, otherwise just the current


### PR DESCRIPTION
Add `StringDictionaryProxy::copyStrings`. This is to avoid special handling of transient strings (special ID handling will be removed later).