### PR TITLE
Update to Calcite 1.35 (latest version)

### DIFF
--- a/omniscidb/Calcite/java/calcite/pom.xml
+++ b/omniscidb/Calcite/java/calcite/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>org.apache.calcite</groupId>
       <artifactId>calcite-core</artifactId>
-      <version>1.33.0</version>
+      <version>1.35.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.pentaho</groupId>
@@ -183,7 +183,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>3.6.0</version>
         <executions>
           <execution>
             <!-- Extract parser grammar template from calcite-core and put
@@ -211,7 +211,7 @@
       <plugin>
         <groupId>org.apache.drill.tools</groupId>
         <artifactId>drill-fmpp-maven-plugin</artifactId>
-        <version>1.21.0</version>
+        <version>1.21.1</version>
         <executions>
           <execution>
             <configuration>

--- a/omniscidb/Calcite/java/calcite/src/main/codegen/config.fmpp
+++ b/omniscidb/Calcite/java/calcite/src/main/codegen/config.fmpp
@@ -591,6 +591,12 @@ data: {
       dropStatementParserMethods: [
       ]
 
+      # List of methods for parsing extensions to "TRUNCATE" calls.
+      # Each must accept arguments "(SqlParserPos pos)".
+      # Example: "SqlTruncate".
+      truncateStatementParserMethods: [
+      ]
+
       # Binary operators tokens
       binaryOperatorsTokens: [
       ]
@@ -611,6 +617,10 @@ data: {
         "interruptQueryParser.ftl"
         "ddlParser.ftl"
       ]
+
+      # Custom identifier token.
+      # Example: "< IDENTIFIER: (<LETTER>|<DIGIT>)+ >".
+      customIdentifierToken: ""
 
       includePosixOperators: false
       includeParsingStringLiteralAsArrayLiteral: false

--- a/omniscidb/Calcite/java/calcite/src/main/codegen/includes/ddlParser.ftl
+++ b/omniscidb/Calcite/java/calcite/src/main/codegen/includes/ddlParser.ftl
@@ -270,7 +270,7 @@ SqlTypeNameSpec OmniSciGeospatialTypeName(Span s) :
             }
         )
         <LPAREN> geoType = OmniSciGeoType() [ <COMMA> coordinateSystem = IntLiteral() ] <RPAREN>
-        [ encoding = OmniSciEncodingOpt() ]
+        [ LOOKAHEAD(2) encoding = OmniSciEncodingOpt() ]
     )
     {
         return new OmniSciGeoTypeNameSpec(geoType, coordinateSystem, isGeography, encoding, s.end(this));
@@ -471,7 +471,7 @@ Pair<String, SqlNode> KVOption() :
     <EQ>
     { s = span(); }
     (
-        <NULL> {  value = SqlLiteral.createCharString("", s.end(this)); }
+        LOOKAHEAD(2) <NULL> {  value = SqlLiteral.createCharString("", s.end(this)); }
     |
         value = Literal()
     )
@@ -719,6 +719,7 @@ SqlNode WrappedOrderedQueryOrExpr(ExprContext exprContext) :
     final SqlNode query;
 }
 {
+    LOOKAHEAD(3)
         <LPAREN>
         query = OrderedQueryOrExpr(exprContext)
         <RPAREN>
@@ -1077,6 +1078,7 @@ SqlDdl SqlGrant(Span si) :
 {
     <GRANT> { s = span(); }
     (
+        LOOKAHEAD(3)
         nodeList = privilegeList()
         grant = SqlGrantPrivilege(s, nodeList)
         |
@@ -1105,6 +1107,7 @@ SqlDdl SqlRevoke(Span si) :
 {
     <REVOKE> { s = span(); }
     (
+        LOOKAHEAD(3)
         nodeList = privilegeList()
         revoke = SqlRevokePrivilege(s, nodeList)
         |

--- a/omniscidb/Calcite/java/calcite/src/main/java/org/apache/calcite/rel/externalize/MapDRelJsonReader.java
+++ b/omniscidb/Calcite/java/calcite/src/main/java/org/apache/calcite/rel/externalize/MapDRelJsonReader.java
@@ -306,12 +306,14 @@ public class MapDRelJsonReader {
     final String name = (String) jsonAggCall.get("name");
     return AggregateCall.create(aggregation,
             distinct,
-            false,
-            false,
+            /*approximate=*/false,
+            /*ignoreNulls=*/false,
             operands,
             filterOperand == null ? -1 : filterOperand,
-            null,
-            RelCollations.EMPTY,
+            /*distinctKeys=*/null,
+            /*collation=*/RelCollations.EMPTY,
+            /*groupCount=*/operands.size(),
+            /*input=*/relInput.getInput(),
             type,
             name);
   }

--- a/omniscidb/Tests/ArrowSQLRunner/SQLiteComparator.cpp
+++ b/omniscidb/Tests/ArrowSQLRunner/SQLiteComparator.cpp
@@ -46,8 +46,10 @@ void checkTypeConsistency(const int ref_col_type, const hdk::ir::Type* col_type)
     CHECK_EQ(SQLITE_INTEGER, ref_col_type);
   } else if (col_type->isFloatingPoint() || col_type->isDecimal()) {
     CHECK(ref_col_type == SQLITE_FLOAT || ref_col_type == SQLITE_INTEGER);
+  } else if (col_type->isBoolean()) {
+    CHECK(ref_col_type == SQLITE_INTEGER || ref_col_type == SQLITE_TEXT);
   } else {
-    CHECK_EQ(SQLITE_TEXT, ref_col_type);
+    CHECK_EQ(SQLITE_TEXT, ref_col_type) << "HDK Type: " << col_type->toString();
   }
 }
 

--- a/omniscidb/Tests/StandaloneQueryRunner.cpp
+++ b/omniscidb/Tests/StandaloneQueryRunner.cpp
@@ -155,16 +155,16 @@ int main(int argc, char** argv) {
       auto eo =
           ArrowSQLRunner::getExecutionOptions(/*allow_loop_joins=*/false, just_explain);
       auto co = ArrowSQLRunner::getCompilationOptions(dt);
-      auto res = ArrowSQLRunner::runSqlQuery(
-          R"(SELECT str, count(*) FROM test GROUP BY str;)", co, eo);
+      auto res =
+          ArrowSQLRunner::runSqlQuery(R"(select m, m_3, m_6, m_9 FROM test; )", co, eo);
       if (just_explain) {
         std::cout << "Explanation for " << device_type_str << res.getExplanation()
                   << std::endl;
       } else {
-        auto rows = res.getRows();
+        auto rows = res.getToken();
         CHECK(rows);
         std::cout << "Result for " << device_type_str << "\n"
-                  << rows->contentToString() << std::endl;
+                  << rows->contentToString(/*header=*/true) << std::endl;
       }
     }
   } catch (const std::exception& e) {


### PR DESCRIPTION
The primary changes to Calcite were in the parser. Some appear to be bug fixes (the changes around Timestamp casts make sense logically, whereas before we seemed to be inventing precision we didn't have). Others appear to be semantics (the cast removal in the interop query) that do not effect us, as the cast in that query appears to be a workaround. I believe the new aggregate call constructor is specified properly, but we will want to sanity test with modin after this is merged.

I updated some Java packages associated with Calcite but left most of those at their current versions pending @vlad-penkin's analysis. 