### PR TITLE
Replace dictionary proxies with nested dictionaries 07/N

### DIFF
--- a/omniscidb/StringDictionary/StringDictionaryProxy.h
+++ b/omniscidb/StringDictionary/StringDictionaryProxy.h
@@ -39,7 +39,8 @@ class StringDictionaryProxy {
  public:
   StringDictionaryProxy(StringDictionaryProxy const&) = delete;
   StringDictionaryProxy const& operator=(StringDictionaryProxy const&) = delete;
-  StringDictionaryProxy(std::shared_ptr<StringDictionary> sd, const int64_t generation);
+  StringDictionaryProxy(std::shared_ptr<StringDictionary> sd,
+                        const int64_t generation = -1);
 
   bool operator==(StringDictionaryProxy const&) const;
   bool operator!=(StringDictionaryProxy const&) const;


### PR DESCRIPTION
Avoid negative generation in dictionary proxy. There is no strong reason to create a proxy with a negative generation anyway. Non-zero generation on a proxy creation would allow us later to stop using negative indices for transient strings. Non-negative indices would allow deep nesting and let us treat proxy-encoded columns as regular dictionary-encoded columns.