### PR TITLE
Replace dictionary proxies with nested dictionaries 19/19

### DIFF
--- a/omniscidb/QueryEngine/Execute.cpp
+++ b/omniscidb/QueryEngine/Execute.cpp
@@ -1170,7 +1170,7 @@ ResultSetPtr Executor::reduceMultiDeviceResults(
     return std::make_shared<ResultSet>(targets,
                                        ExecutorDeviceType::CPU,
                                        QueryMemoryDescriptor(),
-                                       nullptr,
+                                       row_set_mem_owner,
                                        data_mgr_,
                                        blockSize(),
                                        gridSize());

--- a/omniscidb/ResultSet/ResultSet.cpp
+++ b/omniscidb/ResultSet/ResultSet.cpp
@@ -493,6 +493,11 @@ StringDictionary* ResultSet::getStringDictionaryProxy(int const dict_id) const {
   return row_set_mem_owner_->getOrAddStringDictProxy(dict_id);
 }
 
+std::shared_ptr<StringDictionary> ResultSet::getStringDictionaryProxyOwned(
+    int const dict_id) const {
+  return row_set_mem_owner_->getStringDictProxyOwned(dict_id);
+}
+
 class ResultSet::CellCallback {
   std::vector<int32_t> const id_map_;
   int64_t const null_int_;

--- a/omniscidb/ResultSet/ResultSet.h
+++ b/omniscidb/ResultSet/ResultSet.h
@@ -524,6 +524,8 @@ class ResultSet {
   getUniqueStringsForDictEncodedTargetCol(const size_t col_idx) const;
 
   StringDictionary* getStringDictionaryProxy(int const dict_id) const;
+  std::shared_ptr<StringDictionary> getStringDictionaryProxyOwned(
+      int const dict_id) const;
 
   template <typename ENTRY_TYPE, QueryDescriptionType QUERY_TYPE, bool COLUMNAR_FORMAT>
   ENTRY_TYPE getEntryAt(const size_t row_idx,

--- a/omniscidb/ResultSet/RowSetMemoryOwner.h
+++ b/omniscidb/ResultSet/RowSetMemoryOwner.h
@@ -232,6 +232,7 @@ class RowSetMemoryOwner final : public SimpleAllocator, boost::noncopyable {
 
   StringDictionary* getOrAddStringDictProxy(const int dict_id_in,
                                             const int64_t generation = -1);
+  std::shared_ptr<StringDictionary> getStringDictProxyOwned(const int dict_id);
 
   void addLiteralStringDictProxy(std::shared_ptr<StringDictionary> lit_str_dict_proxy) {
     std::lock_guard<std::mutex> lock(state_mutex_);

--- a/omniscidb/ResultSetRegistry/ResultSetRegistry.h
+++ b/omniscidb/ResultSetRegistry/ResultSetRegistry.h
@@ -81,10 +81,17 @@ class ResultSetRegistry : public SimpleSchemaProvider,
     TableStats table_stats;
   };
 
+  struct DictionaryData {
+    std::unique_ptr<DictDescriptor> dict_descriptor;
+    std::set<int> table_ids;
+  };
+
   const int db_id_;
   const int schema_id_;
   int next_table_id_ = 1;
+  int next_dict_id_ = 1;
   std::unordered_map<int, std::unique_ptr<TableData>> tables_;
+  std::unordered_map<int, std::unique_ptr<DictionaryData>> dicts_;
   const ConfigPtr config_;
   mutable mapd_shared_mutex data_mutex_;
 };

--- a/omniscidb/StringDictionary/StringDictionary.h
+++ b/omniscidb/StringDictionary/StringDictionary.h
@@ -89,6 +89,11 @@ class StringDictionary {
 
   int32_t getDbId() const noexcept;
   int32_t getDictId() const noexcept;
+  void setDictId(int32_t new_id) {
+    CHECK_EQ(dict_ref_.dictId, -1);
+    CHECK_GT(new_id, 0);
+    dict_ref_.dictId = new_id;
+  }
 
   StringDictionary* getBaseDictionary() const noexcept { return base_dict_.get(); }
   int64_t getBaseGeneration() const noexcept { return base_generation_; }
@@ -249,7 +254,7 @@ class StringDictionary {
   uint32_t hashById(int string_id) const { return hashByIndex(idToIndex(string_id)); }
   uint32_t hashByIndex(int string_idx) const { return hash_cache_[string_idx]; }
 
-  const DictRef dict_ref_;
+  DictRef dict_ref_;
   const std::shared_ptr<StringDictionary> base_dict_;
   const int64_t base_generation_;
   size_t str_count_;


### PR DESCRIPTION
The final part adds support for dictionaries in ResultSetRegistry. It finally enables all operations on dict columns of result sets. It resolves multiple issues for Modin.

Resolves #588, #662, #667