### PR TITLE
Replace dictionary proxies with nested dictionaries 08/N

### DIFF
--- a/omniscidb/ResultSet/ResultSet.cpp
+++ b/omniscidb/ResultSet/ResultSet.cpp
@@ -236,7 +236,9 @@ std::string ResultSet::getStrScalarVal(const ScalarTargetValue& current_scalar,
   } else {
     if (col_type->isExtDictionary()) {
       const int32_t dict_id = col_type->as<hdk::ir::ExtDictionaryType>()->dictId();
-      const auto sdp = getStringDictionaryProxy(dict_id);
+      const auto sdp = data_mgr_ ? row_set_mem_owner_->getOrAddStringDictProxy(dict_id)
+                                 : row_set_mem_owner_->getStringDictProxy(
+                                       dict_id);  // unit tests bypass the DataMgr
       const auto string_id = boost::get<int64_t>(current_scalar);
       oss << "idx:"
           << ((string_id == inline_int_null_value<int32_t>()) ? "null"

--- a/omniscidb/StringDictionary/StringDictionaryProxy.h
+++ b/omniscidb/StringDictionary/StringDictionaryProxy.h
@@ -80,27 +80,26 @@ class StringDictionaryProxy {
   std::pair<const char*, size_t> getStringBytes(int32_t string_id) const noexcept;
 
   class IdMap {
-    size_t const offset_;
+    const uint32_t dict_size_;
     std::vector<int32_t> vector_map_;
     int64_t num_untranslated_strings_{-1};
 
    public:
-    // +1 is added to skip string_id=-1 reserved for INVALID_STR_ID. id_map[-1]==-1.
     IdMap(uint32_t const tran_size, uint32_t const dict_size)
-        : offset_(tran_size + 1)
-        , vector_map_(offset_ + dict_size, StringDictionary::INVALID_STR_ID) {}
+        : dict_size_(dict_size)
+        , vector_map_(tran_size + dict_size, StringDictionary::INVALID_STR_ID) {}
     IdMap(IdMap const&) = delete;
     IdMap(IdMap&&) = default;
-    bool empty() const { return vector_map_.size() == 1; }
-    inline size_t getIndex(int32_t const id) const { return offset_ + id; }
+    bool empty() const { return vector_map_.empty(); }
+    inline size_t getIndex(int32_t const id) const { return id; }
     std::vector<int32_t> const& getVectorMap() const { return vector_map_; }
     size_t size() const { return vector_map_.size(); }
-    size_t numTransients() const { return offset_ - 1; }
-    size_t numNonTransients() const { return vector_map_.size() - offset_; }
+    size_t numTransients() const { return vector_map_.size() - dict_size_; }
+    size_t numNonTransients() const { return dict_size_; }
     int32_t* data() { return vector_map_.data(); }
     int32_t const* data() const { return vector_map_.data(); }
-    int32_t domainStart() const { return -static_cast<int32_t>(offset_); }
-    int32_t domainEnd() const { return static_cast<int32_t>(numNonTransients()); }
+    int32_t domainStart() const { return 0; }
+    int32_t domainEnd() const { return vector_map_.size(); }
     // Next two methods are currently used by buildUnionTranslationMapToOtherProxy to
     // short circuit iteration over ids after intersection translation if all
     // ids translated. Currently the private num_untranslated_strings_ is initialized
@@ -114,7 +113,7 @@ class StringDictionaryProxy {
     void setNumUntranslatedStrings(const size_t num_untranslated_strings) {
       num_untranslated_strings_ = static_cast<int64_t>(num_untranslated_strings);
     }
-    int32_t* storageData() { return vector_map_.data() + offset_; }
+    int32_t* transientData() { return vector_map_.data() + dict_size_; }
     int32_t& operator[](int32_t const id) { return vector_map_[getIndex(id)]; }
     int32_t operator[](int32_t const id) const { return vector_map_[getIndex(id)]; }
     friend std::ostream& operator<<(std::ostream&, IdMap const&);
@@ -187,17 +186,11 @@ class StringDictionaryProxy {
   void eachStringSerially(StringDictionary::StringCallback&) const;
 
  private:
-  // INVALID_STR_ID = -1 is reserved for invalid string_ids.
-  // Thus the greatest valid transient string_id is -2.
-  static unsigned transientIdToIndex(int32_t const id) {
-    constexpr int max_transient_string_id = -2;
-    return static_cast<unsigned>(max_transient_string_id - id);
+  unsigned transientIdToIndex(int32_t const id) const {
+    return static_cast<unsigned>(id - generation_);
   }
 
-  static int32_t transientIndexToId(unsigned const index) {
-    constexpr int max_transient_string_id = -2;
-    return static_cast<int32_t>(max_transient_string_id - index);
-  }
+  int32_t transientIndexToId(unsigned const index) const { return generation_ + index; }
 
   /**
    * @brief Returns the number of string entries in the underlying string dictionary,

--- a/omniscidb/Tests/ColumnarResultsTest.cpp
+++ b/omniscidb/Tests/ColumnarResultsTest.cpp
@@ -95,6 +95,7 @@ void test_columnar_conversion(const std::vector<TargetInfo>& target_infos,
                       target_infos,
                       query_mem_desc,
                       generator,
+                      0,
                       non_empty_step_size);
 
   // Columnar Conversion:

--- a/omniscidb/Tests/GpuSharedMemoryTestHelpers.cpp
+++ b/omniscidb/Tests/GpuSharedMemoryTestHelpers.cpp
@@ -163,6 +163,7 @@ std::vector<std::unique_ptr<ResultSet>> create_and_fill_input_result_sets(
                         target_infos,
                         query_mem_desc,
                         generators[i],
+                        0,
                         steps[i]);
   }
   return result_sets;

--- a/omniscidb/Tests/ResultSetBaselineRadixSortTest.cpp
+++ b/omniscidb/Tests/ResultSetBaselineRadixSortTest.cpp
@@ -114,7 +114,7 @@ void fill_storage_buffer_baseline_sort_int(int8_t* buff,
                                        sizeof(K),
                                        row_size_quad);
     CHECK(value_slots);
-    fill_one_entry_baseline(value_slots, val, target_infos);
+    fill_one_entry_baseline(value_slots, val, target_infos, 0);
   }
 }
 
@@ -160,7 +160,8 @@ void fill_storage_buffer_baseline_sort_fp(int8_t* buff,
                                        sizeof(int64_t),
                                        key_component_count + target_slot_count);
     CHECK(value_slots);
-    fill_one_entry_baseline(value_slots, val, target_infos, false, val == null_pattern);
+    fill_one_entry_baseline(
+        value_slots, val, target_infos, 0, false, val == null_pattern);
   }
 }
 

--- a/omniscidb/Tests/ResultSetTestUtils.h
+++ b/omniscidb/Tests/ResultSetTestUtils.h
@@ -83,6 +83,7 @@ int8_t* fill_one_entry_no_collisions(int8_t* buff,
                                      const QueryMemoryDescriptor& query_mem_desc,
                                      const int64_t v,
                                      const std::vector<TargetInfo>& target_infos,
+                                     const int64_t dict_generation,
                                      const bool empty,
                                      const bool null_val = false);
 
@@ -105,6 +106,7 @@ void fill_one_entry_one_col(int64_t* value_slot,
 void fill_one_entry_baseline(int64_t* value_slots,
                              const int64_t v,
                              const std::vector<TargetInfo>& target_infos,
+                             const int64_t dict_generation,
                              const bool empty = false,
                              const bool null_val = false);
 
@@ -136,6 +138,7 @@ void fill_storage_buffer(int8_t* buff,
                          const std::vector<TargetInfo>& target_infos,
                          const QueryMemoryDescriptor& query_mem_desc,
                          NumberGenerator& generator,
+                         const int64_t dict_generation,
                          const size_t step);
 
 QueryMemoryDescriptor perfect_hash_one_col_desc_small(


### PR DESCRIPTION
Stop using negative string IDs for transient strings. Base generation becomes the first ID for transient strings. This scheme will allow us to use encoded columns in queries as regular dictionary-encoded strings and use deeper dictionary nesting,