### PR TITLE
Add useless sort nodes removal.

### DIFF
--- a/omniscidb/Tests/PartitionedGroupByTest.cpp
+++ b/omniscidb/Tests/PartitionedGroupByTest.cpp
@@ -173,6 +173,30 @@ TEST_F(PartitionedGroupByTest, AggregationWithSort) {
   compare_res_data(res, id1_vals, id2_vals, id3_vals, id4_vals, v1_sums, v2_sums);
 }
 
+TEST_F(PartitionedGroupByTest, Issue695) {
+  auto old_exec = config().exec;
+  ScopeGuard g([&old_exec]() { config().exec = old_exec; });
+
+  config().exec.group_by.default_max_groups_buffer_entry_guess = 1;
+  config().exec.group_by.big_group_threshold = 1;
+  config().exec.group_by.enable_cpu_partitioned_groupby = true;
+  config().exec.group_by.partitioning_buffer_size_threshold = 10;
+  config().exec.group_by.partitioning_group_size_threshold = 1.5;
+  config().exec.group_by.min_partitions = 2;
+  config().exec.group_by.max_partitions = 8;
+  config().exec.group_by.partitioning_buffer_target_size = 612;
+  config().exec.enable_multifrag_execution_result = true;
+
+  QueryBuilder builder(ctx(), getSchemaProvider(), configPtr());
+  auto scan = builder.scan("test1");
+  auto dag1 = scan.agg({"id1"s, "id2"s, "id3"s, "id4"s}, {"sum(v1)"s, "sum(v2)"s})
+                  .sort(0)
+                  .sort({0, 1, 2, 3})
+                  .finalize();
+  auto res = runQuery(std::move(dag1));
+  compare_res_data(res, id1_vals, id2_vals, id3_vals, id4_vals, v1_sums, v2_sums);
+}
+
 int main(int argc, char* argv[]) {
   TestHelpers::init_logger_stderr_only(argc, argv);
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Some code in RelAlgExecutor doesn't expect a sort node to be an input of another sort node. To not care about such cases, I added a canonicalization pass to remove such dead sort nodes.

Resolves #695