### PR TITLE
Replace dictionary proxies with nested dictionaries 14/N

### DIFF
--- a/omniscidb/StringDictionary/StringDictionary.h
+++ b/omniscidb/StringDictionary/StringDictionary.h
@@ -130,7 +130,7 @@ class StringDictionary {
 
   std::vector<int32_t> getCompare(const std::string& pattern,
                                   const std::string& comp_operator,
-                                  const size_t generation);
+                                  int64_t generation = -1) const;
 
   std::vector<int32_t> getRegexpLike(const std::string& pattern,
                                      const char escape,
@@ -223,12 +223,12 @@ class StringDictionary {
                           size_t& mem_size,
                           const size_t min_capacity_requested = 0) noexcept;
   void invalidateInvertedIndex() noexcept;
-  std::vector<int32_t> getEquals(std::string pattern,
-                                 std::string comp_operator,
-                                 size_t generation);
-  void buildSortedCache();
-  void sortCache(std::vector<int32_t>& cache);
-  void mergeSortedCache(std::vector<int32_t>& temp_sorted_cache);
+  std::vector<int32_t> getEquals(const std::string& pattern,
+                                 const std::string& comp_operator,
+                                 int64_t generation) const;
+  void buildSortedCache() const;
+  void sortCache(std::vector<int32_t>& cache) const;
+  void mergeSortedCache(std::vector<int32_t>& temp_sorted_cache) const;
 
   int indexToId(int string_idx) const { return string_idx + base_generation_; }
   int idToIndex(int string_id) const { return string_id - base_generation_; }
@@ -243,7 +243,7 @@ class StringDictionary {
   size_t collisions_;
   std::vector<int32_t> string_id_uint32_table_;
   std::vector<uint32_t> hash_cache_;
-  std::vector<int32_t> sorted_cache;
+  mutable std::vector<int32_t> sorted_cache;
   bool materialize_hashes_;
   StringIdxEntry* offset_map_;
   char* payload_map_;

--- a/omniscidb/Tests/StringDictionaryTest.cpp
+++ b/omniscidb/Tests/StringDictionaryTest.cpp
@@ -772,6 +772,118 @@ TEST(NestedStringDictionary, IsLike) {
             std::vector<int>({0, 1, 4, 5}));
 }
 
+void sortAndCompare(std::vector<int> actual, const std::vector<int>& expected) {
+  std::sort(actual.begin(), actual.end(), std::less<int>());
+  ASSERT_EQ(actual, expected);
+}
+
+TEST(NestedStringDictionary, GetEquals) {
+  auto dict1 =
+      std::make_shared<StringDictionary>(DictRef{-1, 1}, -1, g_cache_string_hash);
+  ASSERT_EQ(dict1->getOrAdd("str1"), 0);
+  ASSERT_EQ(dict1->getOrAdd("str2"), 1);
+  ASSERT_EQ(dict1->getOrAdd("str3"), 2);
+
+  sortAndCompare(dict1->getCompare("str1", "="), {0});
+  sortAndCompare(dict1->getCompare("str2", "="), {1});
+  sortAndCompare(dict1->getCompare("str5", "="), {});
+  sortAndCompare(dict1->getCompare("str2", "<>"), {0, 2});
+  sortAndCompare(dict1->getCompare("str2", "=", 1), {});
+  sortAndCompare(dict1->getCompare("str2", "<>", 1), {0});
+
+  auto dict2 = std::make_shared<StringDictionary>(dict1, -1, g_cache_string_hash);
+  ASSERT_EQ(dict1->getOrAdd("str4"), 3);
+  ASSERT_EQ(dict2->getOrAdd("str5"), 3);
+  ASSERT_EQ(dict2->getOrAdd("str6"), 4);
+
+  sortAndCompare(dict1->getCompare("str4", "="), {3});
+  sortAndCompare(dict1->getCompare("str4", "=", 3), {});
+  sortAndCompare(dict1->getCompare("str2", "<>"), {0, 2, 3});
+  sortAndCompare(dict1->getCompare("str2", "<>", 3), {0, 2});
+
+  sortAndCompare(dict2->getCompare("str4", "="), {});
+  sortAndCompare(dict2->getCompare("str5", "="), {3});
+  sortAndCompare(dict2->getCompare("str5", "=", 3), {});
+  sortAndCompare(dict2->getCompare("str5", "<>"), {0, 1, 2, 4});
+  sortAndCompare(dict2->getCompare("str5", "<>", 3), {0, 1, 2});
+
+  ASSERT_EQ(dict2->getOrAdd("str7"), 5);
+
+  sortAndCompare(dict2->getCompare("str5", "<>"), {0, 1, 2, 4, 5});
+  sortAndCompare(dict2->getCompare("str7", "="), {5});
+}
+
+TEST(NestedStringDictionary, GetCompare) {
+  auto dict1 =
+      std::make_shared<StringDictionary>(DictRef{-1, 1}, -1, g_cache_string_hash);
+  ASSERT_EQ(dict1->getOrAdd("str1"), 0);
+  ASSERT_EQ(dict1->getOrAdd("str2"), 1);
+  ASSERT_EQ(dict1->getOrAdd("str3"), 2);
+
+  sortAndCompare(dict1->getCompare("str2", "<"), {0});
+  sortAndCompare(dict1->getCompare("str2", "<="), {0, 1});
+  sortAndCompare(dict1->getCompare("str2", "<=", 1), {0});
+  sortAndCompare(dict1->getCompare("str2", ">"), {2});
+  sortAndCompare(dict1->getCompare("str2", ">="), {1, 2});
+  sortAndCompare(dict1->getCompare("str2", ">=", 2), {1});
+  sortAndCompare(dict1->getCompare("str2", "="), {1});
+  sortAndCompare(dict1->getCompare("str2", "<>"), {0, 2});
+
+  sortAndCompare(dict1->getCompare("str11", "<"), {0});
+  sortAndCompare(dict1->getCompare("str11", "<="), {0});
+  sortAndCompare(dict1->getCompare("str11", ">"), {1, 2});
+  sortAndCompare(dict1->getCompare("str11", ">="), {1, 2});
+  sortAndCompare(dict1->getCompare("str11", "<>"), {0, 1, 2});
+  sortAndCompare(dict1->getCompare("str11", "="), {});
+
+  sortAndCompare(dict1->getCompare("str0", "<"), {});
+  sortAndCompare(dict1->getCompare("str0", "<="), {});
+  sortAndCompare(dict1->getCompare("str0", ">"), {0, 1, 2});
+  sortAndCompare(dict1->getCompare("str0", ">="), {0, 1, 2});
+  sortAndCompare(dict1->getCompare("str0", "="), {});
+  sortAndCompare(dict1->getCompare("str0", "<>"), {0, 1, 2});
+
+  sortAndCompare(dict1->getCompare("str4", "<"), {0, 1, 2});
+  sortAndCompare(dict1->getCompare("str4", "<="), {0, 1, 2});
+  sortAndCompare(dict1->getCompare("str4", ">"), {});
+  sortAndCompare(dict1->getCompare("str4", ">="), {});
+  sortAndCompare(dict1->getCompare("str4", "="), {});
+  sortAndCompare(dict1->getCompare("str4", "<>"), {0, 1, 2});
+
+  auto dict2 = std::make_shared<StringDictionary>(dict1, -1, g_cache_string_hash);
+  ASSERT_EQ(dict1->getOrAdd("str4"), 3);
+  ASSERT_EQ(dict2->getOrAdd("str5"), 3);
+  ASSERT_EQ(dict2->getOrAdd("str6"), 4);
+  ASSERT_EQ(dict2->getOrAdd("str7"), 5);
+
+  sortAndCompare(dict1->getCompare("str2", "<"), {0});
+  sortAndCompare(dict1->getCompare("str2", "<="), {0, 1});
+  sortAndCompare(dict1->getCompare("str2", ">"), {2, 3});
+  sortAndCompare(dict1->getCompare("str2", ">="), {1, 2, 3});
+  sortAndCompare(dict1->getCompare("str2", "="), {1});
+  sortAndCompare(dict1->getCompare("str2", "<>"), {0, 2, 3});
+
+  sortAndCompare(dict2->getCompare("str6", "<"), {0, 1, 2, 3});
+  sortAndCompare(dict2->getCompare("str6", "<", 3), {0, 1, 2});
+  sortAndCompare(dict2->getCompare("str6", "<", 1), {0});
+  sortAndCompare(dict2->getCompare("str6", "<="), {0, 1, 2, 3, 4});
+  sortAndCompare(dict2->getCompare("str6", "<=", 3), {0, 1, 2});
+  sortAndCompare(dict2->getCompare("str6", "<=", 1), {0});
+  sortAndCompare(dict2->getCompare("str6", ">"), {5});
+  sortAndCompare(dict2->getCompare("str6", ">", 3), {});
+  sortAndCompare(dict2->getCompare("str6", ">", 1), {});
+  sortAndCompare(dict2->getCompare("str6", ">="), {4, 5});
+  sortAndCompare(dict2->getCompare("str6", ">=", 3), {});
+  sortAndCompare(dict2->getCompare("str6", ">=", 1), {});
+  sortAndCompare(dict2->getCompare("str6", ">=", 5), {4});
+  sortAndCompare(dict2->getCompare("str6", "="), {4});
+  sortAndCompare(dict2->getCompare("str6", "=", 3), {});
+  sortAndCompare(dict2->getCompare("str6", "=", 1), {});
+  sortAndCompare(dict2->getCompare("str6", "<>"), {0, 1, 2, 3, 5});
+  sortAndCompare(dict2->getCompare("str6", "<>", 3), {0, 1, 2});
+  sortAndCompare(dict2->getCompare("str6", "<>", 1), {0});
+}
+
 TEST(StringDictionaryProxy, BuildIntersectionTranslationMapToOtherProxy) {
   // Use existing dictionary from GetBulk
   const DictRef dict_ref1(-1, 1);


### PR DESCRIPTION
Support nested dictionaries in StringDictionary::getCompare.

This patch also fixes several bugs in this method. The logic around the comparison of `cache_index->index` with zero is completely broken because the zero index has no special meaning at all. Added tests cover both nested dictionaries and these fixed bugs.